### PR TITLE
Fimo, allow for dict[str, numpy.ndarray] as input for motif argument.

### DIFF
--- a/tangermeme/tools/fimo.py
+++ b/tangermeme/tools/fimo.py
@@ -283,7 +283,8 @@ def fimo(motifs, sequences, alphabet=['A', 'C', 'G', 'T'], bin_size=0.1,
 	else:
 		raise ValueError("`motifs` must be a dict or a filename.")
 
-	motifs: list[tuple[str, numpy.ndarray]] = []
+	motifs_fwd: list[tuple[str, numpy.ndarray]] = []
+	motifs_rev: list[tuple[str, numpy.ndarray]] = []
 	for name in motifs_:
 		# motifs can be either dict[str, np.ndarray] or dict[str, torch.Tensor],
 		# convert to numpy array if needed.
@@ -294,9 +295,14 @@ def fimo(motifs, sequences, alphabet=['A', 'C', 'G', 'T'], bin_size=0.1,
 			raise ValueError(
 				f"`motifs` must be a dict[str, numpy.ndarray] or dict[str, torch.Tensor], not {type(pwm)}."
 			)
-		motifs.append((name, pwm))
+		motifs_fwd.append((name, pwm))
 		if reverse_complement:
-			motifs.append((name + "-rc", pwm[::-1, ::-1]))
+			motifs_rev.append((name + "-rc", pwm[::-1, ::-1]))
+	
+	if reverse_complement:
+		motifs = [*motifs_fwd, *motifs_rev]
+	else:
+		motifs = motifs_fwd
 
 	# Initialize arrays to store motif properties
 	n_motifs = len(motifs)

--- a/tangermeme/tools/fimo.py
+++ b/tangermeme/tools/fimo.py
@@ -283,11 +283,20 @@ def fimo(motifs, sequences, alphabet=['A', 'C', 'G', 'T'], bin_size=0.1,
 	else:
 		raise ValueError("`motifs` must be a dict or a filename.")
 
-	motifs_ = list(motifs_.items())
-	motifs = [(name, pwm.numpy(force=True)) for name, pwm in motifs_]
-	if reverse_complement:
-		for name, pwm in motifs_:
-			motifs.append((name + '-rc', pwm.numpy(force=True)[::-1, ::-1]))
+	motifs: list[tuple[str, numpy.ndarray]] = []
+	for name in motifs_:
+		# motifs can be either dict[str, np.ndarray] or dict[str, torch.Tensor],
+		# convert to numpy array if needed.
+		pwm = motifs_[name]
+		if isinstance(pwm, torch.Tensor):
+			pwm = pwm.numpy(force=True)
+		elif not isinstance(pwm, numpy.ndarray):
+			raise ValueError(
+				f"`motifs` must be a dict[str, numpy.ndarray] or dict[str, torch.Tensor], not {type(pwm)}."
+			)
+		motifs.append((name, pwm))
+		if reverse_complement:
+			motifs.append((name + "-rc", pwm[::-1, ::-1]))
 
 	# Initialize arrays to store motif properties
 	n_motifs = len(motifs)


### PR DESCRIPTION
Dear Jacob

The documentation of Fimo states that a dict[str, numpy.ndarray] can be used as input for the motif argument.
Internally pwm's were always converted from torch.Tensors to numpy.ndarray, resulting in an attribute error
when using dict[str, numpy.ndarray] as input.

This PR fixes this issue.

[EDIT]
Ok, I realised that the order of the motifs matter. I.e. reverse complement motifs should be at the end of the list of motifs (in the same order as the non-reverse-complemented ones).  This extra commit should adres this: https://github.com/jmschrei/tangermeme/pull/31/commits/1f46d747c9914a517691729f62bedfb9bc62dbc4

Best,

Seppe De Winter
