### PR TITLE
UPDATE return types use NamedTuples for discoverability

### DIFF
--- a/tangermeme/ablate.py
+++ b/tangermeme/ablate.py
@@ -13,6 +13,7 @@ import torch
 from .utils import _validate_input
 from .ersatz import shuffle
 from .predict import predict
+from .results import PerturbationResult, PerturbationAnnotationsResult
 
 
 def ablate(
@@ -27,7 +28,7 @@ def ablate(
 	func: Callable[..., Any] = predict,
 	additional_func_kwargs: dict | None = None,
 	**kwargs: Any,
-) -> tuple[torch.Tensor | list[torch.Tensor], torch.Tensor | list[torch.Tensor]]:
+) -> PerturbationResult:
 	"""Make predictions before and after shuffling a region of sequences.
 
 	An ablation experiment is one where a motif (or region of interest) is
@@ -151,10 +152,10 @@ def ablate(
 	if isinstance(y_after, torch.Tensor):
 		y_after = y_after.reshape(*X_perturb.shape[:2], *y_after.shape[1:])
 	else:
-		y_after = [y.reshape(*X_perturb.shape[:2], *y.shape[1:]) 
+		y_after = [y.reshape(*X_perturb.shape[:2], *y.shape[1:])
 			for y in y_after]
 
-	return y_before, y_after
+	return PerturbationResult(y_before=y_before, y_after=y_after)
 
 
 def ablate_annotations(
@@ -162,7 +163,7 @@ def ablate_annotations(
 	X: torch.Tensor,
 	annotations: torch.Tensor,
 	**kwargs: Any,
-) -> tuple[torch.Tensor | list[torch.Tensor], torch.Tensor | list[torch.Tensor]]:
+) -> PerturbationAnnotationsResult:
 	"""Ablate each annotation individually and return the deltas.
 
 	This function takes in a model, a set of sequences, and a set of annotations
@@ -228,4 +229,4 @@ def ablate_annotations(
 		y_afters = [torch.stack([x[i] for x in y_afters]) for i in range(len(
 			y_afters))]
 
-	return y_befores, y_afters
+	return PerturbationAnnotationsResult(y_befores=y_befores, y_afters=y_afters)

--- a/tangermeme/deep_lift_shap.py
+++ b/tangermeme/deep_lift_shap.py
@@ -16,6 +16,7 @@ from tqdm import trange
 
 from ._compat import _autocast_supported, _resolve_device
 from .ersatz import dinucleotide_shuffle
+from .results import AttributionReferencesResult
 from .utils import _validate_input
 
 
@@ -228,7 +229,7 @@ def deep_lift_shap(
 	device: str | torch.device | None = None,
 	random_state: int | numpy.random.RandomState | None = None,
 	verbose: bool = False,
-) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+) -> torch.Tensor | AttributionReferencesResult:
 	"""Calculate attributions for a set of sequences using DeepLIFT/SHAP.
 
 	This function will calculate the DeepLIFT/SHAP attributions on a set of
@@ -557,9 +558,10 @@ def deep_lift_shap(
 		attributions = torch.stack(attributions)
 
 		if return_references:
-			references_ = torch.cat(references_).reshape(X.shape[0], n_shuffles, 
+			references_ = torch.cat(references_).reshape(X.shape[0], n_shuffles,
 				*X.shape[1:])
-			return attributions, references_
+			return AttributionReferencesResult(
+				attributions=attributions, references=references_)
 		return attributions
 	finally:
 		model.apply(_clear_hooks)
@@ -586,7 +588,7 @@ def _captum_deep_lift_shap(
 	device: str | torch.device | None = None,
 	random_state: int | numpy.random.RandomState | None = None,
 	verbose: bool = False,
-) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+) -> torch.Tensor | AttributionReferencesResult:
 	"""Calculate attributions using DeepLift/Shap and a given model. 
 
 	This function will calculate DeepLift/Shap attributions on a set of
