### PR TITLE
DOC add type hints to all public function signatures

### DIFF
--- a/tangermeme/_compat.py
+++ b/tangermeme/_compat.py
@@ -7,12 +7,15 @@ here is implementation detail that the public functions in `predict`,
 `deep_lift_shap`, `pisa`, `design`, `product`, and `saturation_mutagenesis`
 share."""
 
+from __future__ import annotations
+
 import contextlib
+from collections.abc import Iterator
 
 import torch
 
 
-def _resolve_device(device):
+def _resolve_device(device: str | torch.device | None) -> torch.device:
 	"""Resolve a user-supplied device argument to a concrete `torch.device`.
 
 	If `device` is None, return `'cuda'` when CUDA is available and `'cpu'`
@@ -30,7 +33,10 @@ def _resolve_device(device):
 	return torch.device(device)
 
 
-def _autocast_supported(device, dtype):
+def _autocast_supported(
+	device: torch.device | str,
+	dtype: torch.dtype | None,
+) -> bool:
 	"""Return True when `torch.autocast` is meaningful for this combination.
 
 	`torch.autocast(device_type='cpu', dtype=torch.float32)` raises on
@@ -54,7 +60,10 @@ def _autocast_supported(device, dtype):
 
 
 @contextlib.contextmanager
-def _preserve_model_state(model, device):
+def _preserve_model_state(
+	model: torch.nn.Module,
+	device: torch.device,
+) -> Iterator[None]:
 	"""Move a model to `device` for the duration of a `with` block, then
 	restore its original device and training mode on exit.
 

--- a/tangermeme/ablate.py
+++ b/tangermeme/ablate.py
@@ -1,16 +1,33 @@
 # ablate.py
 # Contact: Jacob Schreiber <jmschreiber91@gmail.com>
 
-import torch
+from __future__ import annotations
+
 import inspect
+from collections.abc import Callable, Sequence
+from typing import Any
+
+import numpy
+import torch
 
 from .utils import _validate_input
 from .ersatz import shuffle
 from .predict import predict
 
 
-def ablate(model, X, start, end, n=20, shuffle_fn=shuffle, args=None, 
-	random_state=None, func=predict, additional_func_kwargs=None, **kwargs):
+def ablate(
+	model: torch.nn.Module,
+	X: torch.Tensor,
+	start: int,
+	end: int,
+	n: int = 20,
+	shuffle_fn: Callable[..., Any] = shuffle,
+	args: Sequence[torch.Tensor] | None = None,
+	random_state: int | numpy.random.RandomState | None = None,
+	func: Callable[..., Any] = predict,
+	additional_func_kwargs: dict | None = None,
+	**kwargs: Any,
+) -> tuple[torch.Tensor | list[torch.Tensor], torch.Tensor | list[torch.Tensor]]:
 	"""Make predictions before and after shuffling a region of sequences.
 
 	An ablation experiment is one where a motif (or region of interest) is
@@ -140,7 +157,12 @@ def ablate(model, X, start, end, n=20, shuffle_fn=shuffle, args=None,
 	return y_before, y_after
 
 
-def ablate_annotations(model, X, annotations, **kwargs):
+def ablate_annotations(
+	model: torch.nn.Module,
+	X: torch.Tensor,
+	annotations: torch.Tensor,
+	**kwargs: Any,
+) -> tuple[torch.Tensor | list[torch.Tensor], torch.Tensor | list[torch.Tensor]]:
 	"""Ablate each annotation individually and return the deltas.
 
 	This function takes in a model, a set of sequences, and a set of annotations

--- a/tangermeme/annotate.py
+++ b/tangermeme/annotate.py
@@ -1,6 +1,10 @@
 # annotate.py
 # Author: Jacob Schreiber <jmschreiber91@gmail.com>
 
+from __future__ import annotations
+
+from typing import Any
+
 import numpy
 import torch
 import pandas
@@ -11,7 +15,14 @@ from .utils import _validate_input
 from memelite.tomtom import tomtom
 
 
-def annotate_seqlets(X, seqlets, motifs, n_nearest=1, n_jobs=-1, **kwargs):
+def annotate_seqlets(
+	X: torch.Tensor,
+	seqlets: pandas.DataFrame,
+	motifs: str | dict,
+	n_nearest: int = 1,
+	n_jobs: int = -1,
+	**kwargs: Any,
+) -> tuple[pandas.DataFrame, list[str]]:
 	"""Annotate a set of seqlets according to a motif database using TOMTOM.
 
 	This function takes in a set of seqlets and a motif database and assigns
@@ -78,7 +89,12 @@ def annotate_seqlets(X, seqlets, motifs, n_nearest=1, n_jobs=-1, **kwargs):
 	return torch.from_numpy(idxs).type(torch.int32), torch.from_numpy(p_values)
 
 
-def count_annotations(X, dtype=torch.uint8, shape=None, dim=None):
+def count_annotations(
+	X: torch.Tensor | pandas.DataFrame,
+	dtype: torch.dtype = torch.uint8,
+	shape: tuple[int, ...] | None = None,
+	dim: int | None = None,
+) -> torch.Tensor:
 	"""A method for counting the annotations for each example.
 
 	This function takes in a tensor of (example_idx, annotation_idx) pairs and
@@ -167,7 +183,13 @@ def count_annotations(X, dtype=torch.uint8, shape=None, dim=None):
 	return y
 
 
-def pairwise_annotations(X, dtype=torch.int64, unique=True, symmetric=True, shape=None):
+def pairwise_annotations(
+	X: torch.Tensor | pandas.DataFrame,
+	dtype: torch.dtype = torch.int64,
+	unique: bool = True,
+	symmetric: bool = True,
+	shape: tuple[int, ...] | None = None,
+) -> torch.Tensor:
 	"""Returns the number of times pairs of annotations occur in an example.
 
 	This function takes in a tensor of (example_idx, annotation_idx) pairs and
@@ -256,8 +278,13 @@ def pairwise_annotations(X, dtype=torch.int64, unique=True, symmetric=True, shap
 	return torch.from_numpy(y)
 
 
-def pairwise_annotations_spacing(X, max_distance=100, dtype=torch.uint8, 
-	symmetric=True, shape=None):
+def pairwise_annotations_spacing(
+	X: torch.Tensor | pandas.DataFrame,
+	max_distance: int = 100,
+	dtype: torch.dtype = torch.uint8,
+	symmetric: bool = True,
+	shape: tuple[int, ...] | None = None,
+) -> torch.Tensor:
 	"""Finds the number of times each annotation pair occurs at each distance.
 
 	This function takes in a tensor of (example_idx, annotation_idx, start, end) 

--- a/tangermeme/deep_lift_shap.py
+++ b/tangermeme/deep_lift_shap.py
@@ -1,9 +1,14 @@
 # deep_lift_shap.py
 # Contact: Jacob Schreiber <jmschreiber91@gmail.com>
 
+from __future__ import annotations
+
 import contextlib
 import warnings
+from collections.abc import Callable
+from typing import Any
 
+import numpy
 import torch
 import torch.nn.functional as F
 
@@ -14,7 +19,11 @@ from .ersatz import dinucleotide_shuffle
 from .utils import _validate_input
 
 
-def hypothetical_attributions(multipliers, X, references):
+def hypothetical_attributions(
+	multipliers: tuple[torch.Tensor],
+	X: tuple[torch.Tensor],
+	references: tuple[torch.Tensor],
+) -> tuple[torch.Tensor]:
 	"""A function for aggregating contributions into hypothetical attributions.
 
 	When handling categorical data, like one-hot encodings, the gradients
@@ -200,11 +209,26 @@ def _maxpool(module, grad_input, grad_output):
 	return (new_grad_inp,)
 
 
-def deep_lift_shap(model, X, args=None, target=0,  batch_size=32,
-	references=dinucleotide_shuffle, n_shuffles=20, return_references=False,
-	hypothetical=False, warning_threshold=0.001, additional_nonlinear_ops=None,
-	print_convergence_deltas=False, raw_outputs=False, only_warn=False,
-	dtype=None, device=None, random_state=None, verbose=False):
+def deep_lift_shap(
+	model: torch.nn.Module,
+	X: torch.Tensor,
+	args: tuple | None = None,
+	target: int = 0,
+	batch_size: int = 32,
+	references: Callable[..., Any] | torch.Tensor = dinucleotide_shuffle,
+	n_shuffles: int = 20,
+	return_references: bool = False,
+	hypothetical: bool = False,
+	warning_threshold: float = 0.001,
+	additional_nonlinear_ops: dict | None = None,
+	print_convergence_deltas: bool = False,
+	raw_outputs: bool = False,
+	only_warn: bool = False,
+	dtype: str | torch.dtype | None = None,
+	device: str | torch.device | None = None,
+	random_state: int | numpy.random.RandomState | None = None,
+	verbose: bool = False,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
 	"""Calculate attributions for a set of sequences using DeepLIFT/SHAP.
 
 	This function will calculate the DeepLIFT/SHAP attributions on a set of
