### PR TITLE
DOC fix typos, copy-paste errors, and stale references across docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 > [!NOTE] 
 > If you use tangermeme in your work, please consider citing the [preprint](https://www.biorxiv.org/content/10.1101/2025.08.08.669296v2). Citations allow me to continue developing software like this for the community. 
 
-Training sequence-based (sometimes called sequence-to-function or S2F) machine learning models has become widespread when studying genomics. But, what have these models learned, and what do we even do with them after training? `tangermeme` aims to provide robust and easy-to-use tools for the what-to-do-after-training question. `tangermeme` implements many atomic sequence operations such as adding a motif to a sequence or shuffling it out, efficient tools for applying predictive models to these sequences, methods for dissecting what these predictive models have learned, and tools for designing new sequences using these models. `tangermeme` aims to be assumption free: models can be multi-input or multi-output, functions do not assume a distance and instead return the raw predictions, and when loss functions are necessary they can be supplied by the user. Although we will provide best practices for how to use these functions, our hope is that being assumption-free makes adaptation of tangermeme into your settings as frictionless as possible. All functions are unit-tested and implemented with both compute- and memory-efficient in mind. Finally, although the library was built with operations on DNA sequences in mind, all functions are extensible to any alphabet.
+Training sequence-based (sometimes called sequence-to-function or S2F) machine learning models has become widespread when studying genomics. But, what have these models learned, and what do we even do with them after training? `tangermeme` aims to provide robust and easy-to-use tools for the what-to-do-after-training question. `tangermeme` implements many atomic sequence operations such as adding a motif to a sequence or shuffling it out, efficient tools for applying predictive models to these sequences, methods for dissecting what these predictive models have learned, and tools for designing new sequences using these models. `tangermeme` aims to be assumption free: models can be multi-input or multi-output, functions do not assume a distance and instead return the raw predictions, and when loss functions are necessary they can be supplied by the user. Although we will provide best practices for how to use these functions, our hope is that being assumption-free makes adaptation of tangermeme into your settings as frictionless as possible. All functions are unit-tested and implemented with both compute- and memory-efficiency in mind. Finally, although the library was built with operations on DNA sequences in mind, all functions are extensible to any alphabet.
 
 Please see the documentation and tutorials linked at the top of this README for more extensive documentation. If you only read one vignette, read THIS ONE: [Inspecting what Cis-Regulatory Features a Model has Learned](https://tangermeme.readthedocs.io/en/latest/vignettes/Inspecting_What_Cis-Regulatory_Features_a_Model_Has_Learned.html).
 
@@ -210,7 +210,7 @@ By running this function across several spacings one can, for instance, measure 
 Given an observed sequence a simple question is "what positions are driving model predictions?" One simple way to answer this question is through saturation mutagenesis, i.e., compare the predictions on the original sequence with that of sequences that comprehensively each contain one mutation with respect to that original sequence. This is another form of attribution method that is conceptually similar to deep mutational scanning but using a predictive model instead of running an experiment. In a region with an AP-1 motif, we can run ISM on Beluga and look at AP-1 factor tasks to identify that the AP-1 motif is what is driving the predictions.
 
 ```python
-from tangermeme.ism import saturation_mutagenesis
+from tangermeme.saturation_mutagenesis import saturation_mutagenesis
 
 X_attr = saturation_mutagenesis(model, X)
 ```
@@ -233,7 +233,7 @@ substitutions = torch.tensor([
 ])
 
 y, y_var = substitution_effect(model, X, substitutions)
-````
+```
 
 When using a BPNet model that predicts GATA2 binding, we can see that a single substitution encoded at this position in the example seems to knock out predicted signal in the middle of the window entirely. Quite a strong effect.
 
@@ -251,7 +251,7 @@ y, y_var = insertion_effect(model, X, insertions)
 
 #### Design
 
-Given a trained predictive model, one can try to design a sequence that has desired attributions. Specifically, one can try to design a sequence that causes the model to give desired predictions.
+Given a trained predictive model, one can try to design a sequence that causes the model to give desired predictions.
 
 Currently, the only design algorithm implemented in tangermeme is a greedy substitution algorithm that will try every given motif at every position each iteration, and take the motif + position combo that yields predictions closest to the desired output from the model.
 

--- a/docs/api/kmers.rst
+++ b/docs/api/kmers.rst
@@ -1,0 +1,5 @@
+kmers
+=====
+
+.. automodule:: tangermeme.kmers
+	:members: kmers, gapped_kmers

--- a/docs/api/pisa.rst
+++ b/docs/api/pisa.rst
@@ -1,0 +1,5 @@
+pisa
+====
+
+.. automodule:: tangermeme.pisa
+	:members: pisa

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,20 +4,12 @@
    contain the root `toctree` directive.
 
 
-    .. image:: logo/pomegranate-logo.png
-        :width: 300px
-
-
-    .. image:: https://readthedocs.org/projects/pomegranate/badge/?version=latest
-       :target: http://pomegranate.readthedocs.io/en/latest/?badge=latest
-
-
 tangermeme
 ==========
 
 tangermeme is a Python package that implements the basic operations necessary to perform sophisticated genomic analyses using machine learning models. Essentially, tangermeme aims to implement everything except for the model that you'd like to use, including I/O, identifying matched region sets, altering sequences (e.g., inserting a motif or scrambling out a motif), running marginalization experiments, and annotating regions. These functions are meant to be used by themselves but also can easily be built on top of if you'd like to customize your analyses. 
 
-Another way of looking at tangermeme is that, if the MEME suite is meant to do sequence analyses when you have only biological sequences (or maybe priors derived from experimental data), tangermeme is meant to do sequence analyses when you have these sequences *and* a predictive machine learning model. How does motif discovery or annotation differ when you have attribution values highlighting nucleotides based on how important they are to the predictions? Accordingly, tangermeme implements several command-line tools that are similar to those in the MEME suite, such as FIMO/TOMTOM/MEME, but also extends the capabilities of these tools to handle attributions, and implements new methods that answer additional questions.
+Another way of looking at tangermeme is that, if the MEME suite is meant to do sequence analyses when you have only biological sequences (or maybe priors derived from experimental data), tangermeme is meant to do sequence analyses when you have these sequences *and* a predictive machine learning model. How does motif discovery or annotation differ when you have attribution values highlighting nucleotides based on how important they are to the predictions? tangermeme extends classic MEME-suite-style analyses to handle attributions, and implements new methods that answer additional questions. The FIMO and TOMTOM tools themselves now live in `memesuite-lite <https://github.com/jmschrei/memesuite-lite>`_, where they can be used without a PyTorch dependency.
 
 Installation
 ============
@@ -58,7 +50,7 @@ No good project is done alone, and so I'd like to thank everyone who tested tang
 Contributions
 =============
 
-Contributions are eagerly accepted! If you would like to contribute a feature then fork the master branch and be sure to run the tests before changing any code. Let us know what you want to do on the issue tracker just in case we're already working on an implementation of something similar. Also, please don't forget to add tests for any new functions. 
+Contributions are eagerly accepted! If you would like to contribute a feature then fork the main branch and be sure to run the tests before changing any code. Let us know what you want to do on the issue tracker just in case we're already working on an implementation of something similar. Also, please don't forget to add tests for any new functions. 
 
 .. toctree::
    :maxdepth: 1
@@ -123,8 +115,10 @@ Contributions are eagerly accepted! If you would like to contribute a feature th
    api/design.rst
    api/ersatz.rst
    api/io.rst
+   api/kmers.rst
    api/marginalize.rst
    api/match.rst
+   api/pisa.rst
    api/plot.rst
    api/predict.rst
    api/product.rst

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -170,7 +170,7 @@ plot
 seqlet
 ------
 
-	- The `recursive_seqlet` algorithm has been slightly modified to more closely match the provided description. This change involves using the calculated p-values instead of the maximum p-value for each position across all seqlets of smaller size. As a consequence, motifs should not be be shifted to the right anymore.
+	- The `recursive_seqlet` algorithm has been slightly modified to more closely match the provided description. This change involves using the calculated p-values instead of the maximum p-value for each position across all seqlets of smaller size. As a consequence, motifs should no longer be shifted to the right.
 
 
 utils
@@ -215,7 +215,7 @@ Version 0.4.3
 ersatz
 ------
 
-	- Substitute now accepts Ns or all-zeroes positions as inputs and, at those positions, will not alter the original sequence. If only one motif is given, this will be the same across all background sequences. If one motif is given per background sequence, this is done on a per-background example.
+	- Substitute now accepts Ns or all-zero positions as inputs and, at those positions, will not alter the original sequence. If only one motif is given, this will be the same across all background sequences. If one motif is given per background sequence, this is done on a per-background example.
 	- The above change means that higher-level functions like `marginalize` can now be run with motifs that contain missing characters, without any changes needed.
 	- The default `start` and `end` of `dinucleotide_shuffle` have been set to `None` because using `0` and `-1` meant that the last provided position never got shuffled.
 
@@ -338,9 +338,9 @@ match
 
 	- Various other changes:
 
-		1. Counts from regions that cannot be extracted from a provided bigwig file (such as for a missing chromosome) are now set to nan rather than 0. This will effect the threshold value used for filtering background regions.
+		1. Counts from regions that cannot be extracted from a provided bigwig file (such as for a missing chromosome) are now set to nan rather than 0. This will affect the threshold value used for filtering background regions.
 		2. Small change to the binning strategy for gc values, which could mean that matching loci generated in a previous version will not be reproduced exactly in all cases, even when using the same random seed.
-		3. Enable the handling of 'N' in sequences or [0,0,0,0], i.e. an ambiguous genomic positions. Updated the ``characters()`` and the ``_validate_input()`` in ``utils`` module to enable this.
+		3. Enable the handling of 'N' in sequences or [0,0,0,0], i.e., ambiguous genomic positions. Updated the ``characters()`` and the ``_validate_input()`` in ``utils`` module to enable this.
 
 
 Version 0.2.3
@@ -365,7 +365,7 @@ tools
 -----
 
 	- FIMO is now base 2 instead of base e, to better match the MEME-suite tool. p-values should remain the same but scores will change.
-	- FIMO `hits` will now return p-values, and will longer return an uninformative `attr` column
+	- FIMO `hits` will now return p-values, and will no longer return an uninformative `attr` column
 
 
 product
@@ -398,7 +398,7 @@ Version 0.2.0
 Highlights
 ----------
 
-	- Alters the API of several functions to make them more general, with the option of taking in a function to apply instead of defaulting to predict, while still back compatible
+	- Alters the API of several functions to make them more general, with the option of taking in a function to apply instead of defaulting to predict, while still backwards compatible
 	- Adds in `deep_lift_shap` and `seqlet` to operate on attributions
 
 
@@ -416,7 +416,7 @@ deep_lift_shap
 ism
 ----
 
-	- Changes the default output from the raw output (which you can get with `raw_output=True`) to defaultly aggregated attribution values to make the API compatible
+	- Changes the default output from the raw output (which you can get with `raw_output=True`) to aggregated attribution values to make the API compatible with the rest of the library
 
 
 marginalize

--- a/tangermeme/ablate.py
+++ b/tangermeme/ablate.py
@@ -20,18 +20,18 @@ def ablate(model, X, start, end, n=20, shuffle_fn=shuffle, args=None,
 
 	Ablation experiments can be thought of as the conceptual opposite of
 	marginalization experiments. Both involve applying a function before and
-	after some sequence modification, but marginalizations usually involve 
+	after some sequence modification: marginalizations usually involve
 	substituting a potentially-informative motif into a set of background
-	sequences, but an ablation usually involves removing drivers of signal
+	sequences, whereas an ablation usually involves removing drivers of signal
 	from a sequence.
 
 	By default, `ablate` will apply the `predict` function to `X` before
-	and after shuffling the given sequence. However, one can pass in any 
-	function, including `deep_lift_shap` or even `saturated_mutagenesis`. These 
-	functions may have additional arguments and those can be passed into 
-	`marginalize` as-is and will be passed along to the function. If any 
-	arguments would have had the same name as those used by this function, you 
-	can use the `additional_func_kwargs` input to ensure those values get to 
+	and after shuffling the given sequence. However, one can pass in any
+	function, including `deep_lift_shap` or even `saturation_mutagenesis`. These
+	functions may have additional arguments and those can be passed into
+	`ablate` as-is and will be passed along to the function. If any
+	arguments would have had the same name as those used by this function, you
+	can use the `additional_func_kwargs` input to ensure those values get to
 	the function.
 
 	Note: if `random_state` is passed in, it will make the shuffling step
@@ -39,7 +39,7 @@ def ablate(model, X, start, end, n=20, shuffle_fn=shuffle, args=None,
 	there is not already a key called `random_state` in it. Essentially,
 	`random_state` makes shuffling deterministic and will also make the function
 	deterministic if the function accepts a random state, but if you'd like to
-	set your own separate state for the function it will not be overriden.
+	set your own separate state for the function it will not be overridden.
 
 
 	Parameters
@@ -50,18 +50,16 @@ def ablate(model, X, start, end, n=20, shuffle_fn=shuffle, args=None,
 		inputs must be specified in the `args` parameter.
 
 	X: torch.tensor, shape=(-1, len(alphabet), length)
-		A one-hot encoded set of sequences to have a motif inserted into.
+		A one-hot encoded set of sequences to have a region shuffled out of.
 
-	start: int, optional
+	start: int
 		The starting position of where to randomize the sequence, inclusive.
-		Default is 0, shuffling the entire sequence.
 
-	end: int, optional
+	end: int
 		The ending position of where to randomize the sequence, not inclusive.
-		Default is -1, shuffling the entire sequence.
 
 	n: int, optional
-		The number of times to shuffle that region. Default is 1.
+		The number of times to shuffle that region. Default is 20.
 
 	shuffle_fn: function
 		A function that will shuffle a portion of the sequence. This can be
@@ -103,13 +101,13 @@ def ablate(model, X, start, end, n=20, shuffle_fn=shuffle, args=None,
 	Returns
 	-------
 	y_before: torch.Tensor or list of torch.Tensors
-		The predictions from the model before inserting the motif in. If the
+		The predictions from the model before shuffling the region. If the
 		output from the model's forward function is a single tensor, it will
 		return that. If the model outputs a list of tensors, it will return
 		those.
 
 	y_after: torch.Tensor or list of torch.Tensors
-		The predictions from the model after inserting the motif in. If the
+		The predictions from the model after shuffling the region. If the
 		output from the model's forward function is a single tensor, it will
 		return that. If the model outputs a list of tensors, it will return
 		those.
@@ -159,7 +157,7 @@ def ablate_annotations(model, X, annotations, **kwargs):
 		inputs must be specified in the `args` parameter.
 
 	X: torch.tensor, shape=(-1, len(alphabet), length)
-		A one-hot encoded set of sequences to have a motif inserted into.
+		A one-hot encoded set of sequences to ablate annotations from.
 
 	annotations: torch.Tensor, shape=(n_annotations, 3)
 		A tensor of annotations where the first column is the example_idx, the
@@ -173,15 +171,15 @@ def ablate_annotations(model, X, annotations, **kwargs):
 	Returns
 	-------
 	y_befores: torch.Tensor or list of torch.Tensors
-		The application of `func` from the model BEFORE ablating the motif. If 
-		the output from the model's forward function is a single tensor, it will 
-		return that. If the model outputs a list of tensors, it will return 
+		The application of `func` from the model BEFORE ablating the annotation.
+		If the output from the model's forward function is a single tensor, it
+		will return that. If the model outputs a list of tensors, it will return
 		those.
 
 	y_afters: torch.Tensor or list of torch.Tensors
-		The application of `func` from the model AFTER ablating the motif. If 
-		the output from the model's forward function is a single tensor, it will
-		return that. If the model outputs a list of tensors, it will return
+		The application of `func` from the model AFTER ablating the annotation.
+		If the output from the model's forward function is a single tensor, it
+		will return that. If the model outputs a list of tensors, it will return
 		those.
 	"""
 

--- a/tangermeme/annotate.py
+++ b/tangermeme/annotate.py
@@ -21,7 +21,7 @@ def annotate_seqlets(X, seqlets, motifs, n_nearest=1, n_jobs=-1, **kwargs):
 	provided threshold, an index of -1 is returned.
 
 	The computation is independent for each seqlet, so ordering of seqlets
-	should not matter, not should running this function on a subset of seqlets
+	should not matter, nor should running this function on a subset of seqlets
 	versus the full set.
 
 
@@ -107,7 +107,7 @@ def count_annotations(X, dtype=torch.uint8, shape=None, dim=None):
 	dim: None, 0, or 1, optional
 		Whether to aggregate the counts along one of the axes. If set to None,
 		the full count matrix will be returned. If set to 0 the first dimension
-		is summed over, returning the number of occurences of each annotation. 
+		is summed over, returning the number of occurrences of each annotation.
 		If set to 1, the second dimension is summed over, returning the number
 		of annotations per example. Default is None. 
 
@@ -190,9 +190,9 @@ def pairwise_annotations(X, dtype=torch.int64, unique=True, symmetric=True, shap
 
 	unique: bool, optional
 		Whether to count only unique pairs within each example or each instance.
-		For example, if set to True, an example with 3 instances of KL4 would
+		For example, if set to True, an example with 3 instances of KLF4 would
 		contribute only a single KLF4-KLF4 interaction to the matrix, whereas
-		if set to True, would contribute many. Default is True.
+		if set to False, would contribute many. Default is True.
 
 	symmetric: bool, optional
 		Whether to return a symmetric matrix or one where the row is the first
@@ -206,10 +206,10 @@ def pairwise_annotations(X, dtype=torch.int64, unique=True, symmetric=True, shap
 
 	Returns
 	-------
-	y: torch.Tensor, shape=(max(example_idx), max(motif_idx))
-		A sparse tensor where each row is an example and each column is an
-		annotation and the values within are the number of times each annotation
-		appears in each example.
+	y: torch.Tensor, shape=(max(motif_idx), max(motif_idx))
+		A tensor where each row and column corresponds to an annotation index
+		and the values within are the number of times that pair of annotations
+		appears in the same example.
 	"""
 
 	if isinstance(X, (list, tuple)):
@@ -258,7 +258,7 @@ def pairwise_annotations(X, dtype=torch.int64, unique=True, symmetric=True, shap
 
 def pairwise_annotations_spacing(X, max_distance=100, dtype=torch.uint8, 
 	symmetric=True, shape=None):
-	"""Finds the number of times each annotation pairs happens at each distance.
+	"""Finds the number of times each annotation pair occurs at each distance.
 
 	This function takes in a tensor of (example_idx, annotation_idx, start, end) 
 	tuples and returns a tensor of counts where the first two dimensions are 
@@ -303,10 +303,11 @@ def pairwise_annotations_spacing(X, max_distance=100, dtype=torch.uint8,
 
 	Returns
 	-------
-	y: torch.Tensor, shape=(max(example_idx), max(motif_idx))
-		A sparse tensor where each row is an example and each column is an
-		annotation and the values within are the number of times each annotation
-		appears in each example.
+	y: torch.Tensor, shape=(max(motif_idx), max(motif_idx), max_distance)
+		A tensor where the first two dimensions are annotation indices and the
+		third dimension is the spacing between the pair, and the values within
+		are the count of the number of times that pair of annotations is found
+		with that spacing.
 	"""
 
 	if isinstance(X, (list, tuple)):

--- a/tangermeme/deep_lift_shap.py
+++ b/tangermeme/deep_lift_shap.py
@@ -1,4 +1,4 @@
-# attribute.py
+# deep_lift_shap.py
 # Contact: Jacob Schreiber <jmschreiber91@gmail.com>
 
 import torch
@@ -21,10 +21,10 @@ def hypothetical_attributions(multipliers, X, references):
 	characters are not there. So, one needs to account for each character change 
 	actually being the addition of one character AND the subtraction of another 
 	character. Basically, once you've calculated the multipliers, you need to 
-	subtract out the contribution of the nucleotide actually present and then 
-	add in the contribution of the nucleotide you are becomming.
+	subtract out the contribution of the nucleotide actually present and then
+	add in the contribution of the nucleotide you are becoming.
 
-	Each element in the tensor is considered an independent example 
+	Each element in the tensor is considered an independent example.
 
 	As an implementation note: to be compatible with Captum, each input must
 	be a tuple of length 1 and the returned value will be a tuple of length 1.
@@ -213,7 +213,7 @@ def deep_lift_shap(model, X, args=None, target=0,  batch_size=32,
 	As an implementation note, the batch size refers to the number of
 	example-reference pairs that are being run simultaneously. When the batch
 	size is smaller than the number of references, multiple batches will be
-	run per example and the attributions will only be averaged only the
+	run per example and the attributions will only be averaged across the
 	references after they have all been covered. You may want to do this if the
 	model or examples are so large that only a few can fit in memory at a time.
 	The result will be identical to if all examples could fit in memory and
@@ -284,9 +284,10 @@ def deep_lift_shap(model, X, args=None, target=0,  batch_size=32,
 
 	hypothetical: bool, optional
 		Whether to return attributions for all possible characters at each
-		position or only for the character that is actually at the sequence.
-		Practically, whether to return the returned attributions from captum
-		with the one-hot encoded sequence. Default is False.
+		position (`True`) or only for the character that is actually in the
+		sequence (`False`). When `False`, the per-character attributions are
+		multiplied by the one-hot encoded input so that only the observed
+		character has a non-zero attribution at each position. Default is False.
 
 	warning_threshold: float, optional
 		A threshold on the convergence delta that will always raise a warning
@@ -479,8 +480,8 @@ def deep_lift_shap(model, X, args=None, target=0,  batch_size=32,
 					(_references,))[0]
 
 			# attr_ is a list where each element is a tensor for the multipliers
-			# of one example so that we can chunk them together once all
-			# references for an example are 
+			# of one example-reference pair, so that once all references for an
+			# example have been processed we can chunk them together.
 			attr_.extend(list(multipliers.cpu().detach()))
 
 			# When all references for a sequence have been calculated, remove
@@ -585,9 +586,10 @@ def _captum_deep_lift_shap(model, X, args=None, target=0, batch_size=32,
 
 	hypothetical: bool, optional
 		Whether to return attributions for all possible characters at each
-		position or only for the character that is actually at the sequence.
-		Practically, whether to return the returned attributions from captum
-		with the one-hot encoded sequence. Default is False.
+		position (`True`) or only for the character that is actually in the
+		sequence (`False`). When `False`, the per-character attributions are
+		multiplied by the one-hot encoded input so that only the observed
+		character has a non-zero attribution at each position. Default is False.
 
 	device: str or torch.device, optional
 		The device to move the model and batches to when making predictions. If

--- a/tangermeme/design.py
+++ b/tangermeme/design.py
@@ -387,7 +387,7 @@ def greedy_marginalize(model, X, y, motifs, loss=torch.nn.MSELoss(
 	This approach attempts to find a set of motifs and their orientations and
 	spacings (a "construct") that yield a desired objective. Rather than 
 	editing an initial sequence, this approach is just trying to greedily build
-	a construct and evaluating its perform by marginalizing all other positions.
+	a construct and evaluate its performance by marginalizing all other positions.
 	Accordingly, rather than trying every motif at every position, it only tries
 	motifs at all positions within a given spacing from the flanks of the
 	construct that has been built so far.
@@ -404,7 +404,7 @@ def greedy_marginalize(model, X, y, motifs, loss=torch.nn.MSELoss(
 	and their other properties achieve your desired goal, without considering a
 	specific sequence. For instance, if you train a model to predict
 	accessibility and then want to design accessible regions generally, this
-	approach may be more appropriate than `greedy_substiution`.
+	approach may be more appropriate than `greedy_substitution`.
 
 
 	Parameters
@@ -439,6 +439,12 @@ def greedy_marginalize(model, X, y, motifs, loss=torch.nn.MSELoss(
 	reverse_complement: bool, optional
 		Whether to augment the provided list of motifs with their reverse
 		complements. This will double the runtime. Default is True.
+
+	max_spacing: int, optional
+		The maximum spacing on either side of the existing construct at which a
+		new motif can be implanted. Each iteration considers positions in a
+		window extending `max_spacing` nucleotides past the current left and
+		right flanks of the construct. Default is 12.
 
 	output_mask: torch.Tensor or None, optional
 		A mask on the outputs from the model to consider. True means to include
@@ -475,7 +481,7 @@ def greedy_marginalize(model, X, y, motifs, loss=torch.nn.MSELoss(
 	device: str or torch.device, optional
 		The device to move the model and batches to when making predictions. If
 		set to 'cuda' without a GPU, this function will crash and must be set
-		to 'cpu'. Default is 'cuda'. 
+		to 'cpu'. Default is 'cuda'.
 
 	verbose: bool, optional
 		Whether to display a progress bar during predictions. Default is False.
@@ -484,7 +490,7 @@ def greedy_marginalize(model, X, y, motifs, loss=torch.nn.MSELoss(
 	Returns
 	-------
 	X: torch.Tensor, shape=(len(alphabet), length)
-		The designed construct. 
+		The designed construct.
 	"""
 
 	tic = time.time()

--- a/tangermeme/ersatz.py
+++ b/tangermeme/ersatz.py
@@ -20,7 +20,7 @@ def insert(X, motif, start=None, alphabet=list("ACGT")):
 	This function will take in a tensor of one-hot encoded sequences or a string
 	that can be one-hot encoded and insert the motif into the defined 
 	position. It will then return a copy of the data with the insertion, 
-	leaving the  original data unperturbed.
+	leaving the original data unperturbed.
 
 	Importantly, an *insertion* means that the entire original sequence is still
 	present, albeit in two halves with the inserted motif in the middle.
@@ -32,24 +32,24 @@ def insert(X, motif, start=None, alphabet=list("ACGT")):
 	If the motif is a string, it will be one-hot encoded according to the
 	alphabet that is provided. If a motif with batch size of 1 is provided, 
 	the same motif will be inserted into all sequences. If a motif with a 
-	batch size equal to that of X is provided, there will be  1-1 correspondance 
-	between the motifs and the sequence, i.e., that motif at index 5 will be 
+	batch size equal to that of X is provided, there will be 1-1 correspondence
+	between the motifs and the sequence, i.e., the motif at index 5 will be
 	substituted into the sequence at index 5.
 
 
 	Parameters
 	----------
 	X: torch.tensor, shape=(-1, len(alphabet), length)
-		A one-hot encoded set of sequences to have a motif substituted into.
+		A one-hot encoded set of sequences to have a motif inserted into.
 
 	motif: torch.tensor, shape=(-1, len(alphabet), motif_length)
-		A one-hot encoded version of a short motif to substitute into the set of
+		A one-hot encoded version of a short motif to insert into the set of
 		sequences.
 
 	start: int or None, optional
-		The starting position of where to substitute the motif. If None,
-		substitute the motif into the middle of the sequence such that the 
-		middle of the motif occurs at the middle of the sequence. Default is 
+		The starting position of where to insert the motif. If None,
+		insert the motif into the middle of the sequence such that the
+		middle of the motif occurs at the middle of the sequence. Default is
 		None.
 
 	alphabet: set or tuple or list, optional
@@ -63,8 +63,8 @@ def insert(X, motif, start=None, alphabet=list("ACGT")):
 
 	Returns
 	-------
-	Y: torch.tensor, shape=(-1, len(alphabet), length)
-		A one-hot encoded set of sequences that each have the motif substituted
+	Y: torch.tensor, shape=(-1, len(alphabet), length + motif_length)
+		A one-hot encoded set of sequences that each have the motif inserted
 		at the same position.
 	"""
 
@@ -92,7 +92,7 @@ def substitute(X, motif, start=None, alphabet=list("ACGT"), ignore=["N"]):
 	This function will take in a tensor of one-hot encoded sequences or a string
 	that can be one-hot encoded and will substitute a motif at a defined 
 	position. It will then return a copy of the data with the substitution, 
-	leaving the  original data unperturbed.
+	leaving the original data unperturbed.
 
 	Importantly, a *substitution* means that part of the original sequence will
 	be missing. Specifically, if we have an original sequence AAAAAACCCCAAAAAA 
@@ -104,8 +104,8 @@ def substitute(X, motif, start=None, alphabet=list("ACGT"), ignore=["N"]):
 	If the motif is a string, it will be one-hot encoded according to the
 	alphabet that is provided. If a motif with batch size of 1 is provided, 
 	the same motif will be substituted into all sequences. If a motif with a 
-	batch size equal to that of X is provided, there will be  1-1 correspondance 
-	between the motifs and the sequence, i.e., that motif at index 5 will be 
+	batch size equal to that of X is provided, there will be 1-1 correspondence
+	between the motifs and the sequence, i.e., the motif at index 5 will be
 	substituted into the sequence at index 5.
 
 	Finally, if all-zeros positions are present in a motif -- or if a string
@@ -183,12 +183,12 @@ def substitute(X, motif, start=None, alphabet=list("ACGT"), ignore=["N"]):
 
 def multisubstitute(X, motifs, spacing, start=None, alphabet=list("ACGT"),
 	ignore=["N"]):
-	"""Substitute a set of motif into sequences with provided spacings.
+	"""Substitute a set of motifs into sequences with provided spacings.
 
-	This function will take in a list of tensors of one-hot encoded sequences 
-	or of strings that can be one-hot encoded and will substitute the motifs 
-	into the sequences given the provided spacings. It will then return a copy 
-	of the data with the substitutions leaving the  original data unperturbed.
+	This function will take in a list of tensors of one-hot encoded sequences
+	or of strings that can be one-hot encoded and will substitute the motifs
+	into the sequences given the provided spacings. It will then return a copy
+	of the data with the substitutions, leaving the original data unperturbed.
 
 	This function is largely just a wrapper around the substitute function,
 	calling it multiple times and figuring out the exact positioning internally.
@@ -196,8 +196,8 @@ def multisubstitute(X, motifs, spacing, start=None, alphabet=list("ACGT"),
 	If the motif is a string, it will be one-hot encoded according to the
 	alphabet that is provided. If a motif with batch size of 1 is provided, 
 	the same motifs will be substituted into all sequences. If a motif with a 
-	batch size equal to that of X is provided, there will be  1-1 correspondance 
-	between the motifs and the sequence, i.e., that motif at index 5 will be 
+	batch size equal to that of X is provided, there will be 1-1 correspondence
+	between the motifs and the sequence, i.e., the motif at index 5 will be
 	substituted into the sequence at index 5.
 
 
@@ -207,7 +207,7 @@ def multisubstitute(X, motifs, spacing, start=None, alphabet=list("ACGT"),
 		A one-hot encoded set of sequences to have a motif substituted into.
 
 	motifs: list of torch.tensor, shape=(-1, len(alphabet), motif_length)
-		A list of strings or of one-hot encoded version of a short motif to 
+		A list of strings or of one-hot encoded versions of short motifs to
 		substitute into the set of sequences.
 
 	spacing: list or int
@@ -217,10 +217,9 @@ def multisubstitute(X, motifs, spacing, start=None, alphabet=list("ACGT"),
 		distance after the $i$-th motif that the $i+1$-th motif begins.
 
 	start: int or None, optional
-		The starting position of where to substitute the motifs. If None,
-		substitute the motif into the middle of the sequence such that the 
-		middle of the motif occurs at the middle of the sequence. Default is 
-		None.
+		The starting position of where to substitute the motifs. If None, the
+		full motif arrangement is centered such that its midpoint coincides
+		with the middle of the sequence. Default is None.
 
 	alphabet : set or tuple or list, optional
 		A pre-defined alphabet where the ordering of the symbols is the same
@@ -294,7 +293,7 @@ def delete(X, start, end):
 	Parameters
 	----------
 	X: torch.tensor, shape=(-1, len(alphabet), length)
-		A one-hot encoded set of sequences to have a motif substituted into.
+		A one-hot encoded set of sequences to have a portion deleted from.
 
 	start: int
 		The starting position to remove, inclusive.
@@ -515,29 +514,24 @@ def _dinucleotide_shuffle(X, n_shuffles=1, random_state=None, verbose=False):
 
 	Parameters
 	----------
-	X: torch.tensor, shape=(-1, len(alphabet), length)
-		A one-hot encoded set of sequences to be shuffled.
+	X: torch.tensor, shape=(len(alphabet), length)
+		A single one-hot encoded sequence to be shuffled.
 
-	start: int, optional
-		The starting position of where to randomize the sequence, inclusive.
-		Default is 0, shuffling the entire sequence.
+	n_shuffles: int, optional
+		The number of shuffled sequences to produce. Default is 1.
 
-	end: int, optional
-		The ending position of where to randomize the sequence, not inclusive.
-		Default is -1, shuffling the entire sequence.
+	random_state: int or None, optional
+		The random seed to use when generating shuffles. If None, draw a new
+		seed at random. Default is None.
 
-	n: int, optional
-		The number of times to shuffle that region. Default is 1.
-
-	random_state: int, numpy.random.RandomState, or None, optional
-		Whether to use a specific random seed when generating the shuffle,
-		to ensure reproducibility. If None, do not use a reproducible seed.
-		Default is None.
+	verbose: bool, optional
+		Whether to print a warning when at least one position is identical
+		across all shuffles. Default is False.
 
 
 	Returns
 	-------
-	shuffled_sequences: torch.tensor, shape=(n, k, -1)
+	shuffled_sequences: torch.tensor, shape=(n_shuffles, len(alphabet), length)
 		The shuffled sequences.
 	"""
 
@@ -614,9 +608,9 @@ def dinucleotide_shuffle(X, start=0, end=-1, n=20, random_state=None,
 		The number of times to shuffle that region. Default is 20.
 
 	random_state: int or None, optional
-		Whether to use a specific random seed when generating the random insert,
+		Whether to use a specific random seed when generating the shuffle,
 		to ensure reproducibility. If None, do not use a reproducible seed.
-		Unlike other methods, cannot be a numpy.random.RandomState object. 
+		Unlike other methods, cannot be a numpy.random.RandomState object.
 		Default is None.
 
 

--- a/tangermeme/io.py
+++ b/tangermeme/io.py
@@ -239,19 +239,19 @@ def extract_loci(loci, sequences, signals=None, in_signals=None, chroms=None,
 	This function will take in a set of loci, sequences, and optionally signals,
 	and return the sequences and signals at each of the loci. Each of these
 	parameters can be a filename, which is loaded internally, or an appropriate
-	Python object (see below for details). The nomenclature `in/out` refer to
-	he expected inputs and outputs of the downstream machine learning model, 
+	Python object (see below for details). The nomenclature `in/out` refers to
+	the expected inputs and outputs of the downstream machine learning model,
 	not this function.
 
 	For each locus a sequence window of size `in_window` will be extracted from
-	the sequences file and each of the `input_signals` files if provided, and
+	the sequences file and each of the `in_signals` files if provided, and
 	a window of size `out_window` will be extracted from each of the `signals`
 	files if provided. These windows are centered at the middle of the provided
-	regions but all be of the same size, regardless of the size of the peak.
+	regions but will all be of the same size, regardless of the size of the peak.
 
 	If `max_jitter` is provided, it will expand the windows for both the input
 	and output. The results are not actually jittered, but this expanded window
-	allows for downstream data generators to created jittered data while
+	allows for downstream data generators to create jittered data while
 	reducing the memory footprint of the returned data.
 
 	There are a few reasons that the returned elements may not match one-to-one
@@ -263,8 +263,8 @@ def extract_loci(loci, sequences, signals=None, in_signals=None, chroms=None,
 		- (2) If any of the loci fall on chromosomes not in a provided list,
 		they will be removed.
 
-		- (3) If min_counts or max_counts are specified and the locus has a 
-		number of counts not in those boundaries.
+		- (3) If min_counts or max_counts are specified and the locus has a
+		number of counts not in those boundaries, the locus will be removed.
 
 	If exclusion lists are provided, they will be used to filter out loci that
 	fall in 100bp chunks that also include any of the regions in any of the
@@ -273,7 +273,7 @@ def extract_loci(loci, sequences, signals=None, in_signals=None, chroms=None,
 
 		chr7    108    234
 
-	loci will be removed if and of their bp fall within chr7 100 300.
+	loci will be removed if any of their bp fall within chr7 100 300.
  
 
 	Parameters
@@ -287,7 +287,7 @@ def extract_loci(loci, sequences, signals=None, in_signals=None, chroms=None,
 
 	sequences: str or dictionary
 		Either the path to a fasta file to read from or a dictionary where the
-		keys are the unique set of chromosoms and the values are one-hot
+		keys are the unique set of chromosomes and the values are one-hot
 		encoded sequences as numpy arrays or memory maps.
 
 	signals: list of strs or list of dictionaries or None, optional
@@ -296,14 +296,14 @@ def extract_loci(loci, sequences, signals=None, in_signals=None, chroms=None,
 		set of unique chromosomes and the values are numpy arrays or memory
 		maps. If None, no signal tensor is returned. Default is None.
 
-	input_signals: list of strs or list of dictionaries or None, optional
+	in_signals: list of strs or list of dictionaries or None, optional
 		A list of filepaths to bigwig files, where each filepath will be read
 		using pybigtools, or a list of dictionaries where the keys are the same
 		set of unique chromosomes and the values are numpy arrays or memory
-		maps. If None, no tensor is returned. Default is None. 
+		maps. If None, no tensor is returned. Default is None.
 
 	chroms: list or None, optional
-		A set of chromosomes to extact loci from. Loci in other chromosomes
+		A set of chromosomes to extract loci from. Loci in other chromosomes
 		in the locus file are ignored. If None, all loci are used. Default is
 		None.
 
@@ -383,17 +383,17 @@ def extract_loci(loci, sequences, signals=None, in_signals=None, chroms=None,
 		the second dimension is in the same order as the list of signal files.
 		If no signal files are given, this is not returned.
 
-	in_signals: torch.tensor, shape=(n, len(in_signals),out_window+2*max_jitter)
+	in_signals: torch.tensor, shape=(n, len(in_signals), in_window+2*max_jitter)
 		The extracted in signals where the first dimension is in the same order
 		as loci in the locus file after optional filtering by chromosome and
 		the second dimension is in the same order as the list of in signal files.
 		If no in signal files are given, this is not returned.
-	
+
 	kept_mask: torch.tensor, shape=(n0,), dtype=bool
 		A boolean vector of length equal to the number of pre-filtered peaks, with
-		entries being True if they were kept and False if they were filted out.
+		entries being True if they were kept and False if they were filtered out.
 		Applying this mask to the complete set of interleaved peaks will yield
-		the returned values. Only returned if `return_idxs=True`.
+		the returned values. Only returned if `return_mask=True`.
 	"""
 
 	seqs, signals_, in_signals_ = [], [], []
@@ -501,13 +501,34 @@ def extract_loci(loci, sequences, signals=None, in_signals=None, chroms=None,
 	return y_return[0] if len(y_return) == 1 else y_return
 
 
-def one_hot_to_fasta(X, filename, mode='w', headers=None, 
+def one_hot_to_fasta(X, filename, mode='w', headers=None,
 	alphabet=['A', 'C', 'G', 'T']):
 	"""Write out one-hot encoded sequences to a FASTA file.
-	
-	This function will take a set of one-hot encoded sequences and convert them to
-	characters and write them out in FASTA format. If headers are provided for
-	each sequence, these are used, otherwise the numeric index is used.
+
+	This function will take a set of one-hot encoded sequences and convert them
+	to characters and write them out in FASTA format. If headers are provided
+	for each sequence, these are used, otherwise the numeric index is used.
+
+
+	Parameters
+	----------
+	X: torch.Tensor, shape=(-1, len(alphabet), length)
+		A set of one-hot encoded sequences to write out.
+
+	filename: str
+		The path to the FASTA file to write to.
+
+	mode: str, optional
+		The file mode to open `filename` with, e.g. 'w' to overwrite or 'a' to
+		append. Default is 'w'.
+
+	headers: list of str or None, optional
+		A list of one header per sequence in `X`. If None, the numeric index of
+		each sequence is used as its header. Default is None.
+
+	alphabet: set or tuple or list, optional
+		A pre-defined alphabet where the ordering of the symbols is the same as
+		the index into the one-hot encoding. Default is ['A', 'C', 'G', 'T'].
 	"""
 	
 	with open(filename, mode=mode) as outfile:
@@ -539,7 +560,11 @@ def read_meme(filename, n_motifs=None):
 	Parameters
 	----------
 	filename: str
-		The filename of the MEME-formatted file to read in
+		The filename of the MEME-formatted file to read in.
+
+	n_motifs: int or None, optional
+		If provided, stop reading after this many motifs have been parsed. If
+		None, read all motifs in the file. Default is None.
 
 
 	Returns
@@ -564,6 +589,7 @@ def read_vcf(filename):
 	Parameters
 	----------
 	filename: str
+		The path to the VCF-formatted file to read in.
 
 
 	Returns

--- a/tangermeme/kmers.py
+++ b/tangermeme/kmers.py
@@ -30,7 +30,13 @@ def kmers(X, k, scores=None):
 
 	k: int
 		The size of the k-mers to consider.
-	
+
+	scores: torch.Tensor, shape=(-1, sequence_length) or None, optional
+		Per-position scores (e.g., attribution values) to weight each k-mer
+		by. When provided, the value stored for each k-mer is the sum of the
+		scores at the k positions it spans. If None, each k-mer instance
+		contributes a count of 1. Default is None.
+
 
 	Returns
 	-------
@@ -168,7 +174,7 @@ def gapped_kmers(X, scores=None, min_k=4, max_k=8, max_gap=2, max_len=10,
 	X: torch.Tensor, shape=(-1, len(alphabet), sequence_length)
 		A one-hot encoded set of sequences.
 
-	attr: torch.Tensor with shape=(-1, sequence_length) or None, optional
+	scores: torch.Tensor with shape=(-1, sequence_length) or None, optional
 		A corresponding set of attribution values to use. If None, return counts
 		instead of sum of attribution values. Default is None.
 
@@ -186,10 +192,13 @@ def gapped_kmers(X, scores=None, min_k=4, max_k=8, max_gap=2, max_len=10,
 		non-gap characters. Default is 10.
 
 	max_gkmers: int, optional
-		The maximum number of gapped k-mers to return.
+		The maximum number of gapped k-mers to return per example, ranked by
+		absolute score. Default is 10.
 
-	top_n_gkmers: int, optional
-		..
+	max_pos: int or None, optional
+		If provided, only consider the top `max_pos` positions per example
+		ranked by score before extracting gapped k-mers. If None, consider
+		all positions. Default is None.
 
 
 	Returns

--- a/tangermeme/marginalize.py
+++ b/tangermeme/marginalize.py
@@ -16,9 +16,9 @@ def marginalize(model, X, motif, start=None, alphabet=['A', 'C', 'G', 'T'],
 	"""Apply a function before and after substituting a motif into sequences.
 
 	A marginalization experiment is one where a function is applied before
-	and after substituting something into a set of sequences. It is named as 
-	such because the sequences are meant to be background sequences and
-	difference in output before and after the substitution represent the
+	and after substituting something into a set of sequences. It is named as
+	such because the sequences are meant to be background sequences and the
+	difference in output before and after the substitution represents the
 	"marginal" effect of adding that something into the sequences. When you are
 	adding a motif to the sequence, the difference in output can be interpreted 
 	as the effect that motif has on the function in isolation.
@@ -26,7 +26,7 @@ def marginalize(model, X, motif, start=None, alphabet=['A', 'C', 'G', 'T'],
 	By default, `marginalize` will apply the `predict` function to `X` before
 	and after substituting in a one-hot encoded version of `motif`. However,
 	one can pass in any function, including `deep_lift_shap` or even
-	`saturated_mutagenesis`. These functions may have additional arguments
+	`saturation_mutagenesis`. These functions may have additional arguments
 	and those can be passed into `marginalize` as-is and will be passed along
 	to the function. If any arguments would have had the same name as those
 	used by this function, you can use the `additional_func_kwargs` input to
@@ -141,7 +141,7 @@ def marginalize_annotations(model, X, X0, annotations, **kwargs):
 		the end position (0-indexed, not inclusive).
 
 	kwargs: arguments
-		Additional optional arguments to pass into the `ablate` function.
+		Additional optional arguments to pass into the `marginalize` function.
 
 	
 	Returns

--- a/tangermeme/match.py
+++ b/tangermeme/match.py
@@ -44,7 +44,7 @@ def _loci_coords_generator(loci_df, width = None):
 	return g if width is None else _resize_coords_generator(g, width)
 
 def _valid_locus(chrom, start, end, chrom_sizes):
-	"""Returns a bool telling whehter the specificed locus is valid, i.e the `chrom`
+	"""Returns a bool telling whether the specified locus is valid, i.e., the `chrom`
 	is found in the `chrom_sizes` dictionary and `start` and `end` are within bounds."""
 	return (chrom in chrom_sizes) and (start >= 0) and (end <= chrom_sizes[chrom])
 
@@ -174,7 +174,7 @@ def _char_perc_from_coords(fasta, coords, chars, num_regions=-1, buffer=False, v
 		Should only be set to true if there are many regions
 		on the same chromosome, such as when calculating GC content for
 		an entire chromosome. It is not recommend to use buffering if
-		calculating char pecentages for only peak regions, but if done
+		calculating char percentages for only peak regions, but if done
 		anyway for some reason, the peaks should be sorted by chromosome.
 		If set to false, will instead only load the sequence for a single
 		region at a time into memory. Default is False.
@@ -197,17 +197,16 @@ def _char_perc_from_coords(fasta, coords, chars, num_regions=-1, buffer=False, v
 	return perc
 
 def _counts_from_coords(bigwig, coords, num_regions=-1, buffer=False, verbose=False):
-	"""An internal function returning the percentage of `chars` for each sequence
-	with `coords` extracted from the `fasta` file.
+	"""An internal function returning the summed signal in each region of `coords`
+	extracted from the `bigwig` file.
 
-	This method will take in a `fasta` file and return the percentage of `chars`
-	in the sequences extracted from the fasta file and defined by the list of `coords`.
-	This is usually used to calculate GC percentage but can also be used to calculate
-	the percentage of N's.
+	This method will take in a `bigwig` file and return the summed signal in
+	each region defined by `coords`. If signal cannot be extracted from a
+	region, NaN is returned for that region.
 
 	Parameters
 	----------
-	fasta: str
+	bigwig: str
 		The path to a bigwig file to extract counts from.
 
 	coords: list, tuple or generator of such
@@ -432,8 +431,8 @@ def extract_matching_loci(loci, fasta, in_window=2114, out_window=1000,
 		will be different each time. Default is None.
 
 	n_jobs: integer, optional
-		Number of parallel processes to use for extracting background gc content.
-		-1 means use all available CPUs. Default is -1.
+		Number of parallel processes to use for extracting background GC content.
+		-1 means use all available CPUs. Default is 1.
 
 	verbose: bool, optional
 		Whether to print display bars and diagnostics to ensure that the

--- a/tangermeme/pisa.py
+++ b/tangermeme/pisa.py
@@ -88,9 +88,10 @@ def pisa(model, X, args=None, batch_size=32, references=dinucleotide_shuffle,
 
     hypothetical: bool, optional
         Whether to return attributions for all possible characters at each
-        position or only for the character that is actually at the sequence.
-        Practically, whether to return the returned attributions from captum
-        with the one-hot encoded sequence. Default is False.
+        position (`True`) or only for the character that is actually in the
+        sequence (`False`). When `False`, the per-character attributions are
+        multiplied by the one-hot encoded input so that only the observed
+        character has a non-zero attribution at each position. Default is False.
 
     warning_threshold: float, optional
         A threshold on the convergence delta that will always raise a warning
@@ -134,16 +135,16 @@ def pisa(model, X, args=None, batch_size=32, references=dinucleotide_shuffle,
     Returns
     -------
     attributions: torch.tensor
-        If `raw_outputs=False` (default), the attribution values with shape
-        equal to `X`. If `raw_outputs=True`, the multipliers for each example-
-        reference pair with shape equal to `(X.shape[0], n_shuffles, X.shape[1],
-        X.shape[2])`. 
+        If `raw_outputs=False` (default), the per-output attribution values
+        with shape `(X.shape[0], n_outputs, X.shape[1], X.shape[2])`. If
+        `raw_outputs=True`, the multipliers for each example-reference pair
+        with shape `(X.shape[0], n_shuffles, n_outputs, X.shape[1], X.shape[2])`.
 
     references: torch.tensor, optional
         The references used for each input sequence, with the shape
         (n_input_sequences, n_shuffles, 4, length). Only returned if
-        `return_references = True`. 
-    """    
+        `return_references = True`.
+    """
 
     _validate_input(X, "X", shape=(-1, -1, -1), ohe=True)
 
@@ -275,7 +276,7 @@ def pisa(model, X, args=None, batch_size=32, references=dinucleotide_shuffle,
             # Discard the accumulated graph
             torch.autograd.grad(y[:1, :1].sum(), x, retain_graph=False)[0]
 
-            # Keep the multpliers across each output
+            # Keep the multipliers across each output
             multipliers.append(torch.cat(_multipliers, dim=0))
 
         attr = torch.stack(multipliers, dim=0)

--- a/tangermeme/plot.py
+++ b/tangermeme/plot.py
@@ -155,7 +155,7 @@ def plot_logo(X_attr, ax=None, color=None, annotations=None, start=None,
 			sequence. Default is None.
 
 	end: int or None, optional
-			The end of the sequence to visuaize. Must be non-negative and cannot be
+			The end of the sequence to visualize. Must be non-negative and cannot be
 			longer than the length of `X_attr`. If `start` is provided, `end` must 
 			be larger. If None, visualize the full sequence. Default is None.
 
@@ -291,7 +291,7 @@ def plot_logo(X_attr, ax=None, color=None, annotations=None, start=None,
 			y_offset_bars=ax.get_ylim()[0]/8
 			y_offset_labels = 0
 
-			#deterrmine label text size and line width according to figure size
+			#determine label text size and line width according to figure size
 			bbox = ax.get_position()
 			fig_width, fig_height = ax.get_figure().get_size_inches()
 			width_in = bbox.width * fig_width
@@ -461,7 +461,7 @@ def plot_attributions(models, X, func=deep_lift_shap, attribute_kwargs=None,
 		One or a set of models to apply to the sequence/s.
 	
 	X: torch.Tensor, shape=(-1, len(alphabet), -1) or (len(alphabet), -1)
-		One or more sequences 
+		One or more sequences to calculate attributions for and visualize.
 
 	func: func, optional
 		The attribution function to use. Default is deep_lift_shap.
@@ -470,7 +470,7 @@ def plot_attributions(models, X, func=deep_lift_shap, attribute_kwargs=None,
 		Arguments to pass into `func`. Default is None.
 	
 	plot_kwargs: dict or None, optional
-		Arguments to pass into `func`. Default is None.
+		Arguments to pass into `plot_logo`. Default is None.
 
 	layout: 2-tuple or None, optional
 		A layout of the subplots, the first two numbers passed into

--- a/tangermeme/product.py
+++ b/tangermeme/product.py
@@ -60,7 +60,8 @@ def apply_pairwise(func, model, X, args=None, batch_size=32, device='cuda',
 		`args` should be one tensor that is input to the model. The elements do
 		not need to be the same size as each other as a product will be
 		constructed over all of them, as well as with `X`. If you only want
-		to use one value for an argument across all function applications 
+		to use one value for an argument across all function applications,
+		pass it in as a length-1 tensor.
 
 	batch_size: int, optional
 		The number of examples to make predictions for at a time. Default is 32.
@@ -78,7 +79,7 @@ def apply_pairwise(func, model, X, args=None, batch_size=32, device='cuda',
 		their way into the function. Default is {}.
 
 	verbose: bool, optional
-		Whether to display a progress bar as spacings are evaluated. Default
+		Whether to display a progress bar as examples are processed. Default
 		is False.
 
 	kwargs: optional
@@ -186,7 +187,8 @@ def apply_product(func, model, X, args, batch_size=32, device='cuda',
 		`args` should be one tensor that is input to the model. The elements do
 		not need to be the same size as each other as a product will be
 		constructed over all of them, as well as with `X`. If you only want
-		to use one value for an argument across all function applications 
+		to use one value for an argument across all function applications,
+		pass it in as a length-1 tensor.
 
 	batch_size: int, optional
 		The number of examples to make predictions for at a time. Default is 32.
@@ -204,7 +206,7 @@ def apply_product(func, model, X, args, batch_size=32, device='cuda',
 		their way into the function. Default is {}.
 
 	verbose: bool, optional
-		Whether to display a progress bar as spacings are evaluated. Default
+		Whether to display a progress bar as examples are processed. Default
 		is False.
 
 	kwargs: optional

--- a/tangermeme/saturation_mutagenesis.py
+++ b/tangermeme/saturation_mutagenesis.py
@@ -1,4 +1,4 @@
-# ism.py
+# saturation_mutagenesis.py
 # Contact: Jacob Schreiber <jmschreiber91@gmail.com>
 
 import numba
@@ -119,7 +119,7 @@ def saturation_mutagenesis(model, X, args=None, start=0, end=-1,
 		Default is 0.
 	
 	end: int, optional
-		The end of where to to make perturbations to the sequence. If end is
+		The end of where to make perturbations to the sequence. If end is
 		positive, it is non-inclusive. If end is negative, it is inclusive.
 		Default is -1, meaning the entire sequence.
 	
@@ -133,7 +133,7 @@ def saturation_mutagenesis(model, X, args=None, start=0, end=-1,
 	
 	hypothetical: bool, optional
 		Whether to return attributions for all possible characters at each
-		position or only for the character that is actually at the sequence.
+		position or only for the character that is actually in the sequence.
 		Only matters when `raw_outputs=False`. Default is False.
 	
 	raw_outputs: bool, optional
@@ -158,9 +158,10 @@ def saturation_mutagenesis(model, X, args=None, start=0, end=-1,
 	Returns
 	-------
 	attr: torch.Tensor
-		Processed attribution values as the z-score normalized difference
-		between the difference in predictions for the original sequence and
-		the perturbed sequences.
+		Processed attribution values. For each example and each position, the
+		difference between the model's prediction on the perturbed sequence and
+		on the original sequence is computed, then mean-subtracted across the
+		alphabet axis so the values at each position are centered on zero.
 	
 	-- or, if raw_outputs=True --
 	

--- a/tangermeme/seqlet.py
+++ b/tangermeme/seqlet.py
@@ -261,7 +261,7 @@ def tfmodisco_seqlets(X_attr, window_size=21, flank=10, target_fdr=0.2,
 
 	weak_threshold_for_counting_sign: float, optional
 		A minimal threshold to use when setting the final threshold value
-		separating seqlets from non-seqlets.
+		separating seqlets from non-seqlets. Default is 0.8.
 
 
 	Returns
@@ -467,7 +467,7 @@ def recursive_seqlets(X, threshold=0.01, min_seqlet_len=4, max_seqlet_len=25,
 	seqlet lengths by discretizing the attribution sum into integers. Then,
 	CDFs are calculated for each distribution (or, more specifically, 1-CDFs).
 	Finally, p-values are calculated via lookup to these 1-CDFs for all
-	potential CDFs, yielding a (n_positions, n_lengths) matrix of p-values.
+	potential spans, yielding a (n_positions, n_lengths) matrix of p-values.
 
 	This algorithm then identifies seqlets by defining them to have a key
 	property: all internal spans of a seqlet must also have been called a
@@ -525,7 +525,8 @@ def recursive_seqlets(X, threshold=0.01, min_seqlet_len=4, max_seqlet_len=25,
 
 	additional_flanks: int, optional
 		An additional value to subtract from the start, and to add to the end,
-		of all called seqlets. Does not affect the called seqlets.
+		of all called seqlets. Does not affect which seqlets are called, only
+		extends their boundaries after calling. Default is 0.
 
 	n_bins: int, optional
 		The number of bins to use when estimating the PDFs and CDFs. Default is

--- a/tangermeme/space.py
+++ b/tangermeme/space.py
@@ -32,10 +32,10 @@ def space(model, X, motifs, spacing, start=None, alphabet=['A', 'C', 'G', 'T'],
 		inputs must be specified in the `args` parameter.
 
 	X: torch.tensor, shape=(-1, len(alphabet), length)
-		A one-hot encoded set of sequences to have a motif inserted into.
+		A one-hot encoded set of sequences to have motifs inserted into.
 
 	motifs: list of torch.tensor, shape=(-1, len(alphabet), motif_length)
-		A list of strings or of one-hot encoded version of a short motif to 
+		A list of strings or of one-hot encoded versions of short motifs to
 		substitute into the set of sequences.
 
 	spacing: torch.Tensor, shape=(-1, len(motifs)-1)
@@ -47,9 +47,9 @@ def space(model, X, motifs, spacing, start=None, alphabet=['A', 'C', 'G', 'T'],
 		between the second and third motif, etc. 
 
 	start: int or None, optional
-		The starting position of where to insert the motif. If None, insert the
-		motif into the middle of the sequence such that the middle of the motif
-		occurs at the middle of the sequence. Default is None.
+		The starting position of where to insert the first motif. If None, the
+		full motif arrangement is centered such that its midpoint coincides with
+		the middle of the sequence. Default is None.
 
 	alphabet : set or tuple or list, optional
 		A pre-defined alphabet where the ordering of the symbols is the same
@@ -81,14 +81,14 @@ def space(model, X, motifs, spacing, start=None, alphabet=['A', 'C', 'G', 'T'],
 
 	Returns
 	-------
-	y_befores: torch.Tensor or list of torch.Tensors
-		The predictions from the model before inserting the motif in. If the
+	y_before: torch.Tensor or list of torch.Tensors
+		The predictions from the model before inserting the motifs in. If the
 		output from the model's forward function is a single tensor, it will
 		return that. If the model outputs a list of tensors, it will return
 		those.
 
 	y_afters: torch.Tensor or list of torch.Tensors
-		The predictions from the model after inserting the motif in. If the
+		The predictions from the model after inserting the motifs in. If the
 		output from the model's forward function is a single tensor, it will
 		return that. If the model outputs a list of tensors, it will return
 		those.

--- a/tangermeme/utils.py
+++ b/tangermeme/utils.py
@@ -51,7 +51,11 @@ def _validate_input(X, name, shape=None, dtype=None, min_value=None,
 	ohe: bool, optional
 		Whether the input must be a one-hot encoding, i.e., only consist of
 		zeroes and ones. Default is False.
-	
+
+	ohe_dim: int, optional
+		When `ohe=True`, the axis along which the one-hot encoding should sum
+		to 1 (or, with `allow_N=True`, sum to at most 1). Default is 1.
+
 	allow_N: bool, optional
 		Whether to allow the return of the character 'N' in the sequence, i.e.
 		if pwm at a position is all 0's return N. Default is False.
@@ -287,7 +291,7 @@ def characters(pwm, alphabet=['A', 'C', 'G', 'T'], force=False, allow_N=False):
 
 	force: bool, optional
 		Whether to force a sequence to be produced even when there are ties.
-		At each position that there is a tight, the character earlier in the
+		At each position that there is a tie, the character earlier in the
 		sequence will be used. Default is False.
   
 	allow_N: bool, optional
@@ -455,7 +459,7 @@ def reverse_complement(seq, complement_map={"A": "T", "C": "G", "G": "C",
 	Returns
 	-------
 	rev_comp: str or torch.Tensor w/ shape (alphabet_size, length)
-		The reverse complemented string or 
+		The reverse complemented string or tensor.
 	"""
 
 	if isinstance(seq, str):
@@ -486,7 +490,7 @@ def random_one_hot(shape, probs=None, dtype='int8', random_state=None):
 
 	This function will generate random one-hot encodings where the second to
 	last dimension has a single element being a one and every other element
-	being a zero. Primary used for debugging. 
+	being a zero. Primarily used for debugging.
 
 
 	Parameters
@@ -497,7 +501,7 @@ def random_one_hot(shape, probs=None, dtype='int8', random_state=None):
 	probs: tuple, list, numpy.ndarray, or None optional
 		A 2D array of probabilities where the first dimension is the batch size
 		equal to the batch size of `X` and the second dimension is the alphabet
-		size. The values should be the probability of that character occuring
+		size. The values should be the probability of that character occurring
 		in that sequence. If a batch size of 1 is used when the batch size of
 		X is greater than 1, the same probabilities are used for each sequence.
 		The sum of probabilities across the alphabet axis must be equal to 1.

--- a/tangermeme/variant_effect.py
+++ b/tangermeme/variant_effect.py
@@ -1,4 +1,4 @@
-# variant.py
+# variant_effect.py
 # Contact: Jacob Schreiber <jmschreiber91@gmail.com>
 
 import torch
@@ -30,10 +30,10 @@ def substitution_effect(model, X, substitutions, args=None, func=predict,
 	after substitutions are made. At least one substitution should be provided 
 	per sequence for the results to be different.
 
-	The substitutions provided must be individual variants, i.e., that each row 
+	The substitutions provided must be individual variants, i.e., each row
 	in the tensor corresponds to a single substitution in a single example, but
 	one can encode longer variants (e.g., entire motifs or just multiple
-	characters) by passing in multiple rows with adjacent positions. 
+	characters) by passing in multiple rows with adjacent positions.
 
 	Note that substitutions are not insertions. A substitution involves changing
 	one character to another character. An insertion involves adding a new
@@ -64,9 +64,8 @@ def substitution_effect(model, X, substitutions, args=None, func=predict,
 		An optional set of additional arguments to pass into the model. If
 		provided, each element in the tuple or list is one input to the model
 		and the element must be formatted to be the same batch size as `X`. If
-		None, no additional arguments are passed into the forward function. This
-		argument is provided here because the args must be copied for each
-		shuffle that occurs. Default is None.
+		None, no additional arguments are passed into the forward function.
+		Default is None.
 
 	func: function, optional
 		A function to apply before and after incorporating the substitution. 
@@ -110,22 +109,22 @@ def deletion_effect(model, X, deletions, left=False, args=None, func=predict,
 	additional_func_kwargs=None, **kwargs):
 	"""Apply a function before and after deleting characters from a sequence.
 
-	This function will calculate the effect that insertions have on the
+	This function will calculate the effect that deletions have on the
 	output from a model. Any number of deletions can be specified for each
 	sequence and the provided `func` is applied before and after the deletions
 	are taken into account. By default, this `func` is the prediction function
 	and so the results are the difference in predictions before and after the
-	deletions are made, but if `func` is something else, such as 
+	deletions are made, but if `func` is something else, such as
 	`deep_lift_shap`, the results will be the attributions before and after the
 	deletions are made. At least one deletion should be provided per sequence
 	for the results to be different.
 
-	The deletions provided must be individual characters, i.e., that each row
+	The deletions provided must be individual characters, i.e., each row
 	in the tensor corresponds to a single deletion in a single example, but one
-	can encode longer deletions (e.g., entire motifs or just multiple 
+	can encode longer deletions (e.g., entire motifs or just multiple
 	characters) by passing in multiple rows with adjacent positions.
 
-	Importantly, because models assume a fixed input window but deletons are by
+	Importantly, because models assume a fixed input window but deletions are by
 	definition changing the length of the sequence, the provided sequences must
 	be of length `model_length + max_deletions_per_sequence`. Basically, if the
 	maximum number of deletions in a sequence is equal to 12 and the model
@@ -173,17 +172,16 @@ def deletion_effect(model, X, deletions, left=False, args=None, func=predict,
 		An optional set of additional arguments to pass into the model. If
 		provided, each element in the tuple or list is one input to the model
 		and the element must be formatted to be the same batch size as `X`. If
-		None, no additional arguments are passed into the forward function. This
-		argument is provided here because the args must be copied for each
-		shuffle that occurs. Default is None.
+		None, no additional arguments are passed into the forward function.
+		Default is None.
 
 	func: function, optional
-		A function to apply before and after incorporating the substitution. 
+		A function to apply before and after incorporating the deletions.
 		Default is `predict`.
 
 	additional_func_kwargs: dict, optional
 		Additional named arguments to pass into the function when it is called.
-		This is provided as an alternate path to route arguments into the 
+		This is provided as an alternate path to route arguments into the
 		function in case they overlap, name-wise, with those in this function,
 		or if you want to be absolutely sure that the arguments are making
 		their way into the function. Default is {}.
@@ -244,20 +242,19 @@ def insertion_effect(model, X, insertions, left=False, args=None, func=predict,
 	insertions are made. At least one insertion should be provided per sequence
 	for the results to be different.
 
-	The insertions provided must be individual characters, i.e., that each row
+	The insertions provided must be individual characters, i.e., each row
 	in the tensor corresponds to a single insertion in a single example, but one
-	can encode longer insertions (e.g., entire motifs or just multiple 
+	can encode longer insertions (e.g., entire motifs or just multiple
 	characters) by passing in multiple rows with adjacent positions.
 
-	Simply removing all of the specified characters will lead to a set of
-	sequences of differing lengths if there are a different number of insertions
-	in each sequence. In order to make these sequences all the same length, we
-	need to trim from each sequence a number of positions from each sequence
-	equal to the number of characters that are being added in. Because there
-	are two ways we can trim positions -- either starting from the left end of 
-	the sequence or from the right end of it -- you can use the `left` parameter
-	to specify that you should trim positions on the left (`left=True`) or from
-	the right (`left=False`, the default) of the sequence. 
+	Because models assume a fixed input window but insertions are by definition
+	changing the length of the sequence, characters must be trimmed off after
+	the insertions are made so the post-insertion sequence has the same length
+	as the original. Because there are two ways we can trim positions -- either
+	starting from the left end of the sequence or from the right end of it --
+	you can use the `left` parameter to specify that you should trim positions
+	on the left (`left=True`) or from the right (`left=False`, the default) of
+	the sequence.
 
 
 	Parameters
@@ -273,13 +270,15 @@ def insertion_effect(model, X, insertions, left=False, args=None, func=predict,
 	insertions: torch.tensor, shape=(-1, 3)
 		A set of insertions indicating characters that should be added to
 		each sequence. Each row should be a single insertion with the first
-		column corresponding to the example and the second column corresponding
-		to the position within that example. Multiple insertions can occur in 
-		each example. 
+		column corresponding to the example index, the second column
+		corresponding to the position within that example at which the
+		character should be inserted, and the third column corresponding to
+		the index in the alphabet of the character to insert. Multiple
+		insertions can occur in each example.
 
 	left: bool, optional
-		If False, use the first `n` positions to run through the model before
-		making the deletion where `n` is the expected tensor length. If True,
+		If False, use the first `n` positions to run through the model after
+		making the insertion where `n` is the expected tensor length. If True,
 		use the last `n` positions. Basically, whether we trim positions from
 		the left or the right when getting sequences of the same length.
 		Default is False.
@@ -288,17 +287,16 @@ def insertion_effect(model, X, insertions, left=False, args=None, func=predict,
 		An optional set of additional arguments to pass into the model. If
 		provided, each element in the tuple or list is one input to the model
 		and the element must be formatted to be the same batch size as `X`. If
-		None, no additional arguments are passed into the forward function. This
-		argument is provided here because the args must be copied for each
-		shuffle that occurs. Default is None.
+		None, no additional arguments are passed into the forward function.
+		Default is None.
 
 	func: function, optional
-		A function to apply before and after incorporating the substitution. 
+		A function to apply before and after incorporating the insertions.
 		Default is `predict`.
 
 	additional_func_kwargs: dict, optional
 		Additional named arguments to pass into the function when it is called.
-		This is provided as an alternate path to route arguments into the 
+		This is provided as an alternate path to route arguments into the
 		function in case they overlap, name-wise, with those in this function,
 		or if you want to be absolutely sure that the arguments are making
 		their way into the function. Default is {}.


### PR DESCRIPTION
## Summary

Sweep across module docstrings, README, and Sphinx sources for typos, unfinished sentences, wrong copy-pasted parameter descriptions, and references that no longer match the code. No runtime behavior changes — docstrings, comments, and prose only, plus two new API stub pages.

- **README**: wrong import path in the saturation-mutagenesis example (`tangermeme.ism` doesn't exist), 4-backtick code fence, contradictory "design a sequence that has desired attributions" sentence.
- **Copy-paste contamination** between `ablate` / `marginalize` / `variant_effect` / `space` / `ersatz`: wrong verbs ("inserting the motif" inside `ablate`), wrong default values (`ablate` `n` doc said 1, signature says 20), `start`/`end` marked optional when they're required, leftover "args must be copied for each shuffle" sentence in `variant_effect`, etc.
- **Attribution modules** (`deep_lift_shap`, `pisa`, `saturation_mutagenesis`): `hypothetical` docstring referenced removed captum behavior across all three; PISA Returns docstring claimed "shape equal to X" but PISA is per-output (`(B, n_outputs, alphabet, length)`); `saturation_mutagenesis` claimed z-score normalization but only mean-subtracts.
- **Missing parameter docs** added: `kmers.scores`, `gapped_kmers.max_pos` (replaces a bogus `top_n_gkmers` entry with `..` as the body), `greedy_marginalize.max_spacing`, `read_meme.n_motifs`, `_validate_input.ohe_dim`, `one_hot_to_fasta` (was a 3-line summary only), `seqlet.weak_threshold_for_counting_sign` default, `seqlet.additional_flanks` default.
- **docs/index.rst**: stale `pomegranate-logo.png` directive and pomegranate readthedocs badge removed; FIMO/TOMTOM/MEME paragraph rewritten to point at `memesuite-lite` since the CLIs were moved; `fork the master branch` → `fork the main branch`; new `api/kmers.rst` and `api/pisa.rst` stubs added to the toctree (those modules existed but had no API page).
- **docs/whats_new.rst**: a handful of typo/grammar fixes (`will effect` → `will affect`, `defaultly`, `back compatible` → `backwards compatible`, etc.).

Files: 22 changed, 285 insertions, 239 deletions.

## Test plan

- [x] `uv run pytest` still passes (no logic changes, but worth confirming nothing inadvertently broke a docstring-based test)
- [x] `uv run ruff check tangermeme tests` clean
- [ ] Build docs locally and confirm the new `kmers` and `pisa` API pages render and the pomegranate stub is gone: `cd docs && make html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)