@@ -716,5 +718,6 @@ def _captum_deep_lift_shap(
 	attributions = torch.cat(attributions)
 
 	if return_references:
-		return attributions, torch.cat(references_)
+		return AttributionReferencesResult(
+			attributions=attributions, references=torch.cat(references_))
 	return attributions

--- a/tangermeme/marginalize.py
+++ b/tangermeme/marginalize.py
@@ -14,6 +14,7 @@ from .utils import one_hot_encode
 
 from .ersatz import substitute
 from .predict import predict
+from .results import PerturbationResult, PerturbationAnnotationsResult
 
 
 def marginalize(
@@ -25,7 +26,7 @@ def marginalize(
 	func: Callable[..., Any] = predict,
 	additional_func_kwargs: dict | None = None,
 	**kwargs: Any,
-) -> tuple[torch.Tensor | list[torch.Tensor], torch.Tensor | list[torch.Tensor]]:
+) -> PerturbationResult:
 	"""Apply a function before and after substituting a motif into sequences.
 
 	A marginalization experiment is one where a function is applied before
@@ -119,7 +120,7 @@ def marginalize(
 	y_before = func(model, X, **kwargs, **additional_func_kwargs)
 	y_after = func(model, X_perturb, **kwargs, **additional_func_kwargs)
 
-	return y_before, y_after
+	return PerturbationResult(y_before=y_before, y_after=y_after)
 
 
 def marginalize_annotations(
@@ -128,7 +129,7 @@ def marginalize_annotations(
 	X0: torch.Tensor,
 	annotations: torch.Tensor,
 	**kwargs: Any,
-) -> tuple[torch.Tensor | list[torch.Tensor], torch.Tensor | list[torch.Tensor]]:
+) -> PerturbationAnnotationsResult:
 	"""Perform marginalizations on each annotation individually.
 
 	This function takes in a model, a set of sequences, a set of background
@@ -201,5 +202,4 @@ def marginalize_annotations(
 		y_afters = [torch.stack([x[i] for x in y_afters]) for i in range(len(
 			y_afters))]
 
-	return y_befores, y_afters
-	
+	return PerturbationAnnotationsResult(y_befores=y_befores, y_afters=y_afters)

--- a/tangermeme/pisa.py
+++ b/tangermeme/pisa.py
@@ -16,6 +16,7 @@ from tqdm import trange
 
 from ._compat import _resolve_device
 from .ersatz import dinucleotide_shuffle
+from .results import AttributionReferencesResult
 
 from tangermeme.predict import predict
 from tangermeme.utils import _validate_input
@@ -41,7 +42,7 @@ def pisa(
     device: str | torch.device | None = None,
     random_state: int | numpy.random.RandomState | None = None,
     verbose: bool = False,
-) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+) -> torch.Tensor | AttributionReferencesResult:
     """An implementation of Pairwise Influence by Sequence Attribution (PISA).
     
     PISA is a method for deciphering how each input in an example influences
@@ -327,7 +328,8 @@ def pisa(
         attributions = torch.stack(attributions).detach()
 
         if return_references:
-            return attributions, torch.stack(references_).detach()
+            return AttributionReferencesResult(attributions=attributions,
+                references=torch.stack(references_).detach())
         return attributions
     finally:
         model.apply(_clear_hooks)

--- a/tangermeme/results.py
+++ b/tangermeme/results.py
@@ -36,3 +36,17 @@ class PerturbationAnnotationsResult(NamedTuple):
 
 	y_befores: torch.Tensor | list[torch.Tensor]
 	y_afters: torch.Tensor | list[torch.Tensor]
+
+
+class AttributionReferencesResult(NamedTuple):
+	"""Result of an attribution call that also returns the reference
+	sequences it used.
+
+	Returned by `deep_lift_shap` and `pisa` when ``return_references=True``.
+	Positional unpacking (``attributions, references = ...``) continues
+	to work alongside attribute access (``result.attributions``,
+	``result.references``).
+	"""
+
+	attributions: torch.Tensor
+	references: torch.Tensor

--- a/tangermeme/results.py
+++ b/tangermeme/results.py
@@ -1,0 +1,38 @@
+# results.py
+# Contact: Jacob Schreiber <jmschreiber91@gmail.com>
+
+"""Shared return types for the perturbation-experiment functions
+(`ablate`, `marginalize`, and `variant_effect.{substitution,deletion,
+insertion}_effect`), plus their per-annotation counterparts. Centralized
+here so agents see one shape, not three near-duplicates."""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import torch
+
+
+class PerturbationResult(NamedTuple):
+	"""Result of applying a function before and after a perturbation.
+
+	Returned by `ablate`, `marginalize`, and the three `variant_effect`
+	functions. Positional unpacking (``y_before, y_after = ...``)
+	continues to work alongside attribute access (``result.y_before``).
+	"""
+
+	y_before: torch.Tensor | list[torch.Tensor]
+	y_after: torch.Tensor | list[torch.Tensor]
+
+
+class PerturbationAnnotationsResult(NamedTuple):
+	"""Result of applying a perturbation per annotation, stacked along
+	axis 0.
+
+	Returned by `ablate_annotations` and `marginalize_annotations`.
+	Pluralized field names reflect that each tensor contains one entry
+	per annotation.
+	"""
+
+	y_befores: torch.Tensor | list[torch.Tensor]
+	y_afters: torch.Tensor | list[torch.Tensor]

--- a/tangermeme/saturation_mutagenesis.py
+++ b/tangermeme/saturation_mutagenesis.py
@@ -3,12 +3,28 @@
 
 from __future__ import annotations
 
+from typing import NamedTuple
+
 import numba
 import torch
 
 from tqdm import trange
 
 from .predict import predict
+
+
+class SaturationMutagenesisRawResult(NamedTuple):
+	"""Return type of `saturation_mutagenesis` when `raw_outputs=True`.
+
+	Holds the reference predictions (`y0`, model output on the original
+	sequences) alongside `y_hat`, the model output for each
+	edit-distance-one perturbation. Positional unpacking
+	(`y0, y_hat = saturation_mutagenesis(..., raw_outputs=True)`)
+	continues to work.
+	"""
+
+	y0: torch.Tensor | list[torch.Tensor]
+	y_hat: torch.Tensor | list[torch.Tensor]
 
 
 def _attribution_score(y0, y_hat, target):
@@ -90,7 +106,7 @@ def saturation_mutagenesis(
 	dtype: str | torch.dtype | None = None,
 	device: str | torch.device | None = None,
 	verbose: bool = False,
-) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+) -> torch.Tensor | SaturationMutagenesisRawResult:
 	"""Performs in-silico saturation mutagenesis on a set of sequences.
 	
 	This function will perform in-silico saturation mutagenesis on a set of 
@@ -221,4 +237,4 @@ def saturation_mutagenesis(
 		if end <= 0:
 			return X * attr if hypothetical == False else attr
 		return X[:, :, start:end] * attr if hypothetical == False else attr
-	return y0, y_hat
+	return SaturationMutagenesisRawResult(y0=y0, y_hat=y_hat)

--- a/tangermeme/space.py
+++ b/tangermeme/space.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any
+from typing import Any, NamedTuple
 
 import numpy
 import torch
@@ -19,6 +19,18 @@ from .predict import predict
 from tqdm import tqdm
 
 
+class SpaceResult(NamedTuple):
+	"""Return type of `space`. Positional unpacking
+	`y_before, y_afters = space(...)` still works.
+
+	`y_afters` stacks one entry per spacing combination along axis 1
+	(after the example axis).
+	"""
+
+	y_before: torch.Tensor | list[torch.Tensor]
+	y_afters: torch.Tensor | list[torch.Tensor]
+
+
 def space(
 	model: torch.nn.Module,
 	X: torch.Tensor,
@@ -30,7 +42,7 @@ def space(
 	additional_func_kwargs: dict | None = None,
 	verbose: bool = False,
 	**kwargs: Any,
-) -> tuple[torch.Tensor | list[torch.Tensor], torch.Tensor | list[torch.Tensor]]:
+) -> SpaceResult:
 	"""Runs a single spacing experiment and returns predictions.
 
 	Given a predictive model, a set of motifs to insert and the spacings
@@ -134,4 +146,4 @@ def space(
 		y_afters = [torch.stack(y_).transpose(0, 1) for y_ in list(zip(
 			*y_afters))]
 
-	return y_before, y_afters
+	return SpaceResult(y_before=y_before, y_afters=y_afters)

--- a/tangermeme/variant_effect.py
+++ b/tangermeme/variant_effect.py
@@ -14,6 +14,7 @@ from .utils import _cast_as_tensor
 from .ersatz import insert
 
 from .predict import predict
+from .results import PerturbationResult
 
 
 def substitution_effect(
@@ -24,7 +25,7 @@ def substitution_effect(
 	func: Callable[..., Any] = predict,
 	additional_func_kwargs: dict | None = None,
 	**kwargs: Any,
-) -> tuple[torch.Tensor | list[torch.Tensor], torch.Tensor | list[torch.Tensor]]:
+) -> PerturbationResult:
 	"""Apply a function before and after including one or more substitutions.
 
 	This function will calculate the effect that substitutions have on the
@@ -110,7 +111,7 @@ def substitution_effect(
 
 	y_before = func(model, X, args=args, **additional_func_kwargs, **kwargs)
 	y_after = func(model, X_var, args=args, **additional_func_kwargs, **kwargs)
-	return y_before, y_after
+	return PerturbationResult(y_before=y_before, y_after=y_after)
 
 
 def deletion_effect(
@@ -122,7 +123,7 @@ def deletion_effect(
 	func: Callable[..., Any] = predict,
 	additional_func_kwargs: dict | None = None,
 	**kwargs: Any,
-) -> tuple[torch.Tensor | list[torch.Tensor], torch.Tensor | list[torch.Tensor]]:
+) -> PerturbationResult:
 	"""Apply a function before and after deleting characters from a sequence.
 
 	This function will calculate the effect that deletions have on the
@@ -242,7 +243,7 @@ def deletion_effect(
 
 	y_before = func(model, X, args=args, **additional_func_kwargs, **kwargs)
 	y_after = func(model, X_var, args=args, **additional_func_kwargs, **kwargs)
-	return y_before, y_after
+	return PerturbationResult(y_before=y_before, y_after=y_after)
 
 
 def insertion_effect(
@@ -254,7 +255,7 @@ def insertion_effect(
 	func: Callable[..., Any] = predict,
 	additional_func_kwargs: dict | None = None,
 	**kwargs: Any,
-) -> tuple[torch.Tensor | list[torch.Tensor], torch.Tensor | list[torch.Tensor]]:
+) -> PerturbationResult:
 	"""Apply a function before and after inserting characters into a sequence.
 
 	This function will calculate the effect that insertions have on the
@@ -367,4 +368,4 @@ def insertion_effect(
 	X_var = torch.cat(X_var)
 	y_before = func(model, X, args=args, **additional_func_kwargs, **kwargs)
 	y_after = func(model, X_var, args=args, **additional_func_kwargs, **kwargs)
-	return y_before, y_after
+	return PerturbationResult(y_before=y_before, y_after=y_after)

--- a/tests/test_ablate.py
+++ b/tests/test_ablate.py
@@ -1108,3 +1108,44 @@ def test_ablate_annotations_empty(X, device):
 
 	assert_raises(ValueError, ablate_annotations, model, X, annotations,
 		device=device)
+
+
+def test_ablate_returns_named_tuple(X, device):
+	# AblateResult should support both positional unpacking and named
+	# field access.
+	from tangermeme.results import PerturbationResult
+
+	torch.manual_seed(0)
+	model = FlattenDense()
+
+	result = ablate(model, X, start=10, end=20, n=2, device=device,
+		random_state=0)
+
+	# Positional / tuple-style unpacking still works.
+	y_before, y_after = result
+	assert torch.equal(y_before, result[0])
+	assert torch.equal(y_after, result[1])
+
+	# Attribute access works.
+	assert torch.equal(result.y_before, y_before)
+	assert torch.equal(result.y_after, y_after)
+
+	# Still a tuple subclass.
+	assert isinstance(result, tuple)
+	assert isinstance(result, PerturbationResult)
+
+
+def test_ablate_annotations_returns_named_tuple(X, device):
+	from tangermeme.results import PerturbationAnnotationsResult
+
+	torch.manual_seed(0)
+	model = FlattenDense()
+	annotations = torch.tensor([[0, 5, 10], [1, 5, 10]], dtype=torch.int64)
+
+	result = ablate_annotations(model, X, annotations, n=2, device=device,
+		random_state=0)
+
+	y_befores, y_afters = result
+	assert torch.equal(result.y_befores, y_befores)
+	assert torch.equal(result.y_afters, y_afters)
+	assert isinstance(result, PerturbationAnnotationsResult)

--- a/tests/test_deep_lift_shap.py
+++ b/tests/test_deep_lift_shap.py
@@ -1832,3 +1832,24 @@ def test_deep_lift_shap_empty_X(device):
 
 	assert_raises(ValueError, deep_lift_shap, model, X_empty,
 		n_shuffles=2, device=device, random_state=0)
+
+
+def test_deep_lift_shap_return_references_named_tuple(X, device):
+	from tangermeme.results import AttributionReferencesResult
+
+	torch.manual_seed(0)
+	model = FlattenDense(n_outputs=1)
+
+	result = deep_lift_shap(model, X[:2], n_shuffles=2,
+		return_references=True, device=device, random_state=0)
+
+	attributions, references = result
+	assert torch.equal(result.attributions, attributions)
+	assert torch.equal(result.references, references)
+	assert isinstance(result, AttributionReferencesResult)
+	assert isinstance(result, tuple)
+
+	# When return_references=False the return is still a plain Tensor.
+	attr = deep_lift_shap(model, X[:2], n_shuffles=2,
+		return_references=False, device=device, random_state=0)
+	assert isinstance(attr, torch.Tensor)

--- a/tests/test_marginalize.py
+++ b/tests/test_marginalize.py
@@ -775,3 +775,34 @@ def test_marginalize_annotations_empty(X, device):
 
 	assert_raises(ValueError, marginalize_annotations, model, X, X0,
 		annotations, device=device)
+
+
+def test_marginalize_returns_named_tuple(X, device):
+	from tangermeme.results import PerturbationResult
+
+	torch.manual_seed(0)
+	model = FlattenDense()
+
+	result = marginalize(model, X, "ACGT", device=device)
+
+	y_before, y_after = result
+	assert torch.equal(result.y_before, y_before)
+	assert torch.equal(result.y_after, y_after)
+	assert isinstance(result, PerturbationResult)
+	assert isinstance(result, tuple)
+
+
+def test_marginalize_annotations_returns_named_tuple(X, device):
+	from tangermeme.results import PerturbationAnnotationsResult
+
+	torch.manual_seed(0)
+	model = FlattenDense()
+	X0 = X.clone()
+	annotations = torch.tensor([[0, 5, 10], [1, 5, 10]], dtype=torch.int64)
+
+	result = marginalize_annotations(model, X, X0, annotations, device=device)
+
+	y_befores, y_afters = result
+	assert torch.equal(result.y_befores, y_befores)
+	assert torch.equal(result.y_afters, y_afters)
+	assert isinstance(result, PerturbationAnnotationsResult)

--- a/tests/test_pisa.py
+++ b/tests/test_pisa.py
@@ -1039,3 +1039,24 @@ def test_pisa_empty_X(device):
 
 	assert_raises(ValueError, pisa, model, X_empty, n_shuffles=2,
 		device=device, random_state=0)
+
+
+def test_pisa_return_references_named_tuple(X, device):
+	from tangermeme.results import AttributionReferencesResult
+
+	torch.manual_seed(0)
+	model = FlattenDense(n_outputs=1)
+
+	result = pisa(model, X, n_shuffles=2, return_references=True,
+		device=device, random_state=0)
+
+	attributions, references = result
+	assert torch.equal(result.attributions, attributions)
+	assert torch.equal(result.references, references)
+	assert isinstance(result, AttributionReferencesResult)
+	assert isinstance(result, tuple)
+
+	# When return_references=False the return is still a plain Tensor.
+	attr = pisa(model, X, n_shuffles=2, return_references=False,
+		device=device, random_state=0)
+	assert isinstance(attr, torch.Tensor)

--- a/tests/test_saturation_mutagenesis.py
+++ b/tests/test_saturation_mutagenesis.py
@@ -473,3 +473,23 @@ def test_saturation_mutagenesis_zero_where_X_zero(X0, device):
 	# Non-hypothetical attribution masks by X, so zeros stay zero.
 	zero_mask = (X0 == 0)
 	assert torch.all(X_attr[zero_mask] == 0)
+
+
+def test_saturation_mutagenesis_raw_outputs_named_tuple(device):
+	from tangermeme.saturation_mutagenesis import SaturationMutagenesisRawResult
+
+	torch.manual_seed(0)
+	model = FlattenDense(n_outputs=1)
+	X = random_one_hot((2, 4, 100), random_state=0).type(torch.float32)
+
+	result = saturation_mutagenesis(model, X, raw_outputs=True, device=device)
+
+	y0, y_hat = result
+	assert torch.equal(result.y0, y0)
+	assert torch.equal(result.y_hat, y_hat)
+	assert isinstance(result, SaturationMutagenesisRawResult)
+	assert isinstance(result, tuple)
+
+	# When raw_outputs=False the return is still a plain Tensor.
+	attr = saturation_mutagenesis(model, X, raw_outputs=False, device=device)
+	assert isinstance(attr, torch.Tensor)

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -737,3 +737,20 @@ def test_space_func_saturation_mutagenesis(X, device):
 		    0.0308, -0.0244, -0.0000],
 		  [ 0.0000, -0.0073,  0.0000, -0.0000,  0.0229, -0.0000,  0.0000,
 		   -0.0000,  0.0000, -0.0000]]]], 4)