@@ -530,9 +554,20 @@ def deep_lift_shap(model, X, args=None, target=0,  batch_size=32,
 	return attributions
 
 
-def _captum_deep_lift_shap(model, X, args=None, target=0, batch_size=32,
-	references=dinucleotide_shuffle, n_shuffles=20,  return_references=False,
-	hypothetical=False, device=None, random_state=None, verbose=False):
+def _captum_deep_lift_shap(
+	model: torch.nn.Module,
+	X: torch.Tensor,
+	args: tuple | None = None,
+	target: int = 0,
+	batch_size: int = 32,
+	references: Callable[..., Any] | torch.Tensor = dinucleotide_shuffle,
+	n_shuffles: int = 20,
+	return_references: bool = False,
+	hypothetical: bool = False,
+	device: str | torch.device | None = None,
+	random_state: int | numpy.random.RandomState | None = None,
+	verbose: bool = False,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
 	"""Calculate attributions using DeepLift/Shap and a given model. 
 
 	This function will calculate DeepLift/Shap attributions on a set of

--- a/tangermeme/design.py
+++ b/tangermeme/design.py
@@ -1,8 +1,13 @@
 # design.py
 # Contact: Jacob Schreiber <jmschreiber91@gmail.com>
 
+from __future__ import annotations
+
 import time
 import heapq
+from collections.abc import Callable
+from typing import Any
+
 import numba
 import numpy
 import torch
@@ -30,10 +35,24 @@ def _fast_tile_substitute(X, motif, idxs):
 				X[i, k, j+idx] = motif[k, j]
 
 
-def screen(model, shape, y=None, loss=torch.nn.MSELoss(reduction='none'), tol=1e-3,
-	max_iter=-1, args=None, n_best=1, alphabet=['A', 'C', 'G', 'T'],
-	batch_size=32, func=random_one_hot, additional_func_kwargs=None, dtype=None,
-	device=None, random_state=None, verbose=False):
+def screen(
+	model: torch.nn.Module,
+	shape: tuple[int, ...],
+	y: torch.Tensor | list[torch.Tensor] | None = None,
+	loss: Callable[..., Any] = torch.nn.MSELoss(reduction='none'),
+	tol: float = 1e-3,
+	max_iter: int = -1,
+	args: tuple | None = None,
+	n_best: int = 1,
+	alphabet: list[str] = ['A', 'C', 'G', 'T'],
+	batch_size: int = 32,
+	func: Callable[..., Any] = random_one_hot,
+	additional_func_kwargs: dict | None = None,
+	dtype: str | torch.dtype | None = None,
+	device: str | torch.device | None = None,
+	random_state: int | numpy.random.RandomState | None = None,
+	verbose: bool = False,
+) -> torch.Tensor:
 	"""Screen randomly generated sequences and choose the best one.
 
 	Potentially, the conceptually simplest method for design is to randomly
@@ -177,10 +196,23 @@ def screen(model, shape, y=None, loss=torch.nn.MSELoss(reduction='none'), tol=1e
 	return X
 
 
-def greedy_substitution(model, X, y=None, motifs=None,
-	loss=torch.nn.MSELoss(reduction='none'), reverse_complement=True,
-	input_mask=None, output_mask=None, tol=1e-3, max_iter=-1, args=None,
-	alphabet=['A', 'C', 'G', 'T'], batch_size=32, device=None, verbose=False):
+def greedy_substitution(
+	model: torch.nn.Module,
+	X: torch.Tensor,
+	y: torch.Tensor | list[torch.Tensor] | None = None,
+	motifs: list[str] | None = None,
+	loss: Callable[..., Any] = torch.nn.MSELoss(reduction='none'),
+	reverse_complement: bool = True,
+	input_mask: torch.Tensor | None = None,
+	output_mask: torch.Tensor | None = None,
+	tol: float = 1e-3,
+	max_iter: int = -1,
+	args: tuple | None = None,
+	alphabet: list[str] = ['A', 'C', 'G', 'T'],
+	batch_size: int = 32,
+	device: str | torch.device | None = None,
+	verbose: bool = False,
+) -> torch.Tensor:
 	"""Greedily add motifs to achieve a desired goal. 
 
 	This design function will greedily add motifs to achieve a desired output
@@ -380,10 +412,23 @@ def greedy_substitution(model, X, y=None, motifs=None,
 	return X
 
 
-def greedy_marginalize(model, X, y, motifs, loss=torch.nn.MSELoss(
-	reduction='none'), max_spacing=12, reverse_complement=True,
-	output_mask=None, tol=1e-3, max_iter=-1, args=None,
-	alphabet=['A', 'C', 'G', 'T'], batch_size=32, device=None, verbose=False):
+def greedy_marginalize(
+	model: torch.nn.Module,
+	X: torch.Tensor,
+	y: torch.Tensor | list[torch.Tensor],
+	motifs: list[str],
+	loss: Callable[..., Any] = torch.nn.MSELoss(reduction='none'),
+	max_spacing: int = 12,
+	reverse_complement: bool = True,
+	output_mask: torch.Tensor | None = None,
+	tol: float = 1e-3,
+	max_iter: int = -1,
+	args: tuple | None = None,
+	alphabet: list[str] = ['A', 'C', 'G', 'T'],
+	batch_size: int = 32,
+	device: str | torch.device | None = None,
+	verbose: bool = False,
+) -> torch.Tensor:
 	"""Greedily builds a construct and evaluates it using marginalizations.
 
 	This approach attempts to find a set of motifs and their orientations and

--- a/tangermeme/ersatz.py
+++ b/tangermeme/ersatz.py
@@ -1,6 +1,8 @@
 # ersatz.py
 # Author: Jacob Schreiber <jmschreiber91@gmail.com>
 
+from __future__ import annotations
+
 import warnings
 
 import numba
@@ -15,7 +17,12 @@ from .utils import random_one_hot
 from .utils import TangermemeWarning
 
 
-def insert(X, motif, start=None, alphabet=list("ACGT")):
+def insert(
+	X: torch.Tensor | str,
+	motif: torch.Tensor | str,
+	start: int | None = None,
+	alphabet: list[str] = list("ACGT"),
+) -> torch.Tensor:
 	"""Insert a motif into a set of sequences at a defined position.
 
 	This function will take in a tensor of one-hot encoded sequences or a string
@@ -87,7 +94,13 @@ def insert(X, motif, start=None, alphabet=list("ACGT")):
 	return torch.cat([X[:, :, :start], motif, X[:, :, start:]], dim=-1)
 
 
-def substitute(X, motif, start=None, alphabet=list("ACGT"), ignore=["N"]):
+def substitute(
+	X: torch.Tensor | str,
+	motif: torch.Tensor | str,
+	start: int | None = None,
+	alphabet: list[str] = list("ACGT"),
+	ignore: list[str] = ["N"],
+) -> torch.Tensor:
 	"""Substitute a motif into a set of sequences at a defined position.
 
 	This function will take in a tensor of one-hot encoded sequences or a string
@@ -182,8 +195,14 @@ def substitute(X, motif, start=None, alphabet=list("ACGT"), ignore=["N"]):
 	return X
 
 
-def multisubstitute(X, motifs, spacing, start=None, alphabet=list("ACGT"),
-	ignore=["N"]):
+def multisubstitute(
+	X: torch.Tensor,
+	motifs: list[torch.Tensor | str],
+	spacing: list[int],
+	start: int | None = None,
+	alphabet: list[str] = list("ACGT"),
+	ignore: list[str] = ["N"],
+) -> torch.Tensor:
 	"""Substitute a set of motifs into sequences with provided spacings.
 
 	This function will take in a list of tensors of one-hot encoded sequences
@@ -278,7 +297,7 @@ def multisubstitute(X, motifs, spacing, start=None, alphabet=list("ACGT"),
 	return X
 
 
-def delete(X, start, end):
+def delete(X: torch.Tensor, start: int, end: int) -> torch.Tensor:
 	"""Delete a portion of a sequence.
 
 	This function will take in a tensor of one-hot encoded sequences and a pair
@@ -321,8 +340,14 @@ def delete(X, start, end):
 	return torch.cat([X[:, :, :start], X[:, :, end:]], dim=-1)
 
 
-def randomize(X, start, end, probs=[[0.25, 0.25, 0.25, 0.25]], n=1,
-	random_state=None):
+def randomize(
+	X: torch.Tensor,
+	start: int,
+	end: int,
+	probs: list | tuple | numpy.ndarray | torch.Tensor = [[0.25, 0.25, 0.25, 0.25]],
+	n: int = 1,
+	random_state: int | numpy.random.RandomState | None = None,
+) -> torch.Tensor:
 	"""Replace a region of the provided loci with randomly drawn sequence.
 
 	This function will take in a batch of sequences and replace region specified
@@ -397,7 +422,13 @@ def randomize(X, start, end, probs=[[0.25, 0.25, 0.25, 0.25]], n=1,
 	return torch.stack(X_rands).permute(1, 0, 2, 3)
 
 
-def shuffle(X, start=0, end=-1, n=1, random_state=None):
+def shuffle(
+	X: torch.Tensor,
+	start: int = 0,
+	end: int = -1,
+	n: int = 1,
+	random_state: int | numpy.random.RandomState | None = None,
+) -> torch.Tensor:
 	"""Replace a region of the provided loci with a shuffled version.
 
 	This function will take in a batch of sequences and shuffle the specified
@@ -574,8 +605,14 @@ def _dinucleotide_shuffle(X, n_shuffles=1, random_state=None, verbose=False):
 	return shuffled_sequences
 
 
-def dinucleotide_shuffle(X, start=0, end=-1, n=20, random_state=None, 
-	verbose=False):
+def dinucleotide_shuffle(
+	X: torch.Tensor,
+	start: int = 0,
+	end: int = -1,
+	n: int = 20,
+	random_state: int | numpy.random.RandomState | None = None,
+	verbose: bool = False,
+) -> torch.Tensor:
 	"""Given a one-hot encoded sequence, dinucleotide shuffle it.
 
 	This function takes in a one-hot encoded sequence (not a string) and

--- a/tangermeme/io.py
+++ b/tangermeme/io.py
@@ -2,6 +2,8 @@
 # Author: Jacob Schreiber <jmschreiber91@gmail.com>
 # Code adapted from Alex Tseng, Avanti Shrikumar, and Ziga Avsec
 
+from __future__ import annotations
+
 import warnings
 
 import numpy
@@ -233,11 +235,26 @@ def _extract_locus_signal(signals, chrom, start, end):
 	return values
 
 
-def extract_loci(loci, sequences, signals=None, in_signals=None, chroms=None, 
-	in_window=2114, out_window=1000, max_jitter=0, min_counts=None,
-	max_counts=None, target_idx=0, n_loci=None, summits=False,
-	alphabet=['A', 'C', 'G', 'T'], ignore=['N'], exclusion_lists=None, 
-	return_mask=False, verbose=False):
+def extract_loci(
+	loci: str | list[str] | pandas.DataFrame | list[pandas.DataFrame],
+	sequences: str | pyfaidx.Fasta | dict,
+	signals: list | None = None,
+	in_signals: list | None = None,
+	chroms: list[str] | None = None,
+	in_window: int = 2114,
+	out_window: int = 1000,
+	max_jitter: int = 0,
+	min_counts: float | None = None,
+	max_counts: float | None = None,
+	target_idx: int = 0,
+	n_loci: int | None = None,
+	summits: bool = False,
+	alphabet: list[str] = ['A', 'C', 'G', 'T'],
+	ignore: list[str] = ['N'],
+	exclusion_lists: list | None = None,
+	return_mask: bool = False,
+	verbose: bool = False,
+) -> tuple:
 	"""Extract sequence and signal information for each provided locus.
 
 	This function will take in a set of loci, sequences, and optionally signals,
@@ -505,8 +522,13 @@ def extract_loci(loci, sequences, signals=None, in_signals=None, chroms=None,
 	return y_return[0] if len(y_return) == 1 else y_return
 
 
-def one_hot_to_fasta(X, filename, mode='w', headers=None,
-	alphabet=['A', 'C', 'G', 'T']):
+def one_hot_to_fasta(
+	X: torch.Tensor | numpy.ndarray,
+	filename: str,
+	mode: str = 'w',
+	headers: list[str] | None = None,
+	alphabet: list[str] = ['A', 'C', 'G', 'T'],
+) -> None:
 	"""Write out one-hot encoded sequences to a FASTA file.
 
 	This function will take a set of one-hot encoded sequences and convert them
@@ -550,7 +572,7 @@ def one_hot_to_fasta(X, filename, mode='w', headers=None,
 			outfile.write("\n")
 
 
-def read_meme(filename, n_motifs=None):
+def read_meme(filename: str, n_motifs: int | None = None) -> dict[str, torch.Tensor]:
 	"""Read a MEME file and return a dictionary of PWMs.
 
 	This method takes in the filename of a MEME-formatted file to read in
@@ -582,7 +604,7 @@ def read_meme(filename, n_motifs=None):
 	return motifs
 
 
-def read_vcf(filename):
+def read_vcf(filename: str) -> pandas.DataFrame:
 	"""Read a VCF file into a pandas DataFrame
 
 	This function takes in the name of a file that is VCF formatted and returns

--- a/tangermeme/kmers.py
+++ b/tangermeme/kmers.py
@@ -1,6 +1,8 @@
 # kmers.py
 # Contact: Jacob Schreiber <jmschreiber91@gmail.com>
 
+from __future__ import annotations
+
 import numpy
 import torch
 import scipy
@@ -13,7 +15,11 @@ key_type = numba.types.int64
 value_type = numba.types.float64
 
 
-def kmers(X, k, scores=None):
+def kmers(
+	X: torch.Tensor,
+	k: int,
+	scores: torch.Tensor | None = None,
+) -> scipy.sparse.csr_matrix:
 	"""Extract all k-mers found in a sequence, optionally weighted by a score.
 
 	This function will count the number of k-mers found in each sequence and
@@ -157,8 +163,16 @@ def _fast_extract_gkmers(X, min_k, max_k, max_gap, max_len, max_entries):
 
 
 
-def gapped_kmers(X, scores=None, min_k=4, max_k=8, max_gap=2, max_len=10, 
-	max_gkmers=10, max_pos=None):
+def gapped_kmers(
+	X: torch.Tensor,
+	scores: torch.Tensor | None = None,
+	min_k: int = 4,
+	max_k: int = 8,
+	max_gap: int = 2,
+	max_len: int = 10,
+	max_gkmers: int = 10,
+	max_pos: int | None = None,
+) -> scipy.sparse.csr_matrix:
 	"""Extract gapped k-mers from sequences and optionally scores.
 
 	This function will extract the gapped k-mers from a set of sequences that

--- a/tangermeme/marginalize.py
+++ b/tangermeme/marginalize.py
@@ -1,6 +1,11 @@
 # marginalize.py
 # Contact: Jacob Schreiber <jmschreiber91@gmail.com>
 
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
 import numpy
 import torch
 
@@ -11,8 +16,16 @@ from .ersatz import substitute
 from .predict import predict
 
 
-def marginalize(model, X, motif, start=None, alphabet=['A', 'C', 'G', 'T'],
-	func=predict, additional_func_kwargs=None, **kwargs):
+def marginalize(
+	model: torch.nn.Module,
+	X: torch.Tensor,
+	motif: torch.Tensor | str,
+	start: int | None = None,
+	alphabet: list[str] = ['A', 'C', 'G', 'T'],
+	func: Callable[..., Any] = predict,
+	additional_func_kwargs: dict | None = None,
+	**kwargs: Any,
+) -> tuple[torch.Tensor | list[torch.Tensor], torch.Tensor | list[torch.Tensor]]:
 	"""Apply a function before and after substituting a motif into sequences.
 
 	A marginalization experiment is one where a function is applied before
@@ -109,7 +122,13 @@ def marginalize(model, X, motif, start=None, alphabet=['A', 'C', 'G', 'T'],
 	return y_before, y_after
 
 
-def marginalize_annotations(model, X, X0, annotations, **kwargs):
+def marginalize_annotations(
+	model: torch.nn.Module,
+	X: torch.Tensor,
+	X0: torch.Tensor,
+	annotations: torch.Tensor,
+	**kwargs: Any,
+) -> tuple[torch.Tensor | list[torch.Tensor], torch.Tensor | list[torch.Tensor]]:
 	"""Perform marginalizations on each annotation individually.
 
 	This function takes in a model, a set of sequences, a set of background

--- a/tangermeme/match.py
+++ b/tangermeme/match.py
@@ -7,6 +7,8 @@ Provides functions for the calculation of GC-content genome-wide and the
 sampling of GC-matched negatives.
 """
 
+from __future__ import annotations
+
 import numpy
 import pandas
 import pyfaidx
@@ -367,9 +369,20 @@ def _extract_and_filter_chrom(fasta, chrom, in_window, out_window,
 	return gc_perc
 
 
-def extract_matching_loci(loci, fasta, in_window=2114, out_window=1000, 
-	max_n_perc=0.1, gc_bin_width=0.02, bigwig=None, signal_beta=0.5, 
-	chroms=None, random_state=None, n_jobs=1, verbose=False):
+def extract_matching_loci(
+	loci: str | pandas.DataFrame,
+	fasta: str,
+	in_window: int = 2114,
+	out_window: int = 1000,
+	max_n_perc: float = 0.1,
+	gc_bin_width: float = 0.02,
+	bigwig: str | None = None,
+	signal_beta: float = 0.5,
+	chroms: list[str] | None = None,
+	random_state: int | numpy.random.RandomState | None = None,
+	n_jobs: int = 1,
+	verbose: bool = False,
+) -> pandas.DataFrame:
 	"""Extract matching loci given a fasta file.
 
 	This function takes in a set of loci (a bed file or a pandas dataframe in

--- a/tangermeme/pisa.py
+++ b/tangermeme/pisa.py
@@ -3,9 +3,13 @@
 # https://www.biorxiv.org/content/10.1101/2025.04.07.647613v2
 # Contact: Jacob Schreiber <jmschreiber91@gmail.com>
 
+from __future__ import annotations
 
 import warnings
+from collections.abc import Callable
+from typing import Any
 
+import numpy
 import torch
 
 from tqdm import trange
@@ -21,11 +25,23 @@ from tangermeme.deep_lift_shap import _clear_hooks, _register_hooks
 from tangermeme.deep_lift_shap import hypothetical_attributions
 
 
-def pisa(model, X, args=None, batch_size=32, references=dinucleotide_shuffle,
-    n_shuffles=20, return_references=False, hypothetical=False,
-    warning_threshold=0.001, additional_nonlinear_ops=None,
-    print_convergence_deltas=False, raw_outputs=False, device=None,
-    random_state=None, verbose=False):
+def pisa(
+    model: torch.nn.Module,
+    X: torch.Tensor,
+    args: tuple | None = None,
+    batch_size: int = 32,
+    references: Callable[..., Any] | torch.Tensor = dinucleotide_shuffle,
+    n_shuffles: int = 20,
+    return_references: bool = False,
+    hypothetical: bool = False,
+    warning_threshold: float = 0.001,
+    additional_nonlinear_ops: dict | None = None,
+    print_convergence_deltas: bool = False,
+    raw_outputs: bool = False,
+    device: str | torch.device | None = None,
+    random_state: int | numpy.random.RandomState | None = None,
+    verbose: bool = False,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     """An implementation of Pairwise Influence by Sequence Attribution (PISA).
     
     PISA is a method for deciphering how each input in an example influences

--- a/tangermeme/plot.py
+++ b/tangermeme/plot.py
@@ -1,6 +1,11 @@
 # plot.py
 # Contact: Jacob Schreiber <jmschreiber91@gmail.com>
 
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
 import torch
 import numpy
 import pandas
@@ -23,17 +28,22 @@ import numpy as np
 
 #plot_logo helper functions for placing annotations
 
-def check_box_overlap(box1, box2):
+def check_box_overlap(box1: Bbox, box2: Bbox) -> bool:
 	"""Check if annotation label text boxes overlap."""
 	return not(box1.x0>=box2.x1 or box2.x0>=box1.x1 or box1.y0>=box2.y1 or box2.y0>=box1.y1)
 
 
-def check_box_overlap_bar(box1, box2):
+def check_box_overlap_bar(box1: Bbox, box2: Bbox) -> bool:
 	"""Check if annotation bars overlap."""
 	return not(box1.x0>=box2.x1 or box2.x0>=box1.x1 or box1.y0!=box2.y0)
 
 
-def place_new_box(box, box_list, n_tracks=4, show_extra=True):
+def place_new_box(
+	box: Bbox,
+	box_list: list[Bbox],
+	n_tracks: int = 4,
+	show_extra: bool = True,
+) -> tuple[Bbox, int]:
     """Place annotation text so that it does not overlap with existing text."""
     box_height = box.y1 - box.y0
     box.y0 -= box_height
@@ -64,7 +74,13 @@ def place_new_box(box, box_list, n_tracks=4, show_extra=True):
     return box, steps_down_taken
 
 
-def place_new_bar(box, box_list, y_step=None, n_tracks=4, show_extra=True):
+def place_new_bar(
+	box: Bbox,
+	box_list: list[Bbox],
+	y_step: float | None = None,
+	n_tracks: int = 4,
+	show_extra: bool = True,
+) -> tuple[Bbox, int]:
     """
     Find a position for a new annotation bar such that it does not overlap with previously plotted bars.
     """
@@ -93,7 +109,14 @@ def _base_path(char):
     return verts, tp.codes.copy()
 
 
-def get_glyph_path(char, x, y, width, height, flip=False):
+def get_glyph_path(
+	char: str,
+	x: float,
+	y: float,
+	width: float,
+	height: float,
+	flip: bool = False,
+) -> Path:
     verts, codes = _base_path(char)
     v = verts.copy()
     v[:, 0] = v[:, 0] * width + x
@@ -104,10 +127,23 @@ def get_glyph_path(char, x, y, width, height, flip=False):
     return Path(v, codes)
 
 
-def plot_logo(X_attr, ax=None, color=None, annotations=None, start=None, 
-	end=None, ylim=None, spacing=4, n_tracks=4, alphabet=["A", "C", "G", "T"],
-	min_height_pct=0.02, score_key='score', show_extra=True, show_score=True, 
-	annot_cmap="Set1"):
+def plot_logo(
+	X_attr: torch.Tensor | numpy.ndarray,
+	ax: matplotlib.axes.Axes | None = None,
+	color: str | dict | None = None,
+	annotations: pandas.DataFrame | None = None,
+	start: int | None = None,
+	end: int | None = None,
+	ylim: tuple[float, float] | None = None,
+	spacing: float = 4,
+	n_tracks: int = 4,
+	alphabet: list[str] = ["A", "C", "G", "T"],
+	min_height_pct: float = 0.02,
+	score_key: str = 'score',
+	show_extra: bool = True,
+	show_score: bool = True,
+	annot_cmap: str = "Set1",
+) -> matplotlib.axes.Axes:
 	"""Make a logo plot and optionally annotate it.
 
 	This function will take in a matrix of weights for each character in a
@@ -393,7 +429,11 @@ def plot_logo(X_attr, ax=None, color=None, annotations=None, start=None,
 	return ax
 
 
-def plot_categorical_scatter(X, colors=None, **kwargs):
+def plot_categorical_scatter(
+	X: pandas.DataFrame,
+	colors: dict | None = None,
+	**kwargs: Any,
+) -> matplotlib.axes.Axes:
 	"""A scatterplot of category weights across a seq, useful for attributions.
 	
 	Frequently, when you calculate attributions you are considering a sequence
@@ -430,8 +470,14 @@ def plot_categorical_scatter(X, colors=None, **kwargs):
 		plt.scatter(pos[idxs], X.sum(axis=0)[idxs], c=[c[i]], **kwargs)
 
 
-def plot_attributions(models, X, func=deep_lift_shap, attribute_kwargs=None, 
-	plot_kwargs=None, layout=None):
+def plot_attributions(
+	models: torch.nn.Module | list[torch.nn.Module],
+	X: torch.Tensor,
+	func: Callable[..., Any] = deep_lift_shap,
+	attribute_kwargs: dict | None = None,
+	plot_kwargs: dict | None = None,
+	layout: tuple[int, int] | None = None,
+) -> tuple[matplotlib.figure.Figure, torch.Tensor]:
 	"""A convenience function for calculating and then plotting attributions.
 	
 	This function will use one or more models and calculate attributions on one or
@@ -529,7 +575,12 @@ def plot_attributions(models, X, func=deep_lift_shap, attribute_kwargs=None,
 	
 	return axs, X_attrs
 
-def plot_pwm(pwm, name=None, alphabet=['A', 'C', 'G', 'T'], eps=1e-7):
+def plot_pwm(
+	pwm: torch.Tensor | numpy.ndarray,
+	name: str | None = None,
+	alphabet: list[str] = ['A', 'C', 'G', 'T'],
+	eps: float = 1e-7,
+) -> None:
 	"""Plots an information-content weighted PWM and its reverse complement.
 
 	This function takes in a PWM, where the sum across all values in the

--- a/tangermeme/predict.py
+++ b/tangermeme/predict.py
@@ -1,7 +1,11 @@
 # predict.py
 # Contact: Jacob Schreiber <jmschreiber91@gmail.com>
 
+from __future__ import annotations
+
 import contextlib
+from collections.abc import Callable, Sequence
+from typing import Any
 
 import torch
 
@@ -10,8 +14,16 @@ from tqdm import trange
 from ._compat import _autocast_supported, _preserve_model_state, _resolve_device
 
 
-def predict(model, X, args=None, func=None, batch_size=32, dtype=None,
-	device=None, verbose=False):
+def predict(
+	model: torch.nn.Module,
+	X: torch.Tensor,
+	args: Sequence[torch.Tensor] | None = None,
+	func: Callable[..., Any] | None = None,
+	batch_size: int = 32,
+	dtype: str | torch.dtype | None = None,
+	device: str | torch.device | None = None,
+	verbose: bool = False,
+) -> torch.Tensor | list[torch.Tensor]:
 	"""Make batched predictions in a memory-efficient manner.
 
 	This function will take a PyTorch model and make predictions from it using

--- a/tangermeme/product.py
+++ b/tangermeme/product.py
@@ -1,7 +1,11 @@
 # product.py
 # Contact: Jacob Schreiber <jmschreiber91@gmail.com>
 
+from __future__ import annotations
+
 import itertools
+from collections.abc import Callable, Sequence
+from typing import Any
 
 import torch
 
@@ -23,8 +27,17 @@ def _apply(func, model, X, args, batch_size, device, verbose,
 	return y
 
 
-def apply_pairwise(func, model, X, args=None, batch_size=32, device=None,
-	additional_func_kwargs=None, verbose=False, **kwargs):
+def apply_pairwise(
+	func: Callable[..., Any],
+	model: torch.nn.Module,
+	X: torch.Tensor,
+	args: Sequence[torch.Tensor] | None = None,
+	batch_size: int = 32,
+	device: str | torch.device | None = None,
+	additional_func_kwargs: dict | None = None,
+	verbose: bool = False,
+	**kwargs: Any,
+) -> torch.Tensor | list[torch.Tensor]:
 	"""Apply a function on the cartesian product between X and args.
 
 	This function will take the provided function and apply it in a batched
@@ -161,8 +174,17 @@ def apply_pairwise(func, model, X, args=None, batch_size=32, device=None,
 	return y
 
 
-def apply_product(func, model, X, args, batch_size=32, device=None,
-	additional_func_kwargs=None, verbose=False, **kwargs):
+def apply_product(
+	func: Callable[..., Any],
+	model: torch.nn.Module,
+	X: torch.Tensor,
+	args: Sequence[torch.Tensor],
+	batch_size: int = 32,
+	device: str | torch.device | None = None,
+	additional_func_kwargs: dict | None = None,
+	verbose: bool = False,
+	**kwargs: Any,
+) -> torch.Tensor | list[torch.Tensor]:
 	"""Apply a function on the cartesian product between X and each args.
 
 	This function will take the provided function and apply it in a batched

--- a/tangermeme/saturation_mutagenesis.py
+++ b/tangermeme/saturation_mutagenesis.py
@@ -1,6 +1,8 @@
 # saturation_mutagenesis.py
 # Contact: Jacob Schreiber <jmschreiber91@gmail.com>
 
+from __future__ import annotations
+
 import numba
 import torch
 
@@ -75,9 +77,20 @@ def _edit_distance_one(X, start, end):
 
 
 
-def saturation_mutagenesis(model, X, args=None, start=0, end=-1,
-	batch_size=32, target=None, hypothetical=False, raw_outputs=False,
-	dtype=None, device=None, verbose=False):
+def saturation_mutagenesis(
+	model: torch.nn.Module,
+	X: torch.Tensor,
+	args: tuple | None = None,
+	start: int = 0,
+	end: int = -1,
+	batch_size: int = 32,
+	target: int | slice | None = None,
+	hypothetical: bool = False,
+	raw_outputs: bool = False,
+	dtype: str | torch.dtype | None = None,
+	device: str | torch.device | None = None,
+	verbose: bool = False,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
 	"""Performs in-silico saturation mutagenesis on a set of sequences.
 	
 	This function will perform in-silico saturation mutagenesis on a set of 

--- a/tangermeme/seqlet.py
+++ b/tangermeme/seqlet.py
@@ -1,6 +1,8 @@
 # seqlet.py
 # Authors: Jacob Schreiber <jmschreiber91@gmail.com>
-# adapted from code written by Avanti Shrikumar 
+# adapted from code written by Avanti Shrikumar
+
+from __future__ import annotations
 
 import math
 import numpy
@@ -206,9 +208,15 @@ def _isotonic_thresholds(values, null_values, increasing, target_fdr,
 	return values[precisions >= (1 - target_fdr)][0].item()
 
 
-def tfmodisco_seqlets(X_attr, window_size=21, flank=10, target_fdr=0.2, 
-	min_passing_frac=0.03, max_passing_frac=0.2, 
-	weak_threshold_for_counting_sign=0.8):
+def tfmodisco_seqlets(
+	X_attr: torch.Tensor,
+	window_size: int = 21,
+	flank: int = 10,
+	target_fdr: float = 0.2,
+	min_passing_frac: float = 0.03,
+	max_passing_frac: float = 0.2,
+	weak_threshold_for_counting_sign: float = 0.8,
+) -> pandas.DataFrame:
 	"""Extract seqlets using the procedure from TF-MoDISco.
 
 	Seqlets are contiguous spans of high attribution characters. This method
@@ -452,8 +460,14 @@ def _recursive_seqlets(X, threshold=0.01, min_seqlet_len=4, max_seqlet_len=25,
 	return seqlets
 
 
-def recursive_seqlets(X, threshold=0.01, min_seqlet_len=4, max_seqlet_len=25, 
-	additional_flanks=0, n_bins=1000):
+def recursive_seqlets(
+	X: torch.Tensor,
+	threshold: float = 0.01,
+	min_seqlet_len: int = 4,
+	max_seqlet_len: int = 25,
+	additional_flanks: int = 0,
+	n_bins: int = 1000,
+) -> pandas.DataFrame:
 	"""A seqlet caller implementing the recursive seqlet algorithm.
 
 	NOTE: Currently only *positive* seqlets will be identified. The easiest way

--- a/tangermeme/space.py
+++ b/tangermeme/space.py
@@ -1,6 +1,11 @@
 # space.py
 # Contact: Jacob Schreiber <jmschreiber91@gmail.com>
 
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
 import numpy
 import torch
 
@@ -14,8 +19,18 @@ from .predict import predict
 from tqdm import tqdm
 
 
-def space(model, X, motifs, spacing, start=None, alphabet=['A', 'C', 'G', 'T'],
-	func=predict, additional_func_kwargs=None, verbose=False, **kwargs):
+def space(
+	model: torch.nn.Module,
+	X: torch.Tensor,
+	motifs: list[torch.Tensor | str],
+	spacing: torch.Tensor | numpy.ndarray | list,
+	start: int | None = None,
+	alphabet: list[str] = ['A', 'C', 'G', 'T'],
+	func: Callable[..., Any] = predict,
+	additional_func_kwargs: dict | None = None,
+	verbose: bool = False,
+	**kwargs: Any,
+) -> tuple[torch.Tensor | list[torch.Tensor], torch.Tensor | list[torch.Tensor]]:
 	"""Runs a single spacing experiment and returns predictions.
 
 	Given a predictive model, a set of motifs to insert and the spacings

--- a/tangermeme/utils.py
+++ b/tangermeme/utils.py
@@ -1,10 +1,14 @@
 # utils.py
 # Author: Jacob Schreiber <jmschreiber91@gmail.com>
 
+from __future__ import annotations
+
 import warnings
+from typing import Any
 
 import numpy
 import numba
+import pandas
 import torch
 
 from tqdm import tqdm
@@ -16,14 +20,28 @@ class TangermemeWarning(UserWarning):
 	`warnings.simplefilter('error', TangermemeWarning)`)."""
 
 
-def _warn_or_raise(error, message, only_warn):
+def _warn_or_raise(
+	error: type[Exception],
+	message: str,
+	only_warn: bool,
+) -> None:
 	if only_warn:
 		warnings.warn(message, TangermemeWarning, stacklevel=3)
 	else:
 		raise error(message)
 
-def _validate_input(X, name, shape=None, dtype=None, min_value=None,
-	max_value=None, ohe=False, ohe_dim=1, allow_N=False, only_warn=False):
+def _validate_input(
+	X: torch.Tensor,
+	name: str,
+	shape: tuple[int, ...] | None = None,
+	dtype: torch.dtype | None = None,
+	min_value: float | None = None,
+	max_value: float | None = None,
+	ohe: bool = False,
+	ohe_dim: int = 1,
+	allow_N: bool = False,
+	only_warn: bool = False,
+) -> torch.Tensor:
 	"""An internal function for validating properties of the input.
 	
 	This function will take in an object and verify characteristics of it, such
@@ -129,7 +147,10 @@ def _validate_input(X, name, shape=None, dtype=None, min_value=None,
 	return X
 
 
-def _cast_as_tensor(value, dtype=None):
+def _cast_as_tensor(
+	value: Any,
+	dtype: torch.dtype | None = None,
+) -> torch.Tensor | None:
 	"""Cast your input as a torch tensor.
 
 	This function will take some array-like input and cast it as a torch
@@ -177,7 +198,12 @@ def _cast_as_tensor(value, dtype=None):
 			return torch.tensor(value, dtype=dtype)
 
 
-def example_to_fasta_coords(example_df, loci_df, window=None, one_indexed=False):
+def example_to_fasta_coords(
+	example_df: pandas.DataFrame,
+	loci_df: pandas.DataFrame,
+	window: int | None = None,
+	one_indexed: bool = False,
+) -> pandas.DataFrame:
 	"""Converts coordinates within a given example to those in a FASTA file.
 	
 	Many analyses involve extracting windows from the genome and processing them
@@ -277,7 +303,12 @@ def example_to_fasta_coords(example_df, loci_df, window=None, one_indexed=False)
 	return coords_df
 
 
-def characters(pwm, alphabet=['A', 'C', 'G', 'T'], force=False, allow_N=False):
+def characters(
+	pwm: torch.Tensor | numpy.ndarray,
+	alphabet: list[str] | tuple[str, ...] = ['A', 'C', 'G', 'T'],
+	force: bool = False,
+	allow_N: bool = False,
+) -> str:
 	"""Converts a PWM/one-hot encoding to a string sequence.
 
 	This function takes in a PWM or one-hot encoding and converts it to the
@@ -361,8 +392,15 @@ def _fast_one_hot_encode(X_ohe, seq, mapping):
 		X_ohe[i, idx] = 1
 
 
-def one_hot_encode(sequence, alphabet=['A', 'C', 'G', 'T'], dtype=torch.int8, 
-	ignore=['N'], desc=None, verbose=False, **kwargs):
+def one_hot_encode(
+	sequence: str | list[str],
+	alphabet: list[str] | tuple[str, ...] = ['A', 'C', 'G', 'T'],
+	dtype: str | torch.dtype = torch.int8,
+	ignore: list[str] = ['N'],
+	desc: str | None = None,
+	verbose: bool = False,
+	**kwargs: Any,
+) -> torch.Tensor:
 	"""Converts a string or list of characters into a one-hot encoding.
 
 	This function will take in either a string or a list and convert it into a
@@ -434,8 +472,11 @@ def one_hot_encode(sequence, alphabet=['A', 'C', 'G', 'T'], dtype=torch.int8,
 	return torch.from_numpy(one_hot_encoding).type(dtype).T
 
 
-def reverse_complement(seq, complement_map={"A": "T", "C": "G", "G": "C", 
-	"T": "A"}, allow_N=True):
+def reverse_complement(
+	seq: str | torch.Tensor,
+	complement_map: dict[str, str] = {"A": "T", "C": "G", "G": "C", "T": "A"},
+	allow_N: bool = True,
+) -> str | torch.Tensor:
 	"""Return the reverse complement of a single sequence.
 
 	This function will take in a single one-hot encoding of a sequence, or a
@@ -493,7 +534,12 @@ def reverse_complement(seq, complement_map={"A": "T", "C": "G", "G": "C",
 	return seq_rc
 
 
-def random_one_hot(shape, probs=None, dtype='int8', random_state=None):
+def random_one_hot(
+	shape: tuple[int, int, int],
+	probs: list | tuple | numpy.ndarray | None = None,
+	dtype: str | numpy.dtype = 'int8',
+	random_state: int | numpy.random.RandomState | None = None,
+) -> torch.Tensor:
 	"""Generate random one-hot encodings. Useful for debugging.
 
 	This function will generate random one-hot encodings where the second to
@@ -558,7 +604,11 @@ def random_one_hot(shape, probs=None, dtype='int8', random_state=None):
 	return torch.from_numpy(ohe)
 
 
-def chunk(X, size=1024, overlap=0):
+def chunk(
+	X: list[torch.Tensor],
+	size: int = 1024,
+	overlap: int = 0,
+) -> torch.Tensor:
 	"""Chunk a set of sequences into overlapping blocks.
 
 	This function will take a set of sequences of variable length and will
@@ -607,7 +657,11 @@ def chunk(X, size=1024, overlap=0):
 		for x in X], dim=0)
 
 
-def unchunk(X, lengths=None, overlap=0):
+def unchunk(
+	X: list | numpy.ndarray | torch.Tensor,
+	lengths: list | numpy.ndarray | torch.Tensor | None = None,
+	overlap: int = 0,
+) -> list[torch.Tensor]:
 	"""Unchunk fixed-length segments back into variable-length sequences.
 
 	After chunking a set of variable length sequences into fixed-length chunks
@@ -688,7 +742,7 @@ def unchunk(X, lengths=None, overlap=0):
 	return y
 	
 
-def pwm_consensus(X):
+def pwm_consensus(X: torch.Tensor | numpy.ndarray) -> torch.Tensor:
 	"""Take in a PWM and return the consensus.
 
 	This function will take in a PWM that encodes the probabilities of each
@@ -724,7 +778,11 @@ def pwm_consensus(X):
 	return Y
 
 
-def extract_signal(loci, X, verbose=False):
+def extract_signal(
+	loci: pandas.DataFrame,
+	X: torch.Tensor | numpy.ndarray,
+	verbose: bool = False,
+) -> torch.Tensor:
 	"""Extracts the signal at coordinates from a tensor of examples.
 
 	This function takes in a dataframe with the first three columns being the

--- a/tangermeme/variant_effect.py
+++ b/tangermeme/variant_effect.py
@@ -1,6 +1,12 @@
 # variant_effect.py
 # Contact: Jacob Schreiber <jmschreiber91@gmail.com>
 
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import numpy
 import torch
 
 from .utils import _cast_as_tensor
@@ -10,8 +16,15 @@ from .ersatz import insert
 from .predict import predict
 
 
-def substitution_effect(model, X, substitutions, args=None, func=predict, 
-	additional_func_kwargs=None, **kwargs):
+def substitution_effect(
+	model: torch.nn.Module,
+	X: torch.Tensor,
+	substitutions: torch.Tensor | numpy.ndarray,
+	args: tuple | None = None,
+	func: Callable[..., Any] = predict,
+	additional_func_kwargs: dict | None = None,
+	**kwargs: Any,
+) -> tuple[torch.Tensor | list[torch.Tensor], torch.Tensor | list[torch.Tensor]]:
 	"""Apply a function before and after including one or more substitutions.
 
 	This function will calculate the effect that substitutions have on the
@@ -100,8 +113,16 @@ def substitution_effect(model, X, substitutions, args=None, func=predict,
 	return y_before, y_after
 
 
-def deletion_effect(model, X, deletions, left=False, args=None, func=predict,
-	additional_func_kwargs=None, **kwargs):
+def deletion_effect(
+	model: torch.nn.Module,
+	X: torch.Tensor,
+	deletions: torch.Tensor | numpy.ndarray,
+	left: bool = False,
+	args: tuple | None = None,
+	func: Callable[..., Any] = predict,
+	additional_func_kwargs: dict | None = None,
+	**kwargs: Any,
+) -> tuple[torch.Tensor | list[torch.Tensor], torch.Tensor | list[torch.Tensor]]:
 	"""Apply a function before and after deleting characters from a sequence.
 
 	This function will calculate the effect that deletions have on the
@@ -224,8 +245,16 @@ def deletion_effect(model, X, deletions, left=False, args=None, func=predict,
 	return y_before, y_after
 
 
-def insertion_effect(model, X, insertions, left=False, args=None, func=predict,
-	additional_func_kwargs=None, **kwargs):
+def insertion_effect(
+	model: torch.nn.Module,
+	X: torch.Tensor,
+	insertions: torch.Tensor | numpy.ndarray,
+	left: bool = False,
+	args: tuple | None = None,
+	func: Callable[..., Any] = predict,
+	additional_func_kwargs: dict | None = None,
+	**kwargs: Any,
+) -> tuple[torch.Tensor | list[torch.Tensor], torch.Tensor | list[torch.Tensor]]:
 	"""Apply a function before and after inserting characters into a sequence.
 
 	This function will calculate the effect that insertions have on the


### PR DESCRIPTION
## Summary

Adds `from __future__ import annotations` and PEP 604 type hints to every public function across all 18 modules. Hints are purely documentary — they are evaluated as strings at runtime, so this PR has **zero runtime behavior change**. All 825 tests pass without modification.

The motivation is discoverability: `inspect.signature(predict)` now returns parameter and return annotations, which IDEs, agents, `mypy`, and `pyright` can use directly.

## Design choices

- **Scope: public surface only.** Non-underscore symbols across the package, plus the two underscored helpers (`_validate_input`, `_cast_as_tensor`) that are widely imported by tests and tutorials. Purely-internal helpers (`_apply`, `_fast_shuffle`, `_nonlinear`, `_maxpool`, numba kernels) are left alone — numba already enforces its own signatures, and the others add diff noise without API benefit.
- **`Callable[..., Any]` for `func=`/`references=`/`shuffle_fn=`/`loss=` parameters.** Acceptable callables (`predict`, `deep_lift_shap`, `saturation_mutagenesis`, user-supplied) have varying signatures. A stricter Callable type would encode a contract that doesn't actually hold uniformly; the loose form documents "this is a callable" without locking down a signature.
- **PEP 604 unions (`X | None`)** rather than `Optional[X]` or `Union[X, None]`. Cleaner reading; works with `from __future__ import annotations` on Python 3.10+.
- **No `TypeVar` for variable-arity returns.** `predict`'s return type is `torch.Tensor | list[torch.Tensor]` — could be parameterized with overloads, but the resulting ~20 lines per function aren't worth the marginal improvement in error messages.
- **No runtime checking added.** This PR is hints only; actual type validation (when the caller passes the wrong type) remains the job of `_validate_input` and Phase 3's input validation upgrades.

## Per-module commits

Each module's hints are a separate commit so reviewers can verify "no behavior change" by visually scanning that every hunk is a signature line. 19 commits total: `_compat`, `predict`, `utils`, `ersatz`, `ablate`, `marginalize`, `space`, `deep_lift_shap`, `pisa`, `saturation_mutagenesis`, `design`, `variant_effect`, `product`, `io`, `annotate`, `match`, `kmers`, `seqlet`, `plot`.

## Test plan

- [x] `uv run pytest` — 825 passed, 2 skipped (identical to baseline).
- [x] `python -c "import tangermeme.<each module>"` succeeds for every module (verified end-to-end via the test suite, which imports them all).

🤖 Generated with [Claude Code](https://claude.com/claude-code)