### PR TITLE
enable N return in characters()

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -18,6 +18,7 @@ match
 	- Various other changes:
 	1) Counts from regions that cannot be extracted from a provided bigwig file (such as for a missing chromosome) are now set to nan rather than 0. This will effect the threshold value used for filtering background regions.
 	2) Small change to the binning strategy for gc values, which could mean that matching loci generated in a previous version will not be reproduced exactly in all cases, even when using the same random seed.
+	3) Enable the handling of 'N' in sequences or [0,0,0,0], i.e. an ambiguous genomic positions. Updated the `characters()` and the `_validate_input()` in `utils` module to enable this.
 
 
 Version 0.2.3

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -79,15 +79,19 @@ def test_characters_raise_alphabet():
 
 def test_characters_raise_dimensions():
 	seq = 'GCTAC'
+	#this will work for shape (1,4,5) but not for (N,4,5) where N > 1
 	ohe = torch.tensor([[
 		[0.25, 0.00, 0.10, 0.95, 0.00],
 		[0.20, 1.00, 1.00, 0.05, 1.00],
 		[0.30, 0.00, 0.30, 0.00, 0.00],
 		[0.25, 0.00, 3.00, 0.00, 0.00]
 	]])
-
+	
+	assert characters(ohe) == seq
+	
+	ohe = torch.concat([ohe, ohe], dim=0)
 	assert_raises(ValueError, characters, ohe, ['A', 'C', 'G', 'T'])
-
+	
 	ohe = torch.tensor([0.25, 0.00, 0.10, 0.95, 0.00])
 	assert_raises(ValueError, characters, ohe, ['A', 'C', 'G', 'T'])
 


### PR DESCRIPTION
Hey Jacob, just consolidated the changes to enable N in the genomic sequences for `characters()`. The issue using characters() (that it can't seem to handle missing bases i.e. 'N') is shown below (tangermeme v0.2.3):
```
from tangermeme.utils import characters,one_hot_encode
a = one_hot_encode("ACGTN")
print(a)
tensor([[[1, 0, 0, 0, 0],
         [0, 1, 0, 0, 0],
         [0, 0, 1, 0, 0],
         [0, 0, 0, 1, 0]]], dtype=torch.int8)
characters(a)
```

Output:
```
ValueError: At least one position in the PWM has multiple letters with the same probability.
```

I have added a parameter `allow_N` (False by default) but when set to True, will enable conversion to N's.

Cheers,
Alan.