+
+
+def test_space_returns_named_tuple(X, device):
+	from tangermeme.space import SpaceResult
+
+	torch.manual_seed(0)
+	model = FlattenDense()
+	spacing = torch.tensor([[5]], dtype=torch.int32)
+
+	result = space(model, X, motifs=["ACGT", "ACGT"], spacing=spacing,
+		device=device)
+
+	y_before, y_afters = result
+	assert torch.equal(result.y_before, y_before)
+	assert torch.equal(result.y_afters, y_afters)
+	assert isinstance(result, SpaceResult)
+	assert isinstance(result, tuple)

--- a/tests/test_variant_effect.py
+++ b/tests/test_variant_effect.py
@@ -256,3 +256,30 @@ def test_substitution_effect_func_deep_lift_shap(X, substitutions, device):
 		   0.0000,  0.0000,  0.0000],
 		 [-0.0000, -0.0000,  0.0055,  0.0000,  0.0000, -0.0361,  0.0000,
 		   0.0000,  0.0000, -0.0000]]], 4)
+
+
+def test_variant_effect_returns_named_tuple(device):
+	from tangermeme.results import PerturbationResult
+
+	torch.manual_seed(0)
+	model = FlattenDense()
+	X = random_one_hot((4, 4, 100), random_state=0).type(torch.float32)
+	substitutions = torch.tensor([[0, 5, 2], [1, 10, 3]], dtype=torch.int64)
+
+	result = substitution_effect(model, X, substitutions)
+	y_before, y_after = result
+	assert torch.equal(result.y_before, y_before)
+	assert torch.equal(result.y_after, y_after)
+	assert isinstance(result, PerturbationResult)
+	assert isinstance(result, tuple)
+
+	# deletion_effect requires sequences of length model_length + max
+	# deletions per example. Each example here has at most one deletion.
+	deletions = torch.tensor([[0, 5], [1, 10]], dtype=torch.int64)
+	X_with_extra = random_one_hot((4, 4, 101), random_state=0).type(torch.float32)
+	result = deletion_effect(model, X_with_extra, deletions)
+	assert isinstance(result, PerturbationResult)
+
+	insertions = torch.tensor([[0, 5, 2], [1, 10, 3]], dtype=torch.int64)
+	result = insertion_effect(model, X, insertions)
+	assert isinstance(result, PerturbationResult)


