### PR TITLE
ADD input validation upgrades and diagnostics helpers

### DIFF
--- a/tangermeme/ablate.py
+++ b/tangermeme/ablate.py
@@ -206,10 +206,14 @@ def ablate_annotations(
 		those.
 	"""
 
+	if len(annotations) == 0:
+		raise ValueError("ablate_annotations requires at least one annotation; "
+			"got an empty annotations tensor.")
+
 	y_befores, y_afters = [], []
 
 	for idx, start, end in annotations:
-		y_before, y_after = ablate(model, X[idx:idx+1], start=start, end=end, 
+		y_before, y_after = ablate(model, X[idx:idx+1], start=start, end=end,
 			**kwargs)
 
 		y_befores.append(y_before)

--- a/tangermeme/deep_lift_shap.py
+++ b/tangermeme/deep_lift_shap.py
@@ -379,7 +379,11 @@ def deep_lift_shap(
 	"""
 
 	_validate_input(X, "X", shape=(-1, -1, -1), ohe=True, only_warn=only_warn)
-	
+
+	if X.shape[0] == 0:
+		raise ValueError("deep_lift_shap requires at least one example; got "
+			"X with shape[0] == 0.")
+
 	_NON_LINEAR_OPS = {
 		torch.nn.ReLU: _nonlinear,
 		torch.nn.ReLU6: _nonlinear,

--- a/tangermeme/marginalize.py
+++ b/tangermeme/marginalize.py
@@ -179,6 +179,10 @@ def marginalize_annotations(
 		those.
 	"""
 
+	if len(annotations) == 0:
+		raise ValueError("marginalize_annotations requires at least one "
+			"annotation; got an empty annotations tensor.")
+
 	y_befores, y_afters = [], []
 
 	for idx, start, end in annotations:

--- a/tangermeme/pisa.py
+++ b/tangermeme/pisa.py
@@ -167,6 +167,10 @@ def pisa(
 
     _validate_input(X, "X", shape=(-1, -1, -1), ohe=True)
 
+    if X.shape[0] == 0:
+        raise ValueError("pisa requires at least one example; got X with "
+            "shape[0] == 0.")
+
     _NON_LINEAR_OPS = {
         torch.nn.ReLU: _nonlinear,
         torch.nn.ReLU6: _nonlinear,

--- a/tangermeme/predict.py
+++ b/tangermeme/predict.py
@@ -90,6 +90,10 @@ def predict(
 		concatenated across all batches.
 	"""
 
+	if X.shape[0] == 0:
+		raise ValueError("predict requires at least one example; got X "
+			"with shape[0] == 0.")
+
 	device = _resolve_device(device)
 
 	if dtype is None:

--- a/tangermeme/seqlet.py
+++ b/tangermeme/seqlet.py
@@ -279,7 +279,12 @@ def tfmodisco_seqlets(
 		and attribution sum for each seqlet that passes the thresholds.
 	"""
 
-	_validate_input(X_attr, "X_attr", shape=(-1, -1)) 
+	_validate_input(X_attr, "X_attr", shape=(-1, -1))
+
+	if X_attr.shape[0] == 0 or X_attr.shape[1] == 0:
+		raise ValueError("tfmodisco_seqlets requires X_attr to be non-empty; "
+			"got X_attr with shape {}.".format(tuple(X_attr.shape)))
+
 	suppress = int(0.5*window_size) + flank
 
 	X_sum = X_attr.unfold(-1, window_size, 1).sum(dim=-1)
@@ -561,8 +566,12 @@ def recursive_seqlets(
 	elif not isinstance(X, numpy.ndarray):
 		raise ValueError("`X` must be either a torch.Tensor or numpy.ndarray.")
 
+	if X.size == 0:
+		raise ValueError("recursive_seqlets requires X to be non-empty; got "
+			"X with shape {}.".format(tuple(X.shape)))
+
 	columns = ['example_idx', 'start', 'end', 'attribution', 'p-value']
-	seqlets = _recursive_seqlets(X, threshold, min_seqlet_len, max_seqlet_len, 
+	seqlets = _recursive_seqlets(X, threshold, min_seqlet_len, max_seqlet_len,
 		additional_flanks, n_bins)
 	seqlets = pandas.DataFrame(seqlets, columns=columns)
 	return seqlets.sort_values("p-value").reset_index(drop=True)

--- a/tangermeme/utils.py
+++ b/tangermeme/utils.py
@@ -128,23 +128,54 @@ def _validate_input(
 	if ohe:
 		values = torch.unique(X)
 		msg = "{} must be one-hot encoded.".format(name)
-		
-		if len(values) != 2:
+
+		# Values must be a subset of {0, 1}. Previously this enforced
+		# `len(unique) == 2`, which incorrectly rejected all-zero
+		# (all-N) inputs that contain only the value 0.
+		if not torch.all((values == 0) | (values == 1)):
 			_warn_or_raise(ValueError, msg, only_warn)
-	
-		if not all(values == torch.tensor([0, 1], device=X.device)):
-			_warn_or_raise(ValueError, msg, only_warn)
-	
+
 		if allow_N:
 			if not torch.all(torch.sum(X, axis=ohe_dim) <= 1):
-				_warn_or_raise(ValueError, msg + "and contain unknown" \
+				_warn_or_raise(ValueError, msg + " and contain unknown"
 					" characters as all-zeroes.", only_warn)
 		else:
 			if not torch.all(X.sum(axis=ohe_dim) == 1):
-				_warn_or_raise(ValueError, msg + "and cannot have unknown" \
-					" characters.", only_warn)			
-	
+				_warn_or_raise(ValueError, msg + " and cannot have unknown"
+					" characters.", only_warn)
+
 	return X
+
+
+def validate_input(
+	X: torch.Tensor,
+	name: str = "input",
+	shape: tuple[int, ...] | None = None,
+	dtype: torch.dtype | None = None,
+	min_value: float | None = None,
+	max_value: float | None = None,
+	ohe: bool = False,
+	ohe_dim: int = 1,
+	allow_N: bool = False,
+	only_warn: bool = False,
+) -> torch.Tensor:
+	"""Public wrapper around the input-validation routine.
+
+	Forwards every argument to `_validate_input`. Use this when you want to
+	pre-flight your own tensor against the same shape / dtype / one-hot /
+	value-range checks the library applies internally; with `only_warn=True`
+	you can get a non-raising mode that emits a `TangermemeWarning` instead.
+
+	The underscored `_validate_input` is retained as an alias for backward
+	compatibility with code (including tests and tutorials) that already
+	imports it.
+	"""
+
+	return _validate_input(
+		X, name, shape=shape, dtype=dtype, min_value=min_value,
+		max_value=max_value, ohe=ohe, ohe_dim=ohe_dim, allow_N=allow_N,
+		only_warn=only_warn,
+	)
 
 
 def _cast_as_tensor(

--- a/tangermeme/utils.py
+++ b/tangermeme/utils.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import random
 import warnings
 from typing import Any
 
@@ -856,3 +857,148 @@ def extract_signal(
 		Y[i] = X[idx, :, start:end].sum(dim=-1)
 
 	return Y
+
+
+def set_seed(seed: int) -> None:
+	"""Seed every RNG that tangermeme code paths might touch.
+
+	Calls `random.seed`, `numpy.random.seed`, `torch.manual_seed`, and
+	`torch.cuda.manual_seed_all`. This is a convenience for the common
+	case where a notebook or script wants "one seed for everything";
+	functions that accept a `random_state=` keyword still take precedence
+	when one is provided.
+
+	Parameters
+	----------
+	seed: int
+		The seed to use for all RNGs.
+	"""
+
+	random.seed(seed)
+	numpy.random.seed(seed)
+	torch.manual_seed(seed)
+	if torch.cuda.is_available():
+		torch.cuda.manual_seed_all(seed)
+
+
+def gc_content(
+	X: torch.Tensor,
+	alphabet: list[str] | tuple[str, ...] = ['A', 'C', 'G', 'T'],
+) -> torch.Tensor:
+	"""Compute the GC content of one-hot encoded sequences.
+
+	The GC content is the fraction of positions whose character is either
+	G or C. Positions that are all-N (sum == 0 along the alphabet axis)
+	are excluded from both numerator and denominator. If a sequence has
+	zero non-N positions its GC content is reported as 0.
+
+	Parameters
+	----------
+	X: torch.Tensor, shape=(-1, len(alphabet), length)
+		A one-hot encoded set of sequences.
+
+	alphabet: list[str] or tuple[str, ...], optional
+		The alphabet whose ordering matches `X`'s second axis. Used only
+		to locate G and C; the rest of the alphabet is ignored. Default
+		is ['A', 'C', 'G', 'T'].
+
+
+	Returns
+	-------
+	gc: torch.Tensor, shape=(-1,)
+		The GC content of each sequence, as a float in [0, 1].
+	"""
+
+	_validate_input(X, "X", shape=(-1, len(alphabet), -1), ohe=True, allow_N=True)
+
+	gc_idxs = [i for i, c in enumerate(alphabet) if c in ('G', 'C')]
+	if len(gc_idxs) == 0:
+		raise ValueError("Alphabet {} does not contain G or C; gc_content "
+			"is only defined for alphabets containing both.".format(alphabet))
+
+	X_float = X.float()
+	non_n = X_float.sum(dim=1)  # (-1, length)
+	gc = X_float[:, gc_idxs].sum(dim=(1, 2))
+	total = non_n.sum(dim=-1)
+	return torch.where(total > 0, gc / total.clamp(min=1), torch.zeros_like(gc))
+
+
+def entropy(
+	X: torch.Tensor,
+	eps: float = 1e-9,
+) -> torch.Tensor:
+	"""Compute the Shannon entropy (in bits) at each position.
+
+	Each position is treated as a probability distribution over the
+	alphabet axis. `X` may already be a PWM (probabilities) or a one-hot
+	encoding; columns are renormalized to sum to 1 before the entropy
+	is computed. Columns whose values sum to 0 contribute zero entropy.
+
+	Parameters
+	----------
+	X: torch.Tensor, shape=(-1, alphabet, length)
+		The input PWM or one-hot encoding.
+
+	eps: float, optional
+		A small constant added under the log to avoid log(0). Default
+		is 1e-9.
+
+
+	Returns
+	-------
+	H: torch.Tensor, shape=(-1, length)
+		The per-position entropy in bits.
+	"""
+
+	X_float = X.float()
+	col_sum = X_float.sum(dim=1, keepdim=True)
+	probs = X_float / col_sum.clamp(min=eps)
+	zero_col = (col_sum.squeeze(1) == 0)
+
+	H = -(probs * torch.log2(probs + eps)).sum(dim=1)
+	H[zero_col] = 0.0
+	return H
+
+
+def information_content(
+	X: torch.Tensor,
+	alphabet_size: int | None = None,
+	eps: float = 1e-9,
+) -> torch.Tensor:
+	"""Compute per-position information content (in bits).
+
+	Information content is `log2(alphabet_size) - entropy`. Columns
+	that sum to zero are reported as 0 (rather than the maximum,
+	`log2(alphabet_size)`) so all-N positions do not appear informative.
+
+	Parameters
+	----------
+	X: torch.Tensor, shape=(-1, alphabet, length)
+		The input PWM or one-hot encoding.
+
+	alphabet_size: int or None, optional
+		The size of the alphabet to use when computing the maximum
+		entropy. If None, use `X.shape[1]`. Default is None.
+
+	eps: float, optional
+		A small constant for numerical stability in the entropy
+		computation. Default is 1e-9.
+
+
+	Returns
+	-------
+	IC: torch.Tensor, shape=(-1, length)
+		The per-position information content in bits.
+	"""
+
+	if alphabet_size is None:
+		alphabet_size = X.shape[1]
+
+	X_float = X.float()
+	col_sum = X_float.sum(dim=1, keepdim=True)
+	zero_col = (col_sum.squeeze(1) == 0)
+
+	max_h = float(numpy.log2(alphabet_size))
+	IC = max_h - entropy(X_float, eps=eps)
+	IC[zero_col] = 0.0
+	return IC

--- a/tests/test_ablate.py
+++ b/tests/test_ablate.py
@@ -1099,3 +1099,12 @@ def test_ablate_func_saturation_mutagenesis(X, device):
 		    0.0000, -0.0244, -0.0000],
 		  [ 0.0000, -0.0000,  0.0000, -0.0000,  0.0000, -0.0029,  0.0000,
 		   -0.0000,  0.0000, -0.0011]]]], 4)
+
+
+def test_ablate_annotations_empty(X, device):
+	torch.manual_seed(0)
+	model = FlattenDense()
+	annotations = torch.zeros(0, 3, dtype=torch.int64)
+
+	assert_raises(ValueError, ablate_annotations, model, X, annotations,
+		device=device)

--- a/tests/test_deep_lift_shap.py
+++ b/tests/test_deep_lift_shap.py
@@ -1823,3 +1823,12 @@ def test_deep_lift_shap_invalid_target(X, device):
 
 	assert_raises(IndexError, deep_lift_shap, model, X[:2], target=999,
 		n_shuffles=2, device=device, random_state=0)
+
+
+def test_deep_lift_shap_empty_X(device):
+	torch.manual_seed(0)
+	model = FlattenDense(n_outputs=1)
+	X_empty = torch.zeros(0, 4, 100)
+
+	assert_raises(ValueError, deep_lift_shap, model, X_empty,
+		n_shuffles=2, device=device, random_state=0)

--- a/tests/test_marginalize.py
+++ b/tests/test_marginalize.py
@@ -765,3 +765,13 @@ def test_marginalize_func_saturation_mutagenesis(X, device):
 		   0.0000, -0.0000, -0.0396],
 		 [ 0.0000, -0.0073,  0.0000, -0.0000,  0.0000, -0.0000,  0.0258,
 		  -0.0000,  0.0097, -0.0000]]], 4)
+
+
+def test_marginalize_annotations_empty(X, device):
+	torch.manual_seed(0)
+	model = FlattenDense()
+	X0 = X.clone()
+	annotations = torch.zeros(0, 3, dtype=torch.int64)
+
+	assert_raises(ValueError, marginalize_annotations, model, X, X0,
+		annotations, device=device)

--- a/tests/test_pisa.py
+++ b/tests/test_pisa.py
@@ -1030,3 +1030,12 @@ def test_pisa_model_unchanged_after_call(X, device):
 		assert not hasattr(module, "_NON_LINEAR_OPS")
 		if hasattr(module, "handles"):
 			assert len(module.handles) == 0
+
+
+def test_pisa_empty_X(device):
+	torch.manual_seed(0)
+	model = FlattenDense(n_outputs=1)
+	X_empty = torch.zeros(0, 4, 100)
+
+	assert_raises(ValueError, pisa, model, X_empty, n_shuffles=2,
+		device=device, random_state=0)

--- a/tests/test_seqlet.py
+++ b/tests/test_seqlet.py
@@ -353,3 +353,11 @@ def test_tfmodisco_seqlets_determinism(X_contrib):
 	seqlets1 = tfmodisco_seqlets(X_contrib)
 
 	assert_array_almost_equal(seqlets0.values, seqlets1.values, 4)
+
+
+def test_recursive_seqlets_empty():
+	assert_raises(ValueError, recursive_seqlets, torch.zeros(0, 100))
+
+
+def test_tfmodisco_seqlets_empty():
+	assert_raises(ValueError, tfmodisco_seqlets, torch.zeros(0, 100))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,9 +4,12 @@
 import numpy
 import torch
 import pandas
+import pytest
 
 
 from tangermeme.utils import _validate_input
+from tangermeme.utils import validate_input
+from tangermeme.utils import TangermemeWarning
 from tangermeme.utils import characters
 from tangermeme.utils import one_hot_encode
 from tangermeme.utils import reverse_complement
@@ -139,6 +142,32 @@ def test_validate_input_allow_N(device):
 	X[0, 1, 0] = 0.5
 	assert_raises(ValueError, _validate_input, X, "X", ohe=True, ohe_dim=1,
 		allow_N=True)
+
+
+def test_validate_input_all_zero_with_allow_N(device):
+	# An all-zero tensor represents a sequence where every position is
+	# unknown (N). With allow_N=True this is a valid one-hot encoding
+	# and must not be rejected. The previous len(unique(X)) == 2 check
+	# tripped on this case because unique returned just [0].
+	X = torch.zeros(1, 4, 5, dtype=torch.int8).to(device)
+	_validate_input(X, "X", ohe=True, ohe_dim=1, allow_N=True)
+
+	# Without allow_N, every position must have exactly one 1; an all-N
+	# input must still raise.
+	assert_raises(ValueError, _validate_input, X, "X", ohe=True, ohe_dim=1)
+
+
+def test_public_validate_input_wrapper(device):
+	# The public validate_input forwards to the internal helper.
+	X = random_one_hot((2, 4, 10), random_state=0).to(device)
+	validate_input(X, "X", ohe=True, ohe_dim=1)
+
+	# Bad input raises as expected.
+	assert_raises(ValueError, validate_input, X + 0.5, "X", ohe=True)
+
+	# only_warn=True surfaces a TangermemeWarning instead of raising.
+	with pytest.warns(TangermemeWarning):
+		validate_input(X + 0.5, "X", ohe=True, only_warn=True)
 
 
 ##

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,6 +10,10 @@ import pytest
 from tangermeme.utils import _validate_input
 from tangermeme.utils import validate_input
 from tangermeme.utils import TangermemeWarning
+from tangermeme.utils import set_seed
+from tangermeme.utils import gc_content
+from tangermeme.utils import entropy
+from tangermeme.utils import information_content
 from tangermeme.utils import characters
 from tangermeme.utils import one_hot_encode
 from tangermeme.utils import reverse_complement
@@ -744,3 +748,92 @@ def test_example_to_fasta_coords_window():
 	# example start=10 -> 135, end=20 -> 145.
 	assert int(out['start'].iloc[0]) == 135
 	assert int(out['end'].iloc[0]) == 145
+
+
+##
+
+
+def test_set_seed_is_deterministic():
+	# After calling set_seed with the same seed twice, all RNGs should
+	# produce identical sequences.
+	import random
+
+	set_seed(0)
+	a_py = random.random()
+	a_np = numpy.random.rand()
+	a_torch = torch.rand(1).item()
+
+	set_seed(0)
+	b_py = random.random()
+	b_np = numpy.random.rand()
+	b_torch = torch.rand(1).item()
+
+	assert a_py == b_py
+	assert a_np == b_np
+	assert a_torch == b_torch
+
+	set_seed(1)
+	c_torch = torch.rand(1).item()
+	assert a_torch != c_torch
+
+
+def test_gc_content_basic():
+	# Build a tensor where the first sequence is all-A (GC=0), the second
+	# all-G (GC=1), the third half C / half T (GC=0.5).
+	X = torch.zeros(3, 4, 4, dtype=torch.float32)
+	X[0, 0, :] = 1  # AAAA
+	X[1, 2, :] = 1  # GGGG
+	X[2, 1, :2] = 1  # CC..
+	X[2, 3, 2:] = 1  # ..TT
+
+	gc = gc_content(X)
+	assert gc.shape == (3,)
+	assert float(gc[0]) == 0.0
+	assert float(gc[1]) == 1.0
+	assert float(gc[2]) == 0.5
+
+
+def test_gc_content_all_N_is_zero():
+	X = torch.zeros(1, 4, 5, dtype=torch.float32)
+	gc = gc_content(X)
+	assert float(gc[0]) == 0.0
+
+
+def test_entropy_uniform_is_log2_4():
+	# A perfectly uniform PWM has entropy = log2(4) = 2 bits per position.
+	X = torch.full((1, 4, 3), 0.25)
+	H = entropy(X)
+	assert H.shape == (1, 3)
+	assert_array_almost_equal(H, [[2.0, 2.0, 2.0]], 4)
+
+
+def test_entropy_one_hot_is_zero():
+	X = torch.zeros(1, 4, 3)
+	X[0, 0, 0] = 1.0
+	X[0, 1, 1] = 1.0
+	X[0, 2, 2] = 1.0
+	H = entropy(X)
+	assert_array_almost_equal(H, [[0.0, 0.0, 0.0]], 4)
+
+
+def test_entropy_all_N_column_is_zero():
+	X = torch.zeros(1, 4, 1)
+	H = entropy(X)
+	assert float(H[0, 0]) == 0.0
+
+
+def test_information_content_complementary_to_entropy():
+	X = torch.full((1, 4, 3), 0.25)
+	IC = information_content(X)
+	assert_array_almost_equal(IC, [[0.0, 0.0, 0.0]], 4)
+
+	X = torch.zeros(1, 4, 3)
+	X[0, 0, :] = 1.0
+	IC = information_content(X)
+	assert_array_almost_equal(IC, [[2.0, 2.0, 2.0]], 4)
+
+
+def test_information_content_all_N_is_zero():
+	X = torch.zeros(1, 4, 1)
+	IC = information_content(X)
+	assert float(IC[0, 0]) == 0.0


### PR DESCRIPTION
## Summary

Three additive groups of changes:

### 3B. `_validate_input` upgrade

- **Fix the all-zero OHE rejection bug.** The one-hot validation gate asserted `len(torch.unique(X)) == 2`, which incorrectly rejected one-hot tensors whose unique value set was `{0}` — i.e., an all-N motif under `allow_N=True`. Switched to a subset-membership check (every value is 0 or 1); the existing per-position sum check downstream already handles `sum == 1` vs `sum <= 1` semantics.
- **Expose a public `tangermeme.utils.validate_input`.** Forwards every argument to `_validate_input`. Lets callers pre-flight their own tensors against the same checks the library applies internally, including `only_warn=True` for a non-raising mode that emits `TangermemeWarning`. The underscored `_validate_input` is retained as an alias.

### 3A. Empty-input validation

Six entry points each crashed with a cryptic message on empty input:

- `predict` and `pisa`: `range() arg 3 must not be zero`
- `deep_lift_shap`: `stack expects a non-empty TensorList`
- `ablate_annotations` / `marginalize_annotations`: `IndexError: list index out of range`
- `recursive_seqlets`: `zero-size array to reduction operation`
- `tfmodisco_seqlets`: `quantile() input tensor must be non-empty`

Each now raises a clear `ValueError` at the top of the function naming what was empty.

### 3F. Diagnostics helpers

Four small utilities currently re-derived in every notebook:

- `set_seed(seed)` — seeds `random`, `numpy.random`, `torch` (CPU), and `torch.cuda` in one call.
- `gc_content(X, alphabet=['A','C','G','T'])` — per-sequence GC fraction; excludes all-N positions.
- `entropy(X, eps=1e-9)` — per-position Shannon entropy in bits; renormalizes columns so PWMs and one-hot encodings both work; all-N columns return 0.
- `information_content(X, alphabet_size=None, eps=1e-9)` — `log2(alphabet_size) - entropy`, with the same all-N treatment.

## Test plan

- [x] `uv run pytest` — 860 passed, 2 skipped (was 838 before this branch; +22 new tests: 2 for `_validate_input`/`validate_input`, 12 for empty-input across cpu/cuda, 8 for diagnostics).
- [x] Each new regression test added in the same commit as the relevant change; verified to fail before the fix where applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)