### PR TITLE
enable N return in characters()

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -18,6 +18,7 @@ match
 	- Various other changes:
 	1) Counts from regions that cannot be extracted from a provided bigwig file (such as for a missing chromosome) are now set to nan rather than 0. This will effect the threshold value used for filtering background regions.
 	2) Small change to the binning strategy for gc values, which could mean that matching loci generated in a previous version will not be reproduced exactly in all cases, even when using the same random seed.
+	3) Enabled the handfing of 'N' in sequences or [0,0,0,0], i.e. an ambiguous genomic position. Updated the `characters()` in `ersatz` module and the `_validate_input()` in `utils` module.
 
 
 Version 0.2.3

--- a/tangermeme/utils.py
+++ b/tangermeme/utils.py
@@ -191,7 +191,7 @@ def characters(pwm, alphabet=['A', 'C', 'G', 'T'], force=False, allow_N=False):
 		pwm = pwm.numpy(force=True)
 
 	if allow_N:
-		n_inds = np.where(pwm.sum(axis=0)==0)[0]
+		n_inds = numpy.where(pwm.sum(axis=0)==0)[0]
 		dna_chars = alphabet[pwm.argmax(axis=0)]
 		dna_chars[n_inds] = 'N'
 	else:

--- a/tangermeme/utils.py
+++ b/tangermeme/utils.py
@@ -82,7 +82,7 @@ def _validate_input(X, name, shape=None, dtype=None, min_value=None,
 			raise ValueError("{} must be one-hot encoded.".format(name))
 
 		if ((not (X.sum(axis=1) == 1).all()) and (not allow_N)
-          ) or not ((allow_N and ((X.sum(axis=ohe_dim) == 1) | (X.sum(axis=ohe_dim) == 0)).all())):
+          ) or ((allow_N) and (not ((X.sum(axis=ohe_dim) == 1) | (X.sum(axis=ohe_dim) == 0)).all())):
 			raise ValueError("{} must be one-hot encoded ".format(name) +
 				"and cannot have unknown characters.")
 


### PR DESCRIPTION
Hey Jacob, amazing work on this extremely useful package! I've started moving over to using it as a base starting piint for any work I'm doing and so if I think of any other use cases I'll try submitting them as PRs. For this one, I ran into an issue using `characters()` which may be intentional but, it can't seem to handle missing bases i.e. 'N' (tangermeme v0.2.3):

```
from tangermeme.utils import characters,one_hot_encode
a = one_hot_encode("ACGTN")
print(a)
tensor([[[1, 0, 0, 0, 0],
         [0, 1, 0, 0, 0],
         [0, 0, 1, 0, 0],
         [0, 0, 0, 1, 0]]], dtype=torch.int8)
characters(a)
---------------------------------------------------------------------------
File ~/anaconda3/envs/g-cads/lib/python3.12/site-packages/tangermeme/utils.py:178, in characters(pwm, alphabet, force)
    [176](https://vscode-remote+ssh-002dremote-002b146-002d169-002d8-002d78-002edsi-002eic-002eac-002euk.vscode-resource.vscode-cdn.net/shared/aemurphy/G-CADS/~/anaconda3/envs/g-cads/lib/python3.12/site-packages/tangermeme/utils.py:176) pwm_ismax = pwm == pwm.max(dim=0, keepdims=True).values
    [177](https://vscode-remote+ssh-002dremote-002b146-002d169-002d8-002d78-002edsi-002eic-002eac-002euk.vscode-resource.vscode-cdn.net/shared/aemurphy/G-CADS/~/anaconda3/envs/g-cads/lib/python3.12/site-packages/tangermeme/utils.py:177) if pwm_ismax.sum(axis=0).max() > 1 and force == False:
--> [178](https://vscode-remote+ssh-002dremote-002b146-002d169-002d8-002d78-002edsi-002eic-002eac-002euk.vscode-resource.vscode-cdn.net/shared/aemurphy/G-CADS/~/anaconda3/envs/g-cads/lib/python3.12/site-packages/tangermeme/utils.py:178) 	raise ValueError("At least one position in the PWM has multiple " +
    [179](https://vscode-remote+ssh-002dremote-002b146-002d169-002d8-002d78-002edsi-002eic-002eac-002euk.vscode-resource.vscode-cdn.net/shared/aemurphy/G-CADS/~/anaconda3/envs/g-cads/lib/python3.12/site-packages/tangermeme/utils.py:179) 		"letters with the same probability.")
    [181](https://vscode-remote+ssh-002dremote-002b146-002d169-002d8-002d78-002edsi-002eic-002eac-002euk.vscode-resource.vscode-cdn.net/shared/aemurphy/G-CADS/~/anaconda3/envs/g-cads/lib/python3.12/site-packages/tangermeme/utils.py:181) alphabet = numpy.array(alphabet)
    [182](https://vscode-remote+ssh-002dremote-002b146-002d169-002d8-002d78-002edsi-002eic-002eac-002euk.vscode-resource.vscode-cdn.net/shared/aemurphy/G-CADS/~/anaconda3/envs/g-cads/lib/python3.12/site-packages/tangermeme/utils.py:182) if isinstance(pwm, torch.Tensor):

ValueError: At least one position in the PWM has multiple letters with the same probability.
```

I believe having a parameter (False by default seems sensible) to enable conversion to N's?

I've implemented a fix on this but let me know if I'm missing something important on including this?

Cheers,
Alan.