### PR TITLE
UPDATE deep_lift_shap and pisa preserve model state and clean up on exception

### DIFF
--- a/tangermeme/deep_lift_shap.py
+++ b/tangermeme/deep_lift_shap.py
@@ -421,137 +421,152 @@ def deep_lift_shap(
 
 	use_autocast = _autocast_supported(device, dtype)
 
-	model = model.to(device).eval()
-	for module in model.modules():
-		module._NON_LINEAR_OPS = _NON_LINEAR_OPS
+	try:
+		_orig_device = next(model.parameters()).device
+	except StopIteration:
+		_orig_device = None
+	_was_training = model.training
+
+	model.to(device).eval()
 
 	try:
-		model.apply(_register_hooks)
-	except Exception as e:
-		model.apply(_clear_hooks)
-		raise(e)
+		for module in model.modules():
+			module._NON_LINEAR_OPS = _NON_LINEAR_OPS
+
+		try:
+			model.apply(_register_hooks)
+		except Exception as e:
+			model.apply(_clear_hooks)
+			raise(e)
 	
-	# Begin DeepLIFT procedure
+		# Begin DeepLIFT procedure
 	
-	attributions, references_, Xi, rj, attr_ = [], [], [], [], []
-	if isinstance(references, torch.Tensor):
-		_validate_input(references, "references", shape=(X.shape[0], -1, X.shape[1], 
-			X.shape[2]), ohe=True, allow_N=False, ohe_dim=-2, only_warn=only_warn)
-		n_shuffles = references.shape[1]
+		attributions, references_, Xi, rj, attr_ = [], [], [], [], []
+		if isinstance(references, torch.Tensor):
+			_validate_input(references, "references", shape=(X.shape[0], -1, X.shape[1], 
+				X.shape[2]), ohe=True, allow_N=False, ohe_dim=-2, only_warn=only_warn)
+			n_shuffles = references.shape[1]
 
-	n, z = X.shape[0] * n_shuffles, 0
+		n, z = X.shape[0] * n_shuffles, 0
 
-	for i in trange(n, disable=not verbose):
-		Xi.append(i // n_shuffles)
-		rj.append(i % n_shuffles)
+		for i in trange(n, disable=not verbose):
+			Xi.append(i // n_shuffles)
+			rj.append(i % n_shuffles)
 
-		if len(Xi) == batch_size or i == (n-1):
-			_X = X[Xi].cpu().type(dtype)
-			_args = None if args is None else tuple([a[Xi].to(device).type(dtype)
-				for a in args])
+			if len(Xi) == batch_size or i == (n-1):
+				_X = X[Xi].cpu().type(dtype)
+				_args = None if args is None else tuple([a[Xi].to(device).type(dtype)
+					for a in args])
 
-			# Handle reference sequences while ensuring that the same seed is
-			# used for each shuffle even if not all shuffles are done in the
-			# same batch.
-			if isinstance(references, torch.Tensor):
-				_references = references[Xi, rj]
-			else:
-				if random_state is None:
-					_references = references(_X, n=1)[:, 0]
+				# Handle reference sequences while ensuring that the same seed is
+				# used for each shuffle even if not all shuffles are done in the
+				# same batch.
+				if isinstance(references, torch.Tensor):
+					_references = references[Xi, rj]
 				else:
-					_references = torch.cat([references(_X[j:j+1], n=1, 
-						random_state=random_state+rj[j])[:, 0] 
-							for j in range(len(_X))])
+					if random_state is None:
+						_references = references(_X, n=1)[:, 0]
+					else:
+						_references = torch.cat([references(_X[j:j+1], n=1, 
+							random_state=random_state+rj[j])[:, 0] 
+								for j in range(len(_X))])
 
-			_X = _X.to(device).type(dtype).requires_grad_()
-			_references = _references.to(device).type(dtype).requires_grad_()
+				_X = _X.to(device).type(dtype).requires_grad_()
+				_references = _references.to(device).type(dtype).requires_grad_()
 
-			# This next block is actually running DeepLIFT by concatenating the
-			# batch of examples and the batch of references and running the
-			# forward and backward passes that have been modified by the above
-			# hooks. In a try-except block to make sure we remove hooks if an
-			# error is raised. 
-			try:
-				X_ = torch.cat([_X, _references])
+				# This next block is actually running DeepLIFT by concatenating the
+				# batch of examples and the batch of references and running the
+				# forward and backward passes that have been modified by the above
+				# hooks. In a try-except block to make sure we remove hooks if an
+				# error is raised. 
+				try:
+					X_ = torch.cat([_X, _references])
 
-				if use_autocast:
-					autocast_ctx = torch.autocast(device_type=device.type, dtype=dtype)
-				else:
-					autocast_ctx = contextlib.nullcontext()
+					if use_autocast:
+						autocast_ctx = torch.autocast(device_type=device.type, dtype=dtype)
+					else:
+						autocast_ctx = contextlib.nullcontext()
 
-				# Calculate the gradients using the rescale rule
-				with torch.autograd.set_grad_enabled(True):
-					with autocast_ctx:
-						if _args is not None:
-							_args = (torch.cat([arg, arg]) for arg in _args)
-							y = model(X_, *_args)[:, target]
-						else:
-							y = model(X_)[:, target]
+					# Calculate the gradients using the rescale rule
+					with torch.autograd.set_grad_enabled(True):
+						with autocast_ctx:
+							if _args is not None:
+								_args = (torch.cat([arg, arg]) for arg in _args)
+								y = model(X_, *_args)[:, target]
+							else:
+								y = model(X_)[:, target]
 
-						multipliers = torch.autograd.grad(y.sum(), _X)[0]
+							multipliers = torch.autograd.grad(y.sum(), _X)[0]
 
-				# Check that the prediction-difference-from-reference is equal to
-				# the sum of the attributions
-				output_diff = torch.sub(*torch.chunk(y, 2))
-				input_diff = torch.sum((_X - _references) * multipliers, 
-					dim=(1, 2))
-				convergence_deltas = abs(output_diff - input_diff)
+					# Check that the prediction-difference-from-reference is equal to
+					# the sum of the attributions
+					output_diff = torch.sub(*torch.chunk(y, 2))
+					input_diff = torch.sum((_X - _references) * multipliers, 
+						dim=(1, 2))
+					convergence_deltas = abs(output_diff - input_diff)
 
-				if torch.any(convergence_deltas > warning_threshold):
-					warnings.warn("Convergence deltas too high: " +   
-						str(convergence_deltas), RuntimeWarning)
+					if torch.any(convergence_deltas > warning_threshold):
+						warnings.warn("Convergence deltas too high: " +   
+							str(convergence_deltas), RuntimeWarning)
 
-				if print_convergence_deltas:
-					print(convergence_deltas)
+					if print_convergence_deltas:
+						print(convergence_deltas)
 
-			except Exception as e:
-				model.apply(_clear_hooks)
-				raise(e)
+				except Exception as e:
+					model.apply(_clear_hooks)
+					raise(e)
 
-			# If not returning the raw multipliers then apply the correction for
-			# character encodings
-			if raw_outputs == False:
-				multipliers = hypothetical_attributions((multipliers,), (_X,), 
-					(_references,))[0]
-
-			# attr_ is a list where each element is a tensor for the multipliers
-			# of one example-reference pair, so that once all references for an
-			# example have been processed we can chunk them together.
-			attr_.extend(list(multipliers.cpu().detach()))
-
-			# When all references for a sequence have been calculated, remove
-			# that block from the list of example-reference attributions and
-			# add it to the final attribution list, averaging across references
-			# if providing the processed results.
-			while len(attr_) >= n_shuffles:
-				attr_chunk = torch.stack(attr_[:n_shuffles])
-
+				# If not returning the raw multipliers then apply the correction for
+				# character encodings
 				if raw_outputs == False:
-					attr_chunk = attr_chunk.mean(dim=0)
-					if not hypothetical:
-						attr_chunk *= X[z].cpu()
+					multipliers = hypothetical_attributions((multipliers,), (_X,), 
+						(_references,))[0]
 
-				attributions.append(attr_chunk)
-				attr_ = attr_[n_shuffles:]
-				z += 1
+				# attr_ is a list where each element is a tensor for the multipliers
+				# of one example-reference pair, so that once all references for an
+				# example have been processed we can chunk them together.
+				attr_.extend(list(multipliers.cpu().detach()))
 
-			if return_references:
-				references_.extend(list(_references.cpu().detach()))
+				# When all references for a sequence have been calculated, remove
+				# that block from the list of example-reference attributions and
+				# add it to the final attribution list, averaging across references
+				# if providing the processed results.
+				while len(attr_) >= n_shuffles:
+					attr_chunk = torch.stack(attr_[:n_shuffles])
 
-			Xi, rj = [], []
+					if raw_outputs == False:
+						attr_chunk = attr_chunk.mean(dim=0)
+						if not hypothetical:
+							attr_chunk *= X[z].cpu()
+
+					attributions.append(attr_chunk)
+					attr_ = attr_[n_shuffles:]
+					z += 1
+
+				if return_references:
+					references_.extend(list(_references.cpu().detach()))
+
+				Xi, rj = [], []
 
 
-	model.apply(_clear_hooks)
-	for module in model.modules():
-		del(module._NON_LINEAR_OPS)
 
-	attributions = torch.stack(attributions)
+		attributions = torch.stack(attributions)
 
-	if return_references:
-		references_ = torch.cat(references_).reshape(X.shape[0], n_shuffles, 
-			*X.shape[1:])
-		return attributions, references_
-	return attributions
+		if return_references:
+			references_ = torch.cat(references_).reshape(X.shape[0], n_shuffles, 
+				*X.shape[1:])
+			return attributions, references_
+		return attributions
+	finally:
+		model.apply(_clear_hooks)
+		for module in model.modules():
+			if hasattr(module, "_NON_LINEAR_OPS"):
+				del module._NON_LINEAR_OPS
+
+		if _was_training:
+			model.train()
+		if _orig_device is not None and _orig_device != device:
+			model.to(_orig_device)
 
 
 def _captum_deep_lift_shap(

--- a/tangermeme/pisa.py
+++ b/tangermeme/pisa.py
@@ -197,127 +197,141 @@ def pisa(
             _NON_LINEAR_OPS[key] = value
 
     device = _resolve_device(device)
-    model = model.to(device).eval()
-    for module in model.modules():
-        module._NON_LINEAR_OPS = _NON_LINEAR_OPS
+    try:
+        _orig_device = next(model.parameters()).device
+    except StopIteration:
+        _orig_device = None
+    _was_training = model.training
+
+    model.to(device).eval()
 
     try:
-        model.apply(_register_hooks)
-    except Exception as e:
-        model.apply(_clear_hooks)
-        raise(e)
+        for module in model.modules():
+            module._NON_LINEAR_OPS = _NON_LINEAR_OPS
 
-    # Begin PISA procedure    
-    attributions, references_ = [], [] 
-    if isinstance(references, torch.Tensor):
-        _validate_input(references, "references", shape=(X.shape[0], -1, X.shape[1], 
-            X.shape[2]), ohe=True, allow_N=False, ohe_dim=-2)
-        n_shuffles = references.shape[1]
+        try:
+            model.apply(_register_hooks)
+        except Exception as e:
+            model.apply(_clear_hooks)
+            raise(e)
 
-    _probe_args = None if args is None else tuple(a[:1] for a in args)
-    n_outputs = predict(model, X[:1], args=_probe_args, device=device).shape[-1]
-
-    # Loop over each of the examples
-    for i in trange(len(X), disable=not verbose):
-        _X = X[i:i+1].to(device).requires_grad_()
-
-        # Either use reference sequences if provided or generate a set of them
-        # for this example being analyzed.
+        # Begin PISA procedure    
+        attributions, references_ = [], [] 
         if isinstance(references, torch.Tensor):
-            _references = references[i]
-        else:
-            _references = references(_X.cpu(), n=n_shuffles, 
-                random_state=random_state)[0]
+            _validate_input(references, "references", shape=(X.shape[0], -1, X.shape[1], 
+                X.shape[2]), ohe=True, allow_N=False, ohe_dim=-2)
+            n_shuffles = references.shape[1]
 
-        _references = _references.to(device).requires_grad_()
-        if return_references:
-            references_.append(_references)
+        _probe_args = None if args is None else tuple(a[:1] for a in args)
+        n_outputs = predict(model, X[:1], args=_probe_args, device=device).shape[-1]
 
-        # Pull out the additional arguments for this example, if additional
-        # arguments are being provided
-        _args = None if args is None else tuple([a[i].to(device) 
-            for a in args])
+        # Loop over each of the examples
+        for i in trange(len(X), disable=not verbose):
+            _X = X[i:i+1].to(device).requires_grad_()
 
-        multipliers = []
+            # Either use reference sequences if provided or generate a set of them
+            # for this example being analyzed.
+            if isinstance(references, torch.Tensor):
+                _references = references[i]
+            else:
+                _references = references(_X.cpu(), n=n_shuffles, 
+                    random_state=random_state)[0]
 
-        # Loop over all of the shuffles for each example
-        for j in range(n_shuffles):
-            # For each output explained, the input and the reference will be
-            # the same, so extract those single elements and expand them to
-            # be the batch size.
+            _references = _references.to(device).requires_grad_()
+            if return_references:
+                references_.append(_references)
 
-            x = _X.expand(batch_size, -1, -1)
-            r = _references[j:j+1].expand(batch_size, -1, -1)
-            xr = (x[:1] - r[:1])
+            # Pull out the additional arguments for this example, if additional
+            # arguments are being provided
+            _args = None if args is None else tuple([a[i].to(device) 
+                for a in args])
+
+            multipliers = []
+
+            # Loop over all of the shuffles for each example
+            for j in range(n_shuffles):
+                # For each output explained, the input and the reference will be
+                # the same, so extract those single elements and expand them to
+                # be the batch size.
+
+                x = _X.expand(batch_size, -1, -1)
+                r = _references[j:j+1].expand(batch_size, -1, -1)
+                xr = (x[:1] - r[:1])
             
-            X_ = torch.cat([x, r])
+                X_ = torch.cat([x, r])
             
-            with torch.autograd.set_grad_enabled(True):
-                if _args is not None:
-                    # Materialize into a tuple and bind to a fresh name so
-                    # `_args` is not overwritten by an exhausted generator
-                    # for the next shuffle iteration.
-                    _args_batched = tuple(torch.cat([arg, arg]) for arg in _args)
-                    y = model(X_, *_args_batched)
-                else:
-                    y = model(X_)
+                with torch.autograd.set_grad_enabled(True):
+                    if _args is not None:
+                        # Materialize into a tuple and bind to a fresh name so
+                        # `_args` is not overwritten by an exhausted generator
+                        # for the next shuffle iteration.
+                        _args_batched = tuple(torch.cat([arg, arg]) for arg in _args)
+                        y = model(X_, *_args_batched)
+                    else:
+                        y = model(X_)
 
-                _multipliers = []
-                edge_size = n_outputs % batch_size
+                    _multipliers = []
+                    edge_size = n_outputs % batch_size
 
-                # Loop over all of the output positions
-                for k in range(0, n_outputs, batch_size):
-                    b = min(batch_size, n_outputs - k)
+                    # Loop over all of the output positions
+                    for k in range(0, n_outputs, batch_size):
+                        b = min(batch_size, n_outputs - k)
  
-                    rows = torch.cat([torch.arange(b), torch.arange(b)+batch_size])
-                    cols = torch.arange(k, k+b).repeat(2)
-                    y_hat = y[rows, cols].sum()
+                        rows = torch.cat([torch.arange(b), torch.arange(b)+batch_size])
+                        cols = torch.arange(k, k+b).repeat(2)
+                        y_hat = y[rows, cols].sum()
                     
-                    multipliers_ = torch.autograd.grad(y_hat, x, retain_graph=True)[0]
+                        multipliers_ = torch.autograd.grad(y_hat, x, retain_graph=True)[0]
                     
-                    # Check that the prediction-difference-from-reference is equal to
-                    # the sum of the attributions                    
-                    output_diff = torch.sub(*torch.chunk(y[rows, cols], 2))
-                    input_diff = torch.sum(xr * multipliers_[:b], dim=(1, 2))
+                        # Check that the prediction-difference-from-reference is equal to
+                        # the sum of the attributions                    
+                        output_diff = torch.sub(*torch.chunk(y[rows, cols], 2))
+                        input_diff = torch.sum(xr * multipliers_[:b], dim=(1, 2))
                                        
-                    convergence_deltas = abs(output_diff - input_diff)
-                    if torch.any(convergence_deltas > warning_threshold):
-                        warnings.warn("Convergence deltas too high: " +   
-                            str(convergence_deltas), RuntimeWarning)
+                        convergence_deltas = abs(output_diff - input_diff)
+                        if torch.any(convergence_deltas > warning_threshold):
+                            warnings.warn("Convergence deltas too high: " +   
+                                str(convergence_deltas), RuntimeWarning)
 
-                    if print_convergence_deltas:
-                        print(convergence_deltas)
+                        if print_convergence_deltas:
+                            print(convergence_deltas)
                     
-                    if not raw_outputs:
-                        multipliers_ = hypothetical_attributions(
-                            (multipliers_[:b],), 
-                            (x[:b],), 
-                            (r[:b],)
-                        )[0].cpu().detach()    
+                        if not raw_outputs:
+                            multipliers_ = hypothetical_attributions(
+                                (multipliers_[:b],), 
+                                (x[:b],), 
+                                (r[:b],)
+                            )[0].cpu().detach()    
                                        
-                    _multipliers.append(multipliers_[:b])                  
+                        _multipliers.append(multipliers_[:b])                  
 
-            # Discard the accumulated graph
-            torch.autograd.grad(y[:1, :1].sum(), x, retain_graph=False)[0]
+                # Discard the accumulated graph
+                torch.autograd.grad(y[:1, :1].sum(), x, retain_graph=False)[0]
 
-            # Keep the multipliers across each output
-            multipliers.append(torch.cat(_multipliers, dim=0))
+                # Keep the multipliers across each output
+                multipliers.append(torch.cat(_multipliers, dim=0))
 
-        attr = torch.stack(multipliers, dim=0)
-        if not raw_outputs:
-            attr = attr.mean(dim=0)
-            if not hypothetical:
-                attr = attr * _X.cpu()
+            attr = torch.stack(multipliers, dim=0)
+            if not raw_outputs:
+                attr = attr.mean(dim=0)
+                if not hypothetical:
+                    attr = attr * _X.cpu()
         
-        attributions.append(attr)
+            attributions.append(attr)
 
 
-    model.apply(_clear_hooks)
-    for module in model.modules():
-        del(module._NON_LINEAR_OPS)
+        attributions = torch.stack(attributions).detach()
 
-    attributions = torch.stack(attributions).detach()
+        if return_references:
+            return attributions, torch.stack(references_).detach()
+        return attributions
+    finally:
+        model.apply(_clear_hooks)
+        for module in model.modules():
+            if hasattr(module, "_NON_LINEAR_OPS"):
+                del module._NON_LINEAR_OPS
 
-    if return_references:
-        return attributions, torch.stack(references_).detach()
-    return attributions
+        if _was_training:
+            model.train()
+        if _orig_device is not None and _orig_device != device:
+            model.to(_orig_device)

--- a/tests/test_deep_lift_shap.py
+++ b/tests/test_deep_lift_shap.py
@@ -1748,6 +1748,47 @@ def test_deep_lift_shap_only_warn(X, device):
 	assert X_attr.shape == X_bad.shape
 
 
+def test_deep_lift_shap_preserves_model_state(X, device):
+	# After deep_lift_shap returns the model should be back on its
+	# original device and in its original training mode, with no
+	# _NON_LINEAR_OPS attributes leaked onto its modules.
+	torch.manual_seed(0)
+	model = FlattenDense(n_outputs=1)
+	model.train()  # explicitly leave model in train mode
+	orig_device = next(model.parameters()).device
+
+	deep_lift_shap(model, X[:4], n_shuffles=2, device=device, random_state=0)
+
+	assert model.training, "training mode was not restored"
+	assert next(model.parameters()).device == orig_device, \
+		"device was not restored"
+	for module in model.modules():
+		assert not hasattr(module, "_NON_LINEAR_OPS"), \
+			"_NON_LINEAR_OPS attribute leaked onto module"
+
+
+def test_deep_lift_shap_cleans_up_hooks_on_exception(X, device):
+	# If the forward pass raises mid-loop, hooks and _NON_LINEAR_OPS
+	# attributes must still be cleaned up by the finally clause.
+	class Boom(torch.nn.Module):
+		def __init__(self):
+			super().__init__()
+			self.dense = torch.nn.Linear(100 * 4, 1)
+
+		def forward(self, X):
+			raise RuntimeError("intentional boom")
+
+	model = Boom()
+
+	with pytest.raises(RuntimeError):
+		deep_lift_shap(model, X[:2], n_shuffles=1, device=device,
+			random_state=0)
+
+	for module in model.modules():
+		assert not hasattr(module, "_NON_LINEAR_OPS"), \
+			"_NON_LINEAR_OPS leaked after exception"
+
+
 def test_deep_lift_shap_dtype_param(X, device):
 	torch.manual_seed(0)
 	model = FlattenDense(n_outputs=1)

--- a/tests/test_pisa.py
+++ b/tests/test_pisa.py
@@ -484,6 +484,46 @@ def test_pisa_args_preserved_across_shuffles(X, device):
 	assert X_attr.shape == (X.shape[0], 1, X.shape[1], X.shape[2])
 
 
+def test_pisa_preserves_model_state(X, device):
+	# After pisa returns the model should be back on its original device
+	# and in its original training mode, with no _NON_LINEAR_OPS attributes
+	# leaked onto its modules.
+	torch.manual_seed(0)
+	model = FlattenDense(n_outputs=1)
+	model.train()  # explicitly leave model in train mode
+	orig_device = next(model.parameters()).device
+
+	pisa(model, X, n_shuffles=2, device=device, random_state=0)
+
+	assert model.training, "training mode was not restored"
+	assert next(model.parameters()).device == orig_device, \
+		"device was not restored"
+	for module in model.modules():
+		assert not hasattr(module, "_NON_LINEAR_OPS"), \
+			"_NON_LINEAR_OPS attribute leaked onto module"
+
+
+def test_pisa_cleans_up_hooks_on_exception(X, device):
+	# If the forward pass raises mid-loop, hooks and _NON_LINEAR_OPS
+	# attributes must still be cleaned up by the finally clause.
+	class Boom(torch.nn.Module):
+		def __init__(self):
+			super().__init__()
+			self.dense = torch.nn.Linear(100 * 4, 1)
+
+		def forward(self, X):
+			raise RuntimeError("intentional boom")
+
+	model = Boom()
+
+	with pytest.raises(RuntimeError):
+		pisa(model, X, n_shuffles=1, device=device, random_state=0)
+
+	for module in model.modules():
+		assert not hasattr(module, "_NON_LINEAR_OPS"), \
+			"_NON_LINEAR_OPS leaked after exception"
+
+
 def test_pisa_raises(references, device):
 	X_ = random_one_hot((16, 4, 100), random_state=0).type(torch.float32)
 	X = substitute(X_, "ACGTACGT")


### PR DESCRIPTION
## Summary

Two parallel changes, one for `deep_lift_shap` and one for `pisa`. Both functions previously called `model.to(device).eval()` and never restored the user's model device or training mode, silently mutating a caller-owned object. Both also cleared their temporary `_NON_LINEAR_OPS` module attributes and hooks only on the happy path, so any exception mid-loop left the model in a broken state for subsequent calls.

This PR brings both modules in line with the model-state preservation already shipped for `predict` and `product` in Phase 1.

### Changes per module

For each of `deep_lift_shap` and `pisa`:

- **State capture at entry.** Record the original device (from `next(model.parameters()).device`) and `model.training` flag before mutating the model.
- **State restoration in `finally`.** After the function body completes (whether by return or exception), restore the training mode and move the model back to its original device if needed.
- **Hook + `_NON_LINEAR_OPS` cleanup in the same `finally`.** Use `if hasattr(module, "_NON_LINEAR_OPS"): del module._NON_LINEAR_OPS` so partial setups also clean up safely.

### Regression tests (4 per module, 8 total over [cpu, cuda])

For each module:

1. `test_*_preserves_model_state`: explicitly leaves the model in training mode, calls the function, asserts the model is back in training mode on its original device with no `_NON_LINEAR_OPS` leaked.

2. `test_*_cleans_up_hooks_on_exception`: passes a model whose forward raises `RuntimeError`, wraps the call in `pytest.raises`, then asserts no `_NON_LINEAR_OPS` attributes survived on any module.

## Implementation note

The body of each function had to be re-indented to live inside a single top-level `try: ... finally:`. The re-indenting was done with a small Python script per file rather than a long sequence of Edit calls, which would have been fragile across so many lines. The diff looks larger than the conceptual change because of the indent shift.

## Test plan

- [x] `uv run pytest` — 838 passed, 2 skipped (was 830; +8 new tests across cpu/cuda for both modules).
- [x] All four new regression tests added in the same commit as the relevant fix; verified to pass after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)