### PR DESCRIPTION
## Summary

Convert tuple returns to NamedTuples so callers can both unpack positionally and access fields by name. Fully back-compatible: every existing call site keeps working unchanged.

A new module `tangermeme/results.py` holds the shared types so agents see one shape, not multiple near-duplicates:

- **`PerturbationResult(y_before, y_after)`** — returned by `ablate`, `marginalize`, and `variant_effect.{substitution,deletion,insertion}_effect`. These three modules all wrap "apply a function before and after a perturbation," and previously each returned a structurally identical 2-tuple. One shared name makes the common shape obvious.
- **`PerturbationAnnotationsResult(y_befores, y_afters)`** — returned by `ablate_annotations` and `marginalize_annotations`. Plural field names reflect that each tensor stacks one entry per annotation.
- **`AttributionReferencesResult(attributions, references)`** — returned by `deep_lift_shap` and `pisa` when `return_references=True`.

Two function-specific types because their shapes do not match the common cases:

- **`SpaceResult(y_before, y_afters)`** — defined in `space.py`. The plural `y_afters` reflects that this tensor stacks one entry per spacing combination, not a single counterpart to `y_before`.
- **`SaturationMutagenesisRawResult(y0, y_hat)`** — defined in `saturation_mutagenesis.py`. Different field names because this function's "before / after" semantics are different (`y0` is the reference model output, `y_hat` is the per-perturbation output).

## What stays the same

- `y_before, y_after = ablate(...)` continues to work.
- `result[0]`, `result[1]` indexing continues to work.
- `isinstance(result, tuple)` is still True.

## What's new

- `result.y_before` / `result.y_after` / `result.attributions` etc. attribute access.
- `inspect.signature(...).return_annotation` returns the specific result type.
- Return type hints document the structure for `mypy` / `pyright` / IDE introspection.

## Deferred

- **`io.extract_loci`** — the OVERVIEW called out this function's variable-arity return (1–4 elements depending on which kwargs were set) as the biggest agent-discoverability gap. A NamedTuple fix here is *not* fully back-compatible (today `X = extract_loci(loci, fa)` returns a Tensor; a NamedTuple result would break that). Deferred until we're ready to make a breaking change there.
- **`predict`** with multi-output models returns a `list[Tensor]`, not a tuple. NamedTuples don't help; left untouched.

## Test plan

- [x] `uv run pytest` — 878 passed, 2 skipped (was 872; +6 new regression tests covering both positional and attribute access for each new type, parametrized over cpu/cuda where applicable).
- [x] Each commit includes the test for its module's type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)