### PR TITLE
FIX bugs that currently raise on valid input

### DIFF
--- a/tangermeme/annotate.py
+++ b/tangermeme/annotate.py
@@ -382,7 +382,7 @@ def pairwise_annotations_spacing(
 			for j, (idx1, start1, end1) in enumerate(annotations[i+1:]):
 				if start0 < start1:
 					d = start1 - end0
-					if d > max_distance:
+					if d >= max_distance:
 						continue
 
 					y[idx0, idx1, d] += 1
@@ -391,7 +391,7 @@ def pairwise_annotations_spacing(
 
 				else:
 					d = start0 - end1
-					if d > max_distance:
+					if d >= max_distance:
 						continue
 
 					y[idx1, idx0, d] += 1

--- a/tangermeme/ersatz.py
+++ b/tangermeme/ersatz.py
@@ -408,7 +408,7 @@ def randomize(
 	if end <= start:
 		raise ValueError("End must come after start.")
 
-	if end >= X.shape[-1] or start < 0:
+	if end > X.shape[-1] or start < 0:
 		raise ValueError("Start or end are falling off the edge of X.")
 
 	X_rands = []

--- a/tangermeme/io.py
+++ b/tangermeme/io.py
@@ -423,10 +423,17 @@ def extract_loci(
 	if signals is None and in_signals is None:
 		out_width = 0
 
-	# Extract the length of each chromosome
+	# Extract the length of each chromosome. Track whether we opened the
+	# fasta ourselves so we know whether we are allowed to close it on
+	# exit; a caller-provided pyfaidx.Fasta is theirs to manage.
 	chrom_lengths = {}
+	opened_fasta = False
 	if isinstance(sequences, str):
 		sequences = pyfaidx.Fasta(sequences)
+		opened_fasta = True
+		for key, value in sequences.items():
+			chrom_lengths[str(key)] = len(value)
+	elif isinstance(sequences, pyfaidx.Fasta):
 		for key, value in sequences.items():
 			chrom_lengths[str(key)] = len(value)
 	else:
@@ -502,7 +509,7 @@ def extract_loci(
 		if n_loci is not None and len(seqs) == n_loci:
 			break 
 
-	if not isinstance(sequences, dict):
+	if opened_fasta:
 		sequences.close()
 		
 	# Figure out how to format the outputs depending on the provided parameters

--- a/tangermeme/pisa.py
+++ b/tangermeme/pisa.py
@@ -214,7 +214,8 @@ def pisa(
             X.shape[2]), ohe=True, allow_N=False, ohe_dim=-2)
         n_shuffles = references.shape[1]
 
-    n_outputs = predict(model, X[:1], device=device).shape[-1]
+    _probe_args = None if args is None else tuple(a[:1] for a in args)
+    n_outputs = predict(model, X[:1], args=_probe_args, device=device).shape[-1]
 
     # Loop over each of the examples
     for i in trange(len(X), disable=not verbose):
@@ -253,8 +254,11 @@ def pisa(
             
             with torch.autograd.set_grad_enabled(True):
                 if _args is not None:
-                    _args = (torch.cat([arg, arg]) for arg in _args)
-                    y = model(X_, *_args)
+                    # Materialize into a tuple and bind to a fresh name so
+                    # `_args` is not overwritten by an exhausted generator
+                    # for the next shuffle iteration.
+                    _args_batched = tuple(torch.cat([arg, arg]) for arg in _args)
+                    y = model(X_, *_args_batched)
                 else:
                     y = model(X_)
 

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -310,6 +310,23 @@ def test_pairwise_annotations_spacing_symmetric_false():
 	assert int(y.sum()) == 3
 
 
+def test_pairwise_annotations_spacing_at_max_distance():
+	# Two annotations whose gap equals max_distance exactly. The output
+	# tensor's last axis has size `max_distance`, so valid indices are
+	# 0..max_distance-1; a pair at distance == max_distance should be
+	# treated as "outside the window" rather than indexing past the end.
+	X = torch.tensor([
+		[0, 0, 0, 5],       # ends at 5
+		[0, 1, 105, 110],   # starts at 105 -> distance = 100
+	], dtype=torch.int64)
+
+	# Should not raise. Pair at exactly max_distance is excluded.
+	y = pairwise_annotations_spacing(X, max_distance=100)
+
+	assert y.shape == (2, 2, 100)
+	assert int(y.sum()) == 0
+
+
 ###
 
 

--- a/tests/test_ersatz.py
+++ b/tests/test_ersatz.py
@@ -591,6 +591,15 @@ def test_randomize_raises_ends(X):
 	assert_raises(ValueError, randomize, X, start=5, end=1000)
 
 
+def test_randomize_full_sequence(X):
+	# `end` is exclusive (matches Python slicing conventions used elsewhere
+	# in ersatz), so end == X.shape[-1] is the "randomize entire sequence"
+	# case and must not raise.
+	X_rand = randomize(X, start=0, end=X.shape[-1], random_state=0)
+	assert X_rand.shape == (1, 1, 4, X.shape[-1])
+	assert X_rand.sum() == X.sum()
+
+
 def test_randomize_raises_probs(X):
 	assert_raises(ValueError, randomize, X, start=5, end=10,
 		probs=[[0.1, 0.8, 0.1]])

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -723,6 +723,20 @@ def test_extract_loci_seq_raises_sequences():
 		"tests/data/test.bed", "ACGTG")
 
 
+def test_extract_loci_does_not_close_user_provided_fasta():
+	# When the caller passes a pre-opened pyfaidx.Fasta, extract_loci
+	# must not close it; the caller still owns the object and needs to
+	# keep using it after the call.
+	fasta = pyfaidx.Fasta("tests/data/test.fa")
+
+	extract_loci("tests/data/test.bed", fasta, in_window=10)
+
+	# Accessing a key after the call should still work. Pre-fix this
+	# raises ValueError("I/O operation on closed file") from the
+	# underlying mmap inside pyfaidx.
+	_ = str(fasta[list(fasta.keys())[0]])
+
+
 ###
 
 

--- a/tests/test_pisa.py
+++ b/tests/test_pisa.py
@@ -428,25 +428,60 @@ def test_pisa_args(X, device):
 	assert_array_almost_equal(X_attr0, X_attr1)
 	assert_raises(AssertionError, assert_array_almost_equal, X_attr0, X_attr2)
 
+	# Regression values reflect args (alpha, beta) being threaded
+	# through every shuffle iteration. Prior to the fix in pisa.py for
+	# the _args generator-exhaustion and the n_outputs probe, args were
+	# silently dropped after iter 0, so the previously-pinned values
+	# captured the buggy behavior.
 	assert_array_almost_equal(X_attr2[:2, :, :10], [
-		[[ 0.0000,  0.0000, -0.0000, -0.0209, -0.0000,  0.0000,  0.0000,
+		[[ 0.0000,  0.0000, -0.0000, -0.0205, -0.0000,  0.0000,  0.0000,
            0.0000, -0.0000,  0.0000],
-         [ 0.0000,  0.0000,  0.0080,  0.0000, -0.0000,  0.0000, -0.0000,
-          -0.0000, -0.0081,  0.0000],
+         [ 0.0000,  0.0000,  0.0078,  0.0000, -0.0000,  0.0000, -0.0000,
+          -0.0000, -0.0079,  0.0000],
          [ 0.0000,  0.0000, -0.0000, -0.0000, -0.0000,  0.0000, -0.0000,
            0.0000,  0.0000,  0.0000],
-         [-0.0000, -0.0160,  0.0000,  0.0000,  0.0245, -0.0336,  0.0200,
-           0.0050,  0.0000, -0.0085]],
+         [-0.0000, -0.0157,  0.0000,  0.0000,  0.0241, -0.0329,  0.0196,
+           0.0049,  0.0000, -0.0084]],
 
-        [[-0.0000, -0.0000, -0.0090, -0.0000, -0.0092,  0.0000,  0.0087,
-           0.0000, -0.0000,  0.0079],
-         [ 0.0000,  0.0000,  0.0000,  0.0000, -0.0000, -0.0000, -0.0000,
-          -0.0000, -0.0000,  0.0000],
-         [-0.0000,  0.0018, -0.0000, -0.0000, -0.0000,  0.0322, -0.0000,
-           0.0000,  0.0000,  0.0000],
-         [-0.0000, -0.0000,  0.0000,  0.0265,  0.0000, -0.0000,  0.0000,
-          -0.0006,  0.0063, -0.0000]]
+        [[ 0.0000,  0.0000,  0.0113,  0.0000,  0.0098, -0.0000, -0.0111,
+          -0.0000,  0.0000, -0.0105],
+         [ 0.0000, -0.0000, -0.0000, -0.0000,  0.0000, -0.0000,  0.0000,
+           0.0000,  0.0000, -0.0000],
+         [ 0.0000, -0.0044,  0.0000,  0.0000,  0.0000, -0.0422,  0.0000,
+          -0.0000, -0.0000, -0.0000],
+         [ 0.0000,  0.0000, -0.0000, -0.0336, -0.0000,  0.0000, -0.0000,
+           0.0006, -0.0094,  0.0000]]
 	], 4)
+
+
+def test_pisa_args_preserved_across_shuffles(X, device):
+	# pisa rebinds `_args` to a generator-from-itself on every shuffle
+	# iteration, which exhausts after the first batch. Any model whose
+	# forward requires the extra arg (no default) then raises TypeError
+	# on iter >= 1. Verify the args are still threaded through on every
+	# shuffle.
+
+	class RequiresArg(torch.nn.Module):
+		def __init__(self):
+			super().__init__()
+			self.dense = torch.nn.Linear(100 * 4, 1)
+
+		def forward(self, X, alpha):
+			# `alpha` has no default; calling forward without it raises
+			# TypeError.
+			return self.dense(X.reshape(X.shape[0], -1)) + alpha
+
+	torch.manual_seed(0)
+	model = RequiresArg()
+	alpha = torch.randn(X.shape[0], 1)
+
+	# n_shuffles=2 is enough to trigger the second iteration where _args
+	# has been exhausted.
+	X_attr = pisa(model, X, args=(alpha,), n_shuffles=2, device=device,
+		random_state=0)
+
+	# pisa output shape: (n_examples, n_outputs, alphabet, length).
+	assert X_attr.shape == (X.shape[0], 1, X.shape[1], X.shape[2])
 
 
 def test_pisa_raises(references, device):


### PR DESCRIPTION
## Summary

Four bug fixes, each one where the bug today causes a user-visible **error** on valid input. Each fix is paired with a regression test (added in the same commit) that demonstrates the failure before the fix and passes after.

Bugs whose only effect is a silently-wrong output were **deferred** from this PR — see the list at the bottom.

### Fixed (each currently raises)

1. **`ersatz.randomize` rejects `end == X.shape[-1]`.** Guard at `ersatz.py:411` was `end >= X.shape[-1]`, but `end` is an exclusive upper bound elsewhere in the module (substitute starts at `start` and writes `end-start` characters, covering `[start, end)`). So "randomize the entire sequence" raised `ValueError` on valid input. Loosened to `>`.

2. **`annotate.pairwise_annotations_spacing` IndexErrors at `d == max_distance`.** Output tensor has shape `(n, n, max_distance)`, valid indices `0..max_distance-1`. The skip guard `if d > max_distance` let `d == max_distance` fall through to a write that indexed past the end. Tightened to `>=`.

3. **`pisa` drops `args=` after the first shuffle iteration.** Two stacked bugs in pisa.py: (a) `n_outputs = predict(model, X[:1], device=device)` at line 217 didn't pass `args=`, so any model whose forward requires extra args raised `TypeError` before the loop began; (b) `_args = (torch.cat([arg, arg]) for arg in _args)` rebound `_args` to a generator-from-itself which exhausts after the unpack, so iterations `j>=1` ran `model(X_)` with no args. For models with defaults (like the existing `FlattenDense`) this silently substituted defaults; for models that *require* the args it raised TypeError. Both fixed. The pre-existing `test_pisa_args` regression values had captured the buggy behavior (`beta` only applied on iter 0); updated to reflect args threaded through every iteration.

4. **`io.extract_loci` errored on user-provided `pyfaidx.Fasta` and closed it.** Two stacked bugs: (a) the non-string `sequences` branch used `sequences[key].shape[-1]`, which only works for dict-of-tensor input; passing a pyfaidx.Fasta raised `AttributeError` immediately. (b) The end-of-function close ran regardless of who opened the fasta, so callers who got past bug (a) would find their Fasta closed under them. Split the chromosome-length branch into three cases (str, pyfaidx.Fasta, dict) and track an `opened_fasta` flag so close only runs for fastas we created internally.

### Verified not-a-bug-today, dropped from this PR

- **`one_hot_to_fasta` "malformed" header (`> {name}` with a leading space).** Hand-checked round-trip: the current `pyfaidx` version reads it back correctly (strips the leading whitespace). The header is technically non-canonical FASTA but does not error today. Will revisit if a stricter parser ever lands.

### Deferred — output-changing bugs (intentionally not in this PR)

These are real defects but their only effect today is silent output drift, not errors. They'd require regression-value updates across multiple tests, which is a larger conversation. Listed here as a forward reference:

- `io.py:457` chromosome-end filter `>=` should be `>` (silently drops loci that end exactly at chromosome length).
- `io.py:451-454` odd-window parity (mid calculation loses a base when window is odd).
- `match.py` GC-bin spillover `> 0` should be `>= 0` (bin 0 can't receive overflow).
- `seqlet.py:416` `p_value[:, -min_seqlet_len] = 1` should be `[:, -min_seqlet_len:] = 1` (masks 1 column instead of `min_seqlet_len`).
- `seqlet.py:444` `range(start, min(start+seqlet_len, l-1))` should use `l`, not `l-1`.
- `_iterative_extract_seqlets` negative `start` when `argmax < flank` (Python negative indices silently wrap).
- `plot.place_new_box` mutates the caller's `Bbox` in place instead of returning a new one.
- `plot.plot_pwm` calls `plt.show()` unconditionally (notebook ergonomics).
- `plot.plot_categorical_scatter` ignores any user-supplied `ax`.
- `plot.plot_attributions` ignores the `func=` argument (always calls `deep_lift_shap`).
- Unifying `ersatz.{shuffle, dinucleotide_shuffle, randomize, delete}` negative-`end` conventions (four different conventions currently; unifying breaks back-compat).

## Test plan

- [x] `uv run pytest` — 830 passed, 2 skipped (baseline was 825; this PR adds 4 new regression tests, with `test_pisa_args_preserved_across_shuffles` covering both cpu and cuda).
- [x] Each new test was added in the same commit as the fix and was verified to fail before the fix and pass after.
- [x] The one pre-existing test whose regression values shifted (`test_pisa_args`) was updated and documented inline as having previously pinned the buggy behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)