### PR TITLE
Phase 1: hygiene sweep across all modules

### DIFF
--- a/tangermeme/_compat.py
+++ b/tangermeme/_compat.py
@@ -1,0 +1,84 @@
+# _compat.py
+# Contact: Jacob Schreiber <jmschreiber91@gmail.com>
+
+"""Small cross-module helpers for device handling and model-state
+preservation. Kept private to discourage external dependence; everything
+here is implementation detail that the public functions in `predict`,
+`deep_lift_shap`, `pisa`, `design`, `product`, and `saturation_mutagenesis`
+share."""
+
+import contextlib
+
+import torch
+
+
+def _resolve_device(device):
+	"""Resolve a user-supplied device argument to a concrete `torch.device`.
+
+	If `device` is None, return `'cuda'` when CUDA is available and `'cpu'`
+	otherwise. If `device` is a string or `torch.device`, it is returned as
+	a `torch.device`. This lets callers avoid the historical default of
+	`device='cuda'`, which crashes on CPU-only machines.
+	"""
+
+	if device is None:
+		return torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+	if isinstance(device, torch.device):
+		return device
+
+	return torch.device(device)
+
+
+def _autocast_supported(device, dtype):
+	"""Return True when `torch.autocast` is meaningful for this combination.
+
+	`torch.autocast(device_type='cpu', dtype=torch.float32)` raises on
+	recent PyTorch versions; autocasting to the native dtype is also a
+	no-op. This helper centralizes the check so `predict` and other
+	callers can skip autocast when it would either crash or do nothing.
+	"""
+
+	if dtype is None:
+		return False
+
+	device_type = device.type if isinstance(device, torch.device) else str(device).split(':')[0]
+
+	if device_type == 'cpu':
+		return dtype in (torch.bfloat16, torch.float16)
+
+	if device_type == 'cuda':
+		return dtype != torch.float32
+
+	return False
+
+
+@contextlib.contextmanager
+def _preserve_model_state(model, device):
+	"""Move a model to `device` for the duration of a `with` block, then
+	restore its original device and training mode on exit.
+
+	Many public entry points (`predict`, `deep_lift_shap`, ...) historically
+	called `model.to(device).eval()` and never restored the original state,
+	silently mutating a user-owned object. Wrapping those calls with this
+	context manager keeps the model where the user left it.
+	"""
+
+	try:
+		orig_device = next(model.parameters()).device
+	except StopIteration:
+		orig_device = None
+
+	was_training = model.training
+
+	if orig_device is None or orig_device != device:
+		model.to(device)
+	model.eval()
+
+	try:
+		yield
+	finally:
+		if was_training:
+			model.train()
+		if orig_device is not None and orig_device != device:
+			model.to(orig_device)

--- a/tangermeme/ablate.py
+++ b/tangermeme/ablate.py
@@ -86,12 +86,13 @@ def ablate(model, X, start, end, n=20, shuffle_fn=shuffle, args=None,
 		A function to apply before and after making the ablation. Default 
 		is `predict`.
 
-	additional_func_kwargs: dict, optional
+	additional_func_kwargs: dict or None, optional
 		Additional named arguments to pass into the function when it is called.
-		This is provided as an alternate path to route arguments into the 
+		This is provided as an alternate path to route arguments into the
 		function in case they overlap, name-wise, with those in this function,
 		or if you want to be absolutely sure that the arguments are making
-		their way into the function. Default is {}.
+		their way into the function. The dict is not modified in place. Default
+		is None.
 
 	kwargs: optional
 		Additional named arguments that will get passed into the function when
@@ -114,7 +115,7 @@ def ablate(model, X, start, end, n=20, shuffle_fn=shuffle, args=None,
 	"""
 
 	_validate_input(X, "X", shape=(-1, -1, -1), ohe=True, allow_N=True)
-	additional_func_kwargs = additional_func_kwargs or {}
+	additional_func_kwargs = dict(additional_func_kwargs or {})
 	if 'random_state' in inspect.signature(func).parameters.keys():
 		if 'random_state' not in additional_func_kwargs:
 			additional_func_kwargs['random_state'] = random_state

--- a/tangermeme/deep_lift_shap.py
+++ b/tangermeme/deep_lift_shap.py
@@ -1,15 +1,17 @@
 # deep_lift_shap.py
 # Contact: Jacob Schreiber <jmschreiber91@gmail.com>
 
+import contextlib
+import warnings
+
 import torch
 import torch.nn.functional as F
 
-import warnings
-
 from tqdm import trange
 
-from .utils import _validate_input
+from ._compat import _autocast_supported, _resolve_device
 from .ersatz import dinucleotide_shuffle
+from .utils import _validate_input
 
 
 def hypothetical_attributions(multipliers, X, references):
@@ -199,10 +201,10 @@ def _maxpool(module, grad_input, grad_output):
 
 
 def deep_lift_shap(model, X, args=None, target=0,  batch_size=32,
-	references=dinucleotide_shuffle, n_shuffles=20, return_references=False, 
+	references=dinucleotide_shuffle, n_shuffles=20, return_references=False,
 	hypothetical=False, warning_threshold=0.001, additional_nonlinear_ops=None,
-	print_convergence_deltas=False, raw_outputs=False, only_warn=False, 
-	dtype=None, device='cuda', random_state=None, verbose=False):
+	print_convergence_deltas=False, raw_outputs=False, only_warn=False,
+	dtype=None, device=None, random_state=None, verbose=False):
 	"""Calculate attributions for a set of sequences using DeepLIFT/SHAP.
 
 	This function will calculate the DeepLIFT/SHAP attributions on a set of
@@ -325,14 +327,14 @@ def deep_lift_shap(model, X, args=None, target=0,  batch_size=32,
 		the *model*. This allows you to use int8 to represent large data sets and
 		only convert batches to the higher precision, saving memory. Default is None.
 
-	device: str or torch.device, optional
+	device: str or torch.device or None, optional
 		The device to move the model and batches to when making predictions. If
-		set to 'cuda' without a GPU, this function will crash and must be set
-		to 'cpu'. Default is 'cuda'. 
+		None, use CUDA when available and fall back to CPU otherwise. Default
+		is None.
 
 	random_state: int or None or numpy.random.RandomState, optional
 		The random seed to use to ensure determinism. If None, the
-		process is not deterministic. Default is None. 
+		process is not deterministic. Default is None.
 
 	verbose: bool, optional
 		Whether to display a progress bar. Default is False.
@@ -344,7 +346,7 @@ def deep_lift_shap(model, X, args=None, target=0,  batch_size=32,
 		If `raw_outputs=False` (default), the attribution values with shape
 		equal to `X`. If `raw_outputs=True`, the multipliers for each example-
 		reference pair with shape equal to `(X.shape[0], n_shuffles, X.shape[1],
-		X.shape[2])`. 
+		X.shape[2])`.
 
 	references: torch.tensor, optional
 		The references used for each input sequence, with the shape
@@ -377,10 +379,12 @@ def deep_lift_shap(model, X, args=None, target=0,  batch_size=32,
 		torch.nn.Softmax: _softmax
 	}
 
+	device = _resolve_device(device)
+
 	if dtype is None:
 		try:
 			dtype = next(model.parameters()).dtype
-		except:
+		except (StopIteration, AttributeError):
 			dtype = torch.float32
 	elif isinstance(dtype, str):
 		dtype = getattr(torch, dtype)
@@ -390,6 +394,8 @@ def deep_lift_shap(model, X, args=None, target=0,  batch_size=32,
 	if additional_nonlinear_ops is not None:
 		for key, value in additional_nonlinear_ops.items():
 			_NON_LINEAR_OPS[key] = value
+
+	use_autocast = _autocast_supported(device, dtype)
 
 	model = model.to(device).eval()
 	for module in model.modules():
@@ -444,9 +450,14 @@ def deep_lift_shap(model, X, args=None, target=0,  batch_size=32,
 			try:
 				X_ = torch.cat([_X, _references])
 
+				if use_autocast:
+					autocast_ctx = torch.autocast(device_type=device.type, dtype=dtype)
+				else:
+					autocast_ctx = contextlib.nullcontext()
+
 				# Calculate the gradients using the rescale rule
 				with torch.autograd.set_grad_enabled(True):
-					with torch.autocast(device_type=device, dtype=dtype):
+					with autocast_ctx:
 						if _args is not None:
 							_args = (torch.cat([arg, arg]) for arg in _args)
 							y = model(X_, *_args)[:, target]
@@ -520,8 +531,8 @@ def deep_lift_shap(model, X, args=None, target=0,  batch_size=32,
 
 
 def _captum_deep_lift_shap(model, X, args=None, target=0, batch_size=32,
-	references=dinucleotide_shuffle, n_shuffles=20,  return_references=False, 
-	hypothetical=False, device='cuda', random_state=None, verbose=False):
+	references=dinucleotide_shuffle, n_shuffles=20,  return_references=False,
+	hypothetical=False, device=None, random_state=None, verbose=False):
 	"""Calculate attributions using DeepLift/Shap and a given model. 
 
 	This function will calculate DeepLift/Shap attributions on a set of
@@ -591,14 +602,14 @@ def _captum_deep_lift_shap(model, X, args=None, target=0, batch_size=32,
 		multiplied by the one-hot encoded input so that only the observed
 		character has a non-zero attribution at each position. Default is False.
 
-	device: str or torch.device, optional
+	device: str or torch.device or None, optional
 		The device to move the model and batches to when making predictions. If
-		set to 'cuda' without a GPU, this function will crash and must be set
-		to 'cpu'. Default is 'cuda'. 
+		None, use CUDA when available and fall back to CPU otherwise. Default
+		is None.
 
 	random_state: int or None or numpy.random.RandomState, optional
 		The random seed to use to ensure determinism. If None, the
-		process is not deterministic. Default is None. 
+		process is not deterministic. Default is None.
 
 	verbose: bool, optional
 		Whether to display a progress bar. Default is False.
@@ -618,6 +629,7 @@ def _captum_deep_lift_shap(model, X, args=None, target=0, batch_size=32,
 
 	from captum.attr import DeepLiftShap as CaptumDeepLiftShap
 
+	device = _resolve_device(device)
 	model = model.to(device).eval()
 
 	attributions = []

--- a/tangermeme/design.py
+++ b/tangermeme/design.py
@@ -31,9 +31,9 @@ def _fast_tile_substitute(X, motif, idxs):
 
 
 def screen(model, shape, y=None, loss=torch.nn.MSELoss(reduction='none'), tol=1e-3,
-	max_iter=-1, args=None, n_best=1, alphabet=['A', 'C', 'G', 'T'], 
-	batch_size=32, func=random_one_hot, additional_func_kwargs={}, dtype=None, 
-	device='cuda', random_state=None, verbose=False):
+	max_iter=-1, args=None, n_best=1, alphabet=['A', 'C', 'G', 'T'],
+	batch_size=32, func=random_one_hot, additional_func_kwargs=None, dtype=None,
+	device=None, random_state=None, verbose=False):
 	"""Screen randomly generated sequences and choose the best one.
 
 	Potentially, the conceptually simplest method for design is to randomly
@@ -103,22 +103,23 @@ def screen(model, shape, y=None, loss=torch.nn.MSELoss(reduction='none'), tol=1e
 		must be that it takes in a tuple of the shape of the batch to generate, e.g. 
 		(32, 4, 2114), and also a random state. Default is `random_one_hot`. 
 
-	additional_func_kwargs: dict, optional
+	additional_func_kwargs: dict or None, optional
 		Additional named arguments to pass into the function when it is called.
-		This is provided as an alternate path to route arguments into the 
+		This is provided as an alternate path to route arguments into the
 		function in case they overlap, name-wise, with those in this function,
 		or if you want to be absolutely sure that the arguments are making
-		their way into the function. Default is {}.
+		their way into the function. The dict is not modified in place. Default
+		is None.
 
 	dtype: str or torch.dtype or None, optional
 		The dtype to use with mixed precision autocasting. If None, use the dtype of
 		the *model*. This allows you to use int8 to represent large data sets and
 		only convert batches to the higher precision, saving memory. Default is None.
 
-	device: str or torch.device, optional
+	device: str or torch.device or None, optional
 		The device to move the model and batches to when making predictions. If
-		set to 'cuda' without a GPU, this function will crash and must be set
-		to 'cpu'. Default is 'cuda'. 
+		None, use CUDA when available and fall back to CPU otherwise. Default
+		is None.
 
 	random_state: int or None, optional
 		The random seed to use to ensure determinism of the generation function.
@@ -138,12 +139,13 @@ def screen(model, shape, y=None, loss=torch.nn.MSELoss(reduction='none'), tol=1e
 		y = [9_999_999]
 
 	y = _cast_as_tensor(y)
-	
+	additional_func_kwargs = dict(additional_func_kwargs or {})
+
 	pq = []
 	iteration = 0
 
 	while True:
-		X = func((batch_size, *shape), random_state=random_state, 
+		X = func((batch_size, *shape), random_state=random_state,
 			**additional_func_kwargs)
 
 		y_hat = predict(model, X, dtype=dtype, device=device, args=args)
@@ -175,10 +177,10 @@ def screen(model, shape, y=None, loss=torch.nn.MSELoss(reduction='none'), tol=1e
 	return X
 
 
-def greedy_substitution(model, X, y=None, motifs=None, 
-	loss=torch.nn.MSELoss(reduction='none'), reverse_complement=True, 
-	input_mask=None, output_mask=None, tol=1e-3, max_iter=-1, args=None, 
-	alphabet=['A', 'C', 'G', 'T'], batch_size=32, device='cuda', verbose=False):
+def greedy_substitution(model, X, y=None, motifs=None,
+	loss=torch.nn.MSELoss(reduction='none'), reverse_complement=True,
+	input_mask=None, output_mask=None, tol=1e-3, max_iter=-1, args=None,
+	alphabet=['A', 'C', 'G', 'T'], batch_size=32, device=None, verbose=False):
 	"""Greedily add motifs to achieve a desired goal. 
 
 	This design function will greedily add motifs to achieve a desired output
@@ -269,10 +271,10 @@ def greedy_substitution(model, X, y=None, motifs=None,
 	batch_size: int, optional
 		The number of examples to make predictions for at a time. Default is 32.
 
-	device: str or torch.device, optional
+	device: str or torch.device or None, optional
 		The device to move the model and batches to when making predictions. If
-		set to 'cuda' without a GPU, this function will crash and must be set
-		to 'cpu'. Default is 'cuda'. 
+		None, use CUDA when available and fall back to CPU otherwise. Default
+		is None.
 
 	verbose: bool, optional
 		Whether to display a progress bar during predictions. Default is False.
@@ -281,7 +283,7 @@ def greedy_substitution(model, X, y=None, motifs=None,
 	Returns
 	-------
 	X: torch.Tensor, shape=(-1, len(alphabet), length)
-		The edited sequence. 
+		The edited sequence.
 	"""
 
 	tic = time.time()
@@ -379,9 +381,9 @@ def greedy_substitution(model, X, y=None, motifs=None,
 
 
 def greedy_marginalize(model, X, y, motifs, loss=torch.nn.MSELoss(
-	reduction='none'), max_spacing=12, reverse_complement=True, 
-	output_mask=None, tol=1e-3, max_iter=-1, args=None, 
-	alphabet=['A', 'C', 'G', 'T'], batch_size=32, device='cuda', verbose=False):
+	reduction='none'), max_spacing=12, reverse_complement=True,
+	output_mask=None, tol=1e-3, max_iter=-1, args=None,
+	alphabet=['A', 'C', 'G', 'T'], batch_size=32, device=None, verbose=False):
 	"""Greedily builds a construct and evaluates it using marginalizations.
 
 	This approach attempts to find a set of motifs and their orientations and
@@ -478,10 +480,10 @@ def greedy_marginalize(model, X, y, motifs, loss=torch.nn.MSELoss(
 	batch_size: int, optional
 		The number of examples to make predictions for at a time. Default is 32.
 
-	device: str or torch.device, optional
+	device: str or torch.device or None, optional
 		The device to move the model and batches to when making predictions. If
-		set to 'cuda' without a GPU, this function will crash and must be set
-		to 'cpu'. Default is 'cuda'.
+		None, use CUDA when available and fall back to CPU otherwise. Default
+		is None.
 
 	verbose: bool, optional
 		Whether to display a progress bar during predictions. Default is False.

--- a/tangermeme/ersatz.py
+++ b/tangermeme/ersatz.py
@@ -1,17 +1,18 @@
 # ersatz.py
 # Author: Jacob Schreiber <jmschreiber91@gmail.com>
 
+import warnings
+
 import numba
 import numpy
 import torch
-import pandas
 
 from tqdm import tqdm
-from itertools import compress
 
 from .utils import _validate_input
 from .utils import one_hot_encode
 from .utils import random_one_hot
+from .utils import TangermemeWarning
 
 
 def insert(X, motif, start=None, alphabet=list("ACGT")):
@@ -563,8 +564,9 @@ def _dinucleotide_shuffle(X, n_shuffles=1, random_state=None, verbose=False):
 	conserved = shuffled_sequences[:, :, 1:-1].sum(dim=0)
 	if conserved.max() == n_shuffles:
 		if verbose:
-			print("Warning: At least one position in dinucleotide shuffle " +
-				"is identical across all positions.")
+			warnings.warn(
+				"At least one position in dinucleotide shuffle is identical "
+				"across all positions.", TangermemeWarning, stacklevel=2)
 	if conserved.max(dim=0).values.min() == n_shuffles and n_shuffles > 1:
 		raise ValueError("All dinucleotide shuffles yield identical " +
 			"sequences, potentially due to a lack of diversity in sequence.")

--- a/tangermeme/io.py
+++ b/tangermeme/io.py
@@ -2,6 +2,8 @@
 # Author: Jacob Schreiber <jmschreiber91@gmail.com>
 # Code adapted from Alex Tseng, Avanti Shrikumar, and Ziga Avsec
 
+import warnings
+
 import numpy
 import torch
 import pandas
@@ -13,6 +15,7 @@ from tqdm import tqdm
 
 from .utils import one_hot_encode
 from .utils import characters
+from .utils import TangermemeWarning
 
 from memelite.io import read_meme as memelite_read_meme
 
@@ -218,10 +221,11 @@ def _extract_locus_signal(signals, chrom, start, end):
 		else:
 			try:
 				values_ = numpy.array(signal.values(chrom, start, end), dtype=numpy.float32)
-			except:
-				print(f"Warning: {chrom} {start} {end} not " +
-					"valid bigwig indexes. Using zeros instead.")
-				values_ = numpy.zeros(end-start,dtype=numpy.float32)
+			except (RuntimeError, ValueError, KeyError):
+				warnings.warn(
+					f"{chrom} {start} {end} not valid bigwig indexes. "
+					"Using zeros instead.", TangermemeWarning, stacklevel=2)
+				values_ = numpy.zeros(end-start, dtype=numpy.float32)
 				
 		values_ = numpy.nan_to_num(values_)
 		values.append(values_)

--- a/tangermeme/kmers.py
+++ b/tangermeme/kmers.py
@@ -210,7 +210,7 @@ def gapped_kmers(X, scores=None, min_k=4, max_k=8, max_gap=2, max_len=10,
 
 
 	X_idxs = X.argmax(axis=1)
-	if not scores:
+	if scores is None:
 		scores = torch.ones_like(X_idxs)
 
 	if max_pos is None:

--- a/tangermeme/marginalize.py
+++ b/tangermeme/marginalize.py
@@ -11,8 +11,8 @@ from .ersatz import substitute
 from .predict import predict
 
 
-def marginalize(model, X, motif, start=None, alphabet=['A', 'C', 'G', 'T'], 
-	func=predict, additional_func_kwargs={}, **kwargs):
+def marginalize(model, X, motif, start=None, alphabet=['A', 'C', 'G', 'T'],
+	func=predict, additional_func_kwargs=None, **kwargs):
 	"""Apply a function before and after substituting a motif into sequences.
 
 	A marginalization experiment is one where a function is applied before
@@ -72,12 +72,13 @@ def marginalize(model, X, motif, start=None, alphabet=['A', 'C', 'G', 'T'],
 		A function to apply before and after making the substitution. Default 
 		is `predict`.
 
-	additional_func_kwargs: dict, optional
+	additional_func_kwargs: dict or None, optional
 		Additional named arguments to pass into the function when it is called.
-		This is provided as an alternate path to route arguments into the 
+		This is provided as an alternate path to route arguments into the
 		function in case they overlap, name-wise, with those in this function,
 		or if you want to be absolutely sure that the arguments are making
-		their way into the function. Default is {}.
+		their way into the function. The dict is not modified in place. Default
+		is None.
 
 	kwargs: optional
 		Additional named arguments that will get passed into the function when
@@ -99,7 +100,7 @@ def marginalize(model, X, motif, start=None, alphabet=['A', 'C', 'G', 'T'],
 	"""
 
 	_validate_input(X, "X", shape=(-1, len(alphabet), -1), ohe=True, allow_N=True)
-	additional_func_kwargs = additional_func_kwargs or {}
+	additional_func_kwargs = dict(additional_func_kwargs or {})
 
 	X_perturb = substitute(X, motif, start=start, alphabet=alphabet)
 	y_before = func(model, X, **kwargs, **additional_func_kwargs)

--- a/tangermeme/match.py
+++ b/tangermeme/match.py
@@ -101,7 +101,7 @@ def _extract_counts(chrom, start, end, bw_stream):
 	try:
 		value = bw_stream.values(chrom, start, end, bins=1, summary="sum", exact=True)[0]
 		return value if value is not None else 0
-	except:
+	except (RuntimeError, ValueError, KeyError, IndexError):
 		return float('nan')
 
 def _count_generator(coords, bw_stream, buffer = False):
@@ -135,7 +135,7 @@ def _count_generator_buffered(coords, bw_stream):
 			buffer_chrom = chrom
 			try:
 				buffer_signal = bw_stream.values(chrom, 0, None)
-			except:
+			except (RuntimeError, ValueError, KeyError):
 				buffer_signal = None
 		if buffer_signal is not None:
 			yield numpy.nansum(buffer_signal[start:end]).item()

--- a/tangermeme/pisa.py
+++ b/tangermeme/pisa.py
@@ -4,10 +4,13 @@
 # Contact: Jacob Schreiber <jmschreiber91@gmail.com>
 
 
-import torch
 import warnings
 
+import torch
+
 from tqdm import trange
+
+from ._compat import _resolve_device
 from .ersatz import dinucleotide_shuffle
 
 from tangermeme.predict import predict
@@ -18,10 +21,10 @@ from tangermeme.deep_lift_shap import _clear_hooks, _register_hooks
 from tangermeme.deep_lift_shap import hypothetical_attributions
 
 
-def pisa(model, X, args=None, batch_size=32, references=dinucleotide_shuffle, 
-    n_shuffles=20, return_references=False, hypothetical=False, 
-    warning_threshold=0.001, additional_nonlinear_ops=None, 
-    print_convergence_deltas=False, raw_outputs=False, device='cuda', 
+def pisa(model, X, args=None, batch_size=32, references=dinucleotide_shuffle,
+    n_shuffles=20, return_references=False, hypothetical=False,
+    warning_threshold=0.001, additional_nonlinear_ops=None,
+    print_convergence_deltas=False, raw_outputs=False, device=None,
     random_state=None, verbose=False):
     """An implementation of Pairwise Influence by Sequence Attribution (PISA).
     
@@ -119,10 +122,10 @@ def pisa(model, X, args=None, batch_size=32, references=dinucleotide_shuffle,
         the multipliers for each example-reference pair -- or the processed
         attribution values. Default is False.
 
-    device: str or torch.device, optional
+    device: str or torch.device or None, optional
         The device to move the model and batches to when making predictions. If
-        set to 'cuda' without a GPU, this function will crash and must be set
-        to 'cpu'. Default is 'cuda'. 
+        None, use CUDA when available and fall back to CPU otherwise. Default
+        is None.
 
     random_state: int or None or numpy.random.RandomState, optional
         The random seed to use to ensure determinism. If None, the
@@ -177,6 +180,7 @@ def pisa(model, X, args=None, batch_size=32, references=dinucleotide_shuffle,
         for key, value in additional_nonlinear_ops.items():
             _NON_LINEAR_OPS[key] = value
 
+    device = _resolve_device(device)
     model = model.to(device).eval()
     for module in model.modules():
         module._NON_LINEAR_OPS = _NON_LINEAR_OPS

--- a/tangermeme/plot.py
+++ b/tangermeme/plot.py
@@ -199,7 +199,7 @@ def plot_logo(X_attr, ax=None, color=None, annotations=None, start=None,
 
 	try:
 			import matplotlib.pyplot as plt
-	except:
+	except ImportError:
 			raise ImportError("Must install matplotlib before using.")
 
 	###
@@ -488,7 +488,7 @@ def plot_attributions(models, X, func=deep_lift_shap, attribute_kwargs=None,
 
 	try:
 		import matplotlib.pyplot as plt
-	except:
+	except ImportError:
 		raise ImportError("Must install matplotlib before using.")
 	
 	

--- a/tangermeme/predict.py
+++ b/tangermeme/predict.py
@@ -1,14 +1,17 @@
 # predict.py
 # Contact: Jacob Schreiber <jmschreiber91@gmail.com>
 
+import contextlib
+
 import torch
-import itertools
 
 from tqdm import trange
 
+from ._compat import _autocast_supported, _preserve_model_state, _resolve_device
 
-def predict(model, X, args=None, func=None, batch_size=32, dtype=None, 
-	device='cuda', verbose=False):
+
+def predict(model, X, args=None, func=None, batch_size=32, dtype=None,
+	device=None, verbose=False):
 	"""Make batched predictions in a memory-efficient manner.
 
 	This function will take a PyTorch model and make predictions from it using
@@ -55,10 +58,11 @@ def predict(model, X, args=None, func=None, batch_size=32, dtype=None,
 		the *model*. This allows you to use int8 to represent large data sets and
 		only convert batches to the higher precision, saving memory. Default is None.
 
-	device: str or torch.device, optional
+	device: str or torch.device or None, optional
 		The device to move the model and batches to when making predictions. If
-		set to 'cuda' without a GPU, this function will crash and must be set
-		to 'cpu'. Default is 'cuda'. 
+		None, use CUDA when available and fall back to CPU otherwise. The model's
+		original device and training mode are restored after the call. Default
+		is None.
 
 	verbose: bool, optional
 		Whether to display a progress bar during predictions. Default is False.
@@ -74,12 +78,12 @@ def predict(model, X, args=None, func=None, batch_size=32, dtype=None,
 		concatenated across all batches.
 	"""
 
-	model = model.to(device).eval()
-	
+	device = _resolve_device(device)
+
 	if dtype is None:
 		try:
 			dtype = next(model.parameters()).dtype
-		except:
+		except (StopIteration, AttributeError):
 			dtype = torch.float32
 	elif isinstance(dtype, str):
 		dtype = getattr(torch, dtype)
@@ -92,8 +96,10 @@ def predict(model, X, args=None, func=None, batch_size=32, dtype=None,
 
 	###
 
+	use_autocast = _autocast_supported(device, dtype)
+
 	y = []
-	with torch.no_grad():
+	with _preserve_model_state(model, device), torch.no_grad():
 		batch_size = min(batch_size, X.shape[0])
 
 		for start in trange(0, X.shape[0], batch_size, disable=not verbose):
@@ -103,7 +109,12 @@ def predict(model, X, args=None, func=None, batch_size=32, dtype=None,
 			if X_.shape[0] == 0:
 				continue
 
-			with torch.autocast(device_type=device, dtype=dtype):
+			if use_autocast:
+				autocast_ctx = torch.autocast(device_type=device.type, dtype=dtype)
+			else:
+				autocast_ctx = contextlib.nullcontext()
+
+			with autocast_ctx:
 				if args is not None:
 					args_ = [a[start:end].type(dtype).to(device) for a in args]
 					y_ = model(X_, *args_)

--- a/tangermeme/product.py
+++ b/tangermeme/product.py
@@ -1,27 +1,30 @@
 # product.py
 # Contact: Jacob Schreiber <jmschreiber91@gmail.com>
 
-import torch
 import itertools
+
+import torch
 
 from tqdm import tqdm
 
+from ._compat import _preserve_model_state, _resolve_device
 
-def _apply(func, model, X, args, batch_size, device, verbose, 
+
+def _apply(func, model, X, args, batch_size, device, verbose,
 	additional_func_kwargs, **kwargs):
 	"""An internal function for applying a function to a batch of data."""
 
 	X = torch.stack(X)
 	args = [torch.stack(a) for a in args]
 
-	y = func(model, X, args=args, batch_size=batch_size, device=device, 
+	y = func(model, X, args=args, batch_size=batch_size, device=device,
 		verbose=False, **additional_func_kwargs, **kwargs)
 
 	return y
 
 
-def apply_pairwise(func, model, X, args=None, batch_size=32, device='cuda', 
-	additional_func_kwargs={}, verbose=False, **kwargs):
+def apply_pairwise(func, model, X, args=None, batch_size=32, device=None,
+	additional_func_kwargs=None, verbose=False, **kwargs):
 	"""Apply a function on the cartesian product between X and args.
 
 	This function will take the provided function and apply it in a batched
@@ -56,27 +59,28 @@ def apply_pairwise(func, model, X, args=None, batch_size=32, device='cuda',
 		A one-hot encoded set of sequences to make predictions for.
 
 	args: tuple or list
-		A set of additional arguments to pass into the model. Each element in
-		`args` should be one tensor that is input to the model. The elements do
-		not need to be the same size as each other as a product will be
-		constructed over all of them, as well as with `X`. If you only want
-		to use one value for an argument across all function applications,
-		pass it in as a length-1 tensor.
+		A set of additional arguments, each of which is one input to the model.
+		Unlike `apply_product`, every element in `args` must have the same
+		length and is paired index-wise (so `args[0][i]` is grouped with
+		`args[1][i]`); the cross is taken with `X`, not within `args`. The
+		resulting output has shape `(len(X), len(args[0]), ...)`.
 
 	batch_size: int, optional
 		The number of examples to make predictions for at a time. Default is 32.
 
-	device: str or torch.device
+	device: str or torch.device or None, optional
 		The device to move the model and batches to when making predictions. If
-		set to 'cuda' without a GPU, this function will crash and must be set
-		to 'cpu'. Default is 'cuda'. 
+		None, use CUDA when available and fall back to CPU otherwise. The
+		model's original device and training mode are restored after the call.
+		Default is None.
 
-	additional_func_kwargs: dict, optional
+	additional_func_kwargs: dict or None, optional
 		Additional named arguments to pass into the function when it is called.
-		This is provided as an alternate path to route arguments into the 
+		This is provided as an alternate path to route arguments into the
 		function in case they overlap, name-wise, with those in this function,
 		or if you want to be absolutely sure that the arguments are making
-		their way into the function. Default is {}.
+		their way into the function. The dict is not modified in place. Default
+		is None.
 
 	verbose: bool, optional
 		Whether to display a progress bar as examples are processed. Default
@@ -97,28 +101,33 @@ def apply_pairwise(func, model, X, args=None, batch_size=32, device='cuda',
 		concatenated across all batches.
 	"""
 
-	model = model.to(device).eval()
+	device = _resolve_device(device)
+	additional_func_kwargs = dict(additional_func_kwargs or {})
+	# Pass device as a string to downstream `func` to remain back-compatible
+	# with callables that haven't yet been updated to accept torch.device.
+	device_arg = str(device)
 
-	X_, y, args_ = [], [], [[] for _ in args] 
-	for x in tqdm(itertools.product(X, zip(*args)), disable=not verbose):
-		X_.append(x[0])
+	with _preserve_model_state(model, device):
+		X_, y, args_ = [], [], [[] for _ in args]
+		for x in tqdm(itertools.product(X, zip(*args)), disable=not verbose):
+			X_.append(x[0])
 
-		for i, arg in enumerate(x[1]):
-			args_[i].append(arg)
+			for i, arg in enumerate(x[1]):
+				args_[i].append(arg)
 
-		if len(X_) == batch_size:
-			y_ = _apply(func, model, X_, args=args_, batch_size=batch_size, 
-				device=device, verbose=verbose, 
-				additional_func_kwargs=additional_func_kwargs, **kwargs)
-			y.append(y_)
+			if len(X_) == batch_size:
+				y_ = _apply(func, model, X_, args=args_, batch_size=batch_size,
+					device=device_arg, verbose=verbose,
+					additional_func_kwargs=additional_func_kwargs, **kwargs)
+				y.append(y_)
 
-			X_, args_ = [], [[] for _ in args]
-	else:
-		if len(X_) > 0:
-			y_ = _apply(func, model, X_, args=args_, batch_size=batch_size, 
-				device=device, verbose=verbose, 
-				additional_func_kwargs=additional_func_kwargs, **kwargs)
-			y.append(y_)
+				X_, args_ = [], [[] for _ in args]
+		else:
+			if len(X_) > 0:
+				y_ = _apply(func, model, X_, args=args_, batch_size=batch_size,
+					device=device_arg, verbose=verbose,
+					additional_func_kwargs=additional_func_kwargs, **kwargs)
+				y.append(y_)
 
 	Xal = [len(X), len(args[0])]
 
@@ -152,8 +161,8 @@ def apply_pairwise(func, model, X, args=None, batch_size=32, device='cuda',
 	return y
 
 
-def apply_product(func, model, X, args, batch_size=32, device='cuda', 
-	additional_func_kwargs={}, verbose=False, **kwargs):
+def apply_product(func, model, X, args, batch_size=32, device=None,
+	additional_func_kwargs=None, verbose=False, **kwargs):
 	"""Apply a function on the cartesian product between X and each args.
 
 	This function will take the provided function and apply it in a batched
@@ -193,17 +202,19 @@ def apply_product(func, model, X, args, batch_size=32, device='cuda',
 	batch_size: int, optional
 		The number of examples to make predictions for at a time. Default is 32.
 
-	device: str or torch.device
+	device: str or torch.device or None, optional
 		The device to move the model and batches to when making predictions. If
-		set to 'cuda' without a GPU, this function will crash and must be set
-		to 'cpu'. Default is 'cuda'. 
+		None, use CUDA when available and fall back to CPU otherwise. The
+		model's original device and training mode are restored after the call.
+		Default is None.
 
-	additional_func_kwargs: dict, optional
+	additional_func_kwargs: dict or None, optional
 		Additional named arguments to pass into the function when it is called.
-		This is provided as an alternate path to route arguments into the 
+		This is provided as an alternate path to route arguments into the
 		function in case they overlap, name-wise, with those in this function,
 		or if you want to be absolutely sure that the arguments are making
-		their way into the function. Default is {}.
+		their way into the function. The dict is not modified in place. Default
+		is None.
 
 	verbose: bool, optional
 		Whether to display a progress bar as examples are processed. Default
@@ -224,28 +235,33 @@ def apply_product(func, model, X, args, batch_size=32, device='cuda',
 		concatenated across all batches.
 	"""
 
-	model = model.to(device).eval()
+	device = _resolve_device(device)
+	additional_func_kwargs = dict(additional_func_kwargs or {})
+	# Pass device as a string to downstream `func` to remain back-compatible
+	# with callables that haven't yet been updated to accept torch.device.
+	device_arg = str(device)
 
-	X_, y, args_ = [], [], [[] for _ in args] 
-	for x in tqdm(itertools.product(X, *args), disable=not verbose):
-		X_.append(x[0])
+	with _preserve_model_state(model, device):
+		X_, y, args_ = [], [], [[] for _ in args]
+		for x in tqdm(itertools.product(X, *args), disable=not verbose):
+			X_.append(x[0])
 
-		for i, arg in enumerate(x[1:]):
-			args_[i].append(arg)
+			for i, arg in enumerate(x[1:]):
+				args_[i].append(arg)
 
-		if len(X_) == batch_size:
-			y_ = _apply(func, model, X_, args=args_, batch_size=batch_size, 
-				device=device, verbose=verbose, 
-				additional_func_kwargs=additional_func_kwargs, **kwargs)
-			y.append(y_)
+			if len(X_) == batch_size:
+				y_ = _apply(func, model, X_, args=args_, batch_size=batch_size,
+					device=device_arg, verbose=verbose,
+					additional_func_kwargs=additional_func_kwargs, **kwargs)
+				y.append(y_)
 
-			X_, args_ = [], [[] for _ in args]
-	else:
-		if len(X_) > 0:
-			y_ = _apply(func, model, X_, args=args_, batch_size=batch_size, 
-				device=device, verbose=verbose,
-				additional_func_kwargs=additional_func_kwargs, **kwargs)
-			y.append(y_)
+				X_, args_ = [], [[] for _ in args]
+		else:
+			if len(X_) > 0:
+				y_ = _apply(func, model, X_, args=args_, batch_size=batch_size,
+					device=device_arg, verbose=verbose,
+					additional_func_kwargs=additional_func_kwargs, **kwargs)
+				y.append(y_)
 
 	Xal = [len(X)] + [len(a) for a in args]
 

--- a/tangermeme/saturation_mutagenesis.py
+++ b/tangermeme/saturation_mutagenesis.py
@@ -3,7 +3,6 @@
 
 import numba
 import torch
-import itertools
 
 from tqdm import trange
 
@@ -76,9 +75,9 @@ def _edit_distance_one(X, start, end):
 
 
 
-def saturation_mutagenesis(model, X, args=None, start=0, end=-1, 
-	batch_size=32, target=None, hypothetical=False, raw_outputs=False, 
-	dtype=None, device='cuda', verbose=False):
+def saturation_mutagenesis(model, X, args=None, start=0, end=-1,
+	batch_size=32, target=None, hypothetical=False, raw_outputs=False,
+	dtype=None, device=None, verbose=False):
 	"""Performs in-silico saturation mutagenesis on a set of sequences.
 	
 	This function will perform in-silico saturation mutagenesis on a set of 
@@ -146,10 +145,10 @@ def saturation_mutagenesis(model, X, args=None, start=0, end=-1,
 		the *model*. This allows you to use int8 to represent large data sets and
 		only convert batches to the higher precision, saving memory. Default is None.
 	
-	device: str or torch.device, optional
+	device: str or torch.device or None, optional
 		The device to move the model and batches to when making predictions. If
-		set to 'cuda' without a GPU, this function will crash and must be set
-		to 'cpu'. Default is 'cuda'. 
+		None, use CUDA when available and fall back to CPU otherwise. Default
+		is None.
 	
 	verbose: bool, optional
 		Whether to display a progress bar during predictions. Default is False.

--- a/tangermeme/space.py
+++ b/tangermeme/space.py
@@ -14,8 +14,8 @@ from .predict import predict
 from tqdm import tqdm
 
 
-def space(model, X, motifs, spacing, start=None, alphabet=['A', 'C', 'G', 'T'], 
-	func=predict, additional_func_kwargs={}, verbose=False, **kwargs):
+def space(model, X, motifs, spacing, start=None, alphabet=['A', 'C', 'G', 'T'],
+	func=predict, additional_func_kwargs=None, verbose=False, **kwargs):
 	"""Runs a single spacing experiment and returns predictions.
 
 	Given a predictive model, a set of motifs to insert and the spacings
@@ -63,12 +63,13 @@ def space(model, X, motifs, spacing, start=None, alphabet=['A', 'C', 'G', 'T'],
 		A function to apply before and after making the substitutions. Default 
 		is `predict`.
 
-	additional_func_kwargs: dict, optional
+	additional_func_kwargs: dict or None, optional
 		Additional named arguments to pass into the function when it is called.
-		This is provided as an alternate path to route arguments into the 
+		This is provided as an alternate path to route arguments into the
 		function in case they overlap, name-wise, with those in this function,
 		or if you want to be absolutely sure that the arguments are making
-		their way into the function. Default is {}.
+		their way into the function. The dict is not modified in place. Default
+		is None.
 
 	verbose: bool, optional
 		Whether to display a progress bar as spacings are evaluated. Default
@@ -94,9 +95,11 @@ def space(model, X, motifs, spacing, start=None, alphabet=['A', 'C', 'G', 'T'],
 		those.
 	"""
 
-	spacing = _validate_input(_cast_as_tensor(spacing, dtype=torch.int32), 
+	spacing = _validate_input(_cast_as_tensor(spacing, dtype=torch.int32),
 		"spacing", shape=(-1, len(motifs)-1))
 	X = _validate_input(X, "X", shape=(-1, len(alphabet), -1))
+
+	additional_func_kwargs = dict(additional_func_kwargs or {})
 
 	y_before = func(model, X, **kwargs, **additional_func_kwargs)
 	y_afters = []

--- a/tangermeme/utils.py
+++ b/tangermeme/utils.py
@@ -1,6 +1,8 @@
 # utils.py
 # Author: Jacob Schreiber <jmschreiber91@gmail.com>
 
+import warnings
+
 import numpy
 import numba
 import torch
@@ -8,9 +10,15 @@ import torch
 from tqdm import tqdm
 
 
+class TangermemeWarning(UserWarning):
+	"""A category for warnings emitted by tangermeme so callers can filter on
+	`tangermeme.utils.TangermemeWarning` specifically (e.g. via
+	`warnings.simplefilter('error', TangermemeWarning)`)."""
+
+
 def _warn_or_raise(error, message, only_warn):
 	if only_warn:
-		print("Warning: {}".format(message))
+		warnings.warn(message, TangermemeWarning, stacklevel=3)
 	else:
 		raise error(message)
 
@@ -96,8 +104,8 @@ def _validate_input(X, name, shape=None, dtype=None, min_value=None,
 			name, min_value), only_warn)
 	
 	if max_value is not None and X.max() > max_value:
-		raise ValueError("{} cannot have a value above {}".format(name,
-			max_value), only_warn)
+		_warn_or_raise(ValueError, "{} cannot have a value above {}".format(
+			name, max_value), only_warn)
 	
 	if ohe:
 		values = torch.unique(X)
@@ -390,8 +398,8 @@ def one_hot_encode(sequence, alphabet=['A', 'C', 'G', 'T'], dtype=torch.int8,
 
 	Returns
 	-------
-	ohe : numpy.ndarray
-		A binary matrix of shape (alphabet_size, sequence_length) where
+	ohe : torch.Tensor
+		A binary tensor of shape (alphabet_size, sequence_length) where
 		alphabet_size is the number of unique elements in the sequence and
 		sequence_length is the length of the input sequence.
 	"""
@@ -459,7 +467,7 @@ def reverse_complement(seq, complement_map={"A": "T", "C": "G", "G": "C",
 	Returns
 	-------
 	rev_comp: str or torch.Tensor w/ shape (alphabet_size, length)
-		The reverse complemented string or tensor.
+		The reverse complemented string or tensor, matching the type of `seq`.
 	"""
 
 	if isinstance(seq, str):
@@ -506,7 +514,7 @@ def random_one_hot(shape, probs=None, dtype='int8', random_state=None):
 		X is greater than 1, the same probabilities are used for each sequence.
 		The sum of probabilities across the alphabet axis must be equal to 1.
 		If None, use a uniform distribution across the axis specified in shape.
-		Default is [[0.25, 0.25, 0.25, 0.25]].
+		Default is None.
 
 	dtype: str or numpy.dtype, optional
 		The datatype to return the matrix as. Default is 'int8'.

--- a/tangermeme/variant_effect.py
+++ b/tangermeme/variant_effect.py
@@ -2,18 +2,12 @@
 # Contact: Jacob Schreiber <jmschreiber91@gmail.com>
 
 import torch
-import itertools
 
-from .io import extract_loci
-
-from .utils import one_hot_encode
 from .utils import _cast_as_tensor
 
-from .ersatz import delete
 from .ersatz import insert
 
 from .predict import predict
-from .marginalize import marginalize
 
 
 def substitution_effect(model, X, substitutions, args=None, func=predict, 
@@ -71,12 +65,13 @@ def substitution_effect(model, X, substitutions, args=None, func=predict,
 		A function to apply before and after incorporating the substitution. 
 		Default is `predict`.
 
-	additional_func_kwargs: dict, optional
+	additional_func_kwargs: dict or None, optional
 		Additional named arguments to pass into the function when it is called.
-		This is provided as an alternate path to route arguments into the 
+		This is provided as an alternate path to route arguments into the
 		function in case they overlap, name-wise, with those in this function,
 		or if you want to be absolutely sure that the arguments are making
-		their way into the function. Default is {}.
+		their way into the function. The dict is not modified in place. Default
+		is None.
 
 	kwargs: optional
 		Additional named arguments that will get passed into the function when
@@ -94,7 +89,7 @@ def substitution_effect(model, X, substitutions, args=None, func=predict,
 
 	substitutions = _cast_as_tensor(substitutions)
 
-	additional_func_kwargs = additional_func_kwargs or {}
+	additional_func_kwargs = dict(additional_func_kwargs or {})
 
 	X_var = torch.clone(X)
 	X_var[substitutions[:, 0], :, substitutions[:, 1]] = 0
@@ -179,12 +174,13 @@ def deletion_effect(model, X, deletions, left=False, args=None, func=predict,
 		A function to apply before and after incorporating the deletions.
 		Default is `predict`.
 
-	additional_func_kwargs: dict, optional
+	additional_func_kwargs: dict or None, optional
 		Additional named arguments to pass into the function when it is called.
 		This is provided as an alternate path to route arguments into the
 		function in case they overlap, name-wise, with those in this function,
 		or if you want to be absolutely sure that the arguments are making
-		their way into the function. Default is {}.
+		their way into the function. The dict is not modified in place. Default
+		is None.
 
 	kwargs: optional
 		Additional named arguments that will get passed into the function when
@@ -202,7 +198,7 @@ def deletion_effect(model, X, deletions, left=False, args=None, func=predict,
 
 	deletions = _cast_as_tensor(deletions)
 
-	additional_func_kwargs = additional_func_kwargs or {}
+	additional_func_kwargs = dict(additional_func_kwargs or {})
 
 	mask = torch.zeros_like(X[:, 0]).type(torch.int32)
 	mask[deletions[:, 0], deletions[:, 1]] = 1
@@ -294,12 +290,13 @@ def insertion_effect(model, X, insertions, left=False, args=None, func=predict,
 		A function to apply before and after incorporating the insertions.
 		Default is `predict`.
 
-	additional_func_kwargs: dict, optional
+	additional_func_kwargs: dict or None, optional
 		Additional named arguments to pass into the function when it is called.
 		This is provided as an alternate path to route arguments into the
 		function in case they overlap, name-wise, with those in this function,
 		or if you want to be absolutely sure that the arguments are making
-		their way into the function. Default is {}.
+		their way into the function. The dict is not modified in place. Default
+		is None.
 
 	kwargs: optional
 		Additional named arguments that will get passed into the function when
@@ -317,7 +314,7 @@ def insertion_effect(model, X, insertions, left=False, args=None, func=predict,
 
 	insertions = _cast_as_tensor(insertions)
 
-	additional_func_kwargs = additional_func_kwargs or {}
+	additional_func_kwargs = dict(additional_func_kwargs or {})
 	X_var = []
 
 	for i in range(X.shape[0]):

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -293,7 +293,7 @@ def test_predict_residual_conv(X, device):
 
 def test_predict_transformer(X, device):
 	torch.manual_seed(0)
-	model = Transformer().to(device)
+	model = Transformer().to(device).eval()
 	y = predict(model, X, batch_size=8, device=device)
 
 	assert y.shape == (64, 1)
@@ -368,7 +368,7 @@ def test_predict_dilated_conv(X, device):
 
 def test_predict_conv_batch_norm(X, device):
 	torch.manual_seed(0)
-	model = ConvBatchNorm().to(device)
+	model = ConvBatchNorm().to(device).eval()
 	y = predict(model, X, batch_size=8, device=device)
 
 	assert y.shape == (64, 1)


### PR DESCRIPTION
## Summary

A hygiene sweep across all modules. No algorithmic changes, no API surface changes; existing call sites continue to work. All 825 tests pass.

- **`device='cuda'` defaults → `device=None` with auto-detect.** `predict`, `deep_lift_shap`, `pisa`, `design.{screen,greedy_substitution,greedy_marginalize}`, `saturation_mutagenesis`, `product.{apply_pairwise,apply_product}` no longer crash on CPU-only machines when the caller doesn't pass `device`. A shared `tangermeme/_compat.py` provides `_resolve_device`, `_autocast_supported`, and `_preserve_model_state`.
- **`predict` no longer crashes on CPU+float32.** The unconditional `torch.autocast` call is now skipped when it would be a no-op or unsupported on the target device; the `device.type` string is passed to `autocast` so `torch.device` objects compose correctly.
- **`additional_func_kwargs` no longer mutated.** `ablate`, `marginalize`, `space`, `product.{apply_pairwise,apply_product}`, `variant_effect.{substitution,deletion,insertion}_effect`, and `design.screen` now defensively copy the caller's dict; mutable `={}` defaults replaced with `None`.
- **Model-state preservation.** `predict` and `product.{apply_pairwise,apply_product}` restore the user's model `.train()/.eval()` state and original device after the call.
- **Bare `except:` narrowed across `io.py`, `match.py`, `predict.py`, `deep_lift_shap.py`, `plot.py`.** Each is now scoped to the actual exception family the underlying library raises.
- **`print` → `warnings.warn`.** `utils._warn_or_raise`, `io._extract_locus_signal`, and `ersatz._dinucleotide_shuffle` emit warnings under a new `TangermemeWarning(UserWarning)` category for filtering and pytest capture.
- **`kmers.gapped_kmers` no-scores check.** `if not scores:` on a multi-element `torch.Tensor` raised `RuntimeError`; replaced with `if scores is None`.
- **Small `utils._validate_input` bug fix.** The `max_value` branch raised `ValueError` directly (with a stray `only_warn` arg) instead of going through `_warn_or_raise`; it now honors `only_warn=True` like every other branch.
- **Docstring drift.** Corrected stale `Default is {}` text; fixed `one_hot_encode` return type (was `numpy.ndarray`, returns `torch.Tensor`); fixed `random_one_hot.probs` default; filled the truncated final sentence in `reverse_complement`'s Returns; rewrote `apply_pairwise`'s `args` description (had been copy-pasted from `apply_product`).
- **Unused imports.** Dropped `extract_loci`, `itertools`, `one_hot_encode`, `marginalize`, `delete` from `variant_effect.py`; `pandas`, `itertools.compress` from `ersatz.py`; `itertools` from `saturation_mutagenesis.py`.

## Test plan

- [x] `uv run pytest` — 825 passed, 2 skipped (matches baseline before any changes).
- [x] Two `test_predict` tests (`test_predict_transformer`, `test_predict_conv_batch_norm`) were updated to call `.eval()` before comparing `predict(model, X)` to `model(X.to(device))` — they had been pinning the old side effect of `predict` leaving the model in eval mode permanently. Now they exercise the intended comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)