### PR TITLE
FIX plot side effects (place_new_box mutation, plot_pwm figure, etc.)

### DIFF
--- a/tangermeme/plot.py
+++ b/tangermeme/plot.py
@@ -438,12 +438,13 @@ def plot_logo(
 
 
 def plot_categorical_scatter(
-	X: pandas.DataFrame,
+	X: torch.Tensor,
 	colors: dict | None = None,
+	ax: matplotlib.axes.Axes | None = None,
 	**kwargs: Any,
 ) -> matplotlib.axes.Axes:
 	"""A scatterplot of category weights across a seq, useful for attributions.
-	
+
 	Frequently, when you calculate attributions you are considering a sequence
 	that is too long to be easily visualized in the standard character format,
 	e.g. in `plot_logo`. One could scan the sequence a few times to find the
@@ -452,30 +453,45 @@ def plot_categorical_scatter(
 	which nucleotide is there) and the value is the weight encoded in the matrix.
 	Basically, this is a way to consider attributions on an entire sequence and
 	get a sense for which areas you may want to follow-up with.
-	
+
 	This function is not meant solely for attributions, though. You can put any
 	value in the matrix to be visualized.
-	
-	
+
+
 	Parameters
 	----------
 	X: torch.Tensor, shape=(alphabet_len, length)
 		A sequence to be visualized.
-	
+
 	colors: list or None, optional
 		The colors to use for each category. By default, uses the standard
 		nucleotide color scheme.
-	
+
+	ax: matplotlib.axes.Axes or None, optional
+		The axes to plot on. If None, use the current axes via `plt.gca()`.
+		Default is None.
+
 	**kwargs: any additional arguments
+
+
+	Returns
+	-------
+	ax: matplotlib.axes.Axes
+		The axes on which the scatterplot was drawn.
 	"""
-	
+
+	if ax is None:
+		ax = plt.gca()
+
 	if colors is None:
 		c = [[0, 0.5, 0], [0, 0, 1], [1, 0.65, 0], [1, 0, 0]]
 
 	pos = numpy.arange(X.shape[-1])
 	for i in range(X.shape[0]):
-		idxs = torch.abs(X).argmax(axis=0) == i    
-		plt.scatter(pos[idxs], X.sum(axis=0)[idxs], c=[c[i]], **kwargs)
+		idxs = torch.abs(X).argmax(axis=0) == i
+		ax.scatter(pos[idxs], X.sum(axis=0)[idxs], c=[c[i]], **kwargs)
+
+	return ax
 
 
 def plot_attributions(

--- a/tangermeme/plot.py
+++ b/tangermeme/plot.py
@@ -44,7 +44,11 @@ def place_new_box(
 	n_tracks: int = 4,
 	show_extra: bool = True,
 ) -> tuple[Bbox, int]:
-    """Place annotation text so that it does not overlap with existing text."""
+    """Place annotation text so that it does not overlap with existing text.
+
+    The returned Bbox is a fresh object; the input `box` is not mutated.
+    """
+    box = Bbox.from_extents(box.x0, box.y0, box.x1, box.y1)
     box_height = box.y1 - box.y0
     box.y0 -= box_height
     box.y1 -= box_height
@@ -83,9 +87,13 @@ def place_new_bar(
 ) -> tuple[Bbox, int]:
     """
     Find a position for a new annotation bar such that it does not overlap with previously plotted bars.
+
+    The returned Bbox is a fresh object; the input `box` is not mutated.
     """
     if y_step is None:
         raise ValueError("y_step must be provided.")
+
+    box = Bbox.from_extents(box.x0, box.y0, box.x1, box.y1)
 
     if len(box_list)==0:
         return box, 0

--- a/tangermeme/plot.py
+++ b/tangermeme/plot.py
@@ -586,7 +586,7 @@ def plot_attributions(
 	
 	X_attrs = []
 	for i, model in enumerate(models):
-		X_attr = deep_lift_shap(model, X[i:i+1], **attribute_kwargs)
+		X_attr = func(model, X[i:i+1], **attribute_kwargs)
 		X_attrs.append(X_attr)
 	X_attrs = torch.cat(X_attrs, dim=0).detach()
 	

--- a/tangermeme/plot.py
+++ b/tangermeme/plot.py
@@ -601,16 +601,22 @@ def plot_attributions(
 
 def plot_pwm(
 	pwm: torch.Tensor | numpy.ndarray,
+	ax: matplotlib.axes.Axes | None = None,
 	name: str | None = None,
 	alphabet: list[str] = ['A', 'C', 'G', 'T'],
 	eps: float = 1e-7,
-) -> None:
-	"""Plots an information-content weighted PWM and its reverse complement.
+) -> matplotlib.axes.Axes:
+	"""Plot an information-content weighted PWM as a sequence logo.
 
 	This function takes in a PWM, where the sum across all values in the
-	alphabet is equal to 1, and plots the information-content weighted version
-	of it, as well as the reverse complement. This should be used when you want
-	to visualize a motif, perhaps from a motif database.
+	alphabet is equal to 1, and plots the information-content weighted
+	version of it. To visualize the reverse complement, call this function
+	a second time with `pwm[::-1, ::-1]`.
+
+	The function no longer creates its own figure or calls `plt.show()`;
+	it draws on the provided `ax` (or `plt.gca()` if none is given) and
+	returns the axes used. This matches the convention used by
+	`plot_logo` and `plot_categorical_scatter`.
 
 
 	Parameters
@@ -618,9 +624,12 @@ def plot_pwm(
 	pwm: torch.Tensor or numpy.ndarray, shape=(len(alphabet), length)
 		The PWM to visualize. The rows must sum to 1.
 
+	ax: matplotlib.axes.Axes or None, optional
+		The axes to draw on. If None, use the current axes via
+		`plt.gca()`. Default is None.
+
 	name: str or None, optional
-		The name to put as the title for the plots. If None, do not put
-		anything. Default is None.
+		The title for the plot. If None, no title is set. Default is None.
 
 	alphabet: list, optional
 		A list of characters that comprise the alphabet. Default is
@@ -629,34 +638,29 @@ def plot_pwm(
 	eps: float, optional
 		A small pseudocount to add to counts to make the log work correctly.
 		Default is 1e-7.
+
+
+	Returns
+	-------
+	ax: matplotlib.axes.Axes
+		The axes on which the logo was drawn.
 	"""
 
 	if isinstance(pwm, torch.Tensor):
 		pwm = pwm.numpy(force=True)
-	
+
+	if ax is None:
+		ax = plt.gca()
+
 	bg = 0.25 * numpy.log(0.25) / numpy.log(2)
 
-	
-	plt.figure(figsize=(8, 2.5))
-	ax = plt.subplot(121)
-	plt.title(name)
-	
 	ic = pwm * numpy.log(pwm + eps) / numpy.log(2) - bg
 	ic = numpy.sum(ic, axis=0, keepdims=True)
 	plot_logo(pwm * ic, ax=ax)
-	plt.xlabel("Motif Position")
-	plt.ylabel("Information Content (Bits)", fontsize=10)
-	
-	
-	ax = plt.subplot(122)
-	plt.title(name + "RC" if name is not None else "RC")
-	pwm = pwm[::-1, ::-1]
-	ic = pwm * numpy.log(pwm + eps) / numpy.log(2) - bg
-	ic = numpy.sum(ic, axis=0, keepdims=True)
-	plot_logo(pwm * ic, ax=ax)
-	plt.xlabel("Motif Position")
-	plt.ylabel("Information Content (Bits)", fontsize=10)
-	
-	plt.tight_layout()
-	plt.show()
-	
+
+	if name is not None:
+		ax.set_title(name)
+	ax.set_xlabel("Motif Position")
+	ax.set_ylabel("Information Content (Bits)", fontsize=10)
+
+	return ax

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -161,3 +161,39 @@ def test_place_new_bar_does_not_mutate_input():
 	new_box, _ = place_new_bar(box, [], y_step=1.0)
 	assert (box.x0, box.y0, box.x1, box.y1) == original
 	assert new_box is not box
+
+
+def test_plot_categorical_scatter_respects_ax():
+	from tangermeme.plot import plot_categorical_scatter
+
+	X = torch.tensor([
+		[1.0, 0.0, 0.0, 0.0, 0.5],
+		[0.0, 1.0, 0.0, 0.0, 0.0],
+		[0.0, 0.0, 1.0, 0.0, 0.0],
+		[0.0, 0.0, 0.0, 1.0, 0.5],
+	])
+
+	# Create a user-owned figure with two axes; pass the second one in.
+	fig, (ax1, ax2) = plt.subplots(2, 1)
+	returned = plot_categorical_scatter(X, ax=ax2)
+
+	# The function should draw on ax2 (the one we passed), not ax1.
+	assert returned is ax2, "function did not return the passed ax"
+	assert len(ax2.collections) > 0, "expected scatter on ax2"
+	assert len(ax1.collections) == 0, "ax1 should be untouched"
+
+
+def test_plot_categorical_scatter_defaults_to_gca():
+	from tangermeme.plot import plot_categorical_scatter
+
+	X = torch.tensor([
+		[1.0, 0.0, 0.5],
+		[0.0, 1.0, 0.0],
+		[0.0, 0.0, 0.0],
+		[0.0, 0.0, 0.5],
+	])
+
+	fig, ax = plt.subplots()
+	plt.sca(ax)
+	returned = plot_categorical_scatter(X)
+	assert returned is ax

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -234,3 +234,27 @@ def test_plot_pwm_does_not_call_show(monkeypatch):
 	plot_pwm(pwm, ax=ax)
 
 	assert called == [], "plot_pwm should not call plt.show()"
+
+
+def test_plot_attributions_uses_provided_func():
+	# plot_attributions previously hard-coded a call to deep_lift_shap
+	# and ignored the `func=` kwarg. Verify the kwarg is now honored.
+	from tangermeme.plot import plot_attributions
+
+	calls = []
+
+	def fake_attribute(model, X, **kwargs):
+		calls.append((model, tuple(X.shape)))
+		# Return something the size of X so plot_logo can render it.
+		return X * 0.0
+
+	from tests.toy_models import FlattenDense
+	torch.manual_seed(0)
+	model = FlattenDense()
+	X = torch.zeros(1, 4, 20)
+	X[0, 0] = 1.0  # all-A so plot_logo doesn't error
+
+	axs, X_attrs = plot_attributions(model, X, func=fake_attribute)
+
+	assert len(calls) == 1, "fake_attribute should have been called once"
+	assert X_attrs.shape == X.shape

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -197,3 +197,40 @@ def test_plot_categorical_scatter_defaults_to_gca():
 	plt.sca(ax)
 	returned = plot_categorical_scatter(X)
 	assert returned is ax
+
+
+def test_plot_pwm_respects_ax():
+	# plot_pwm should draw on the provided ax and return it, rather than
+	# creating its own figure or calling plt.show().
+	pwm = numpy.full((4, 6), 0.25)
+
+	fig, (ax1, ax2) = plt.subplots(2, 1)
+	returned = plot_pwm(pwm, ax=ax2)
+
+	assert returned is ax2, "plot_pwm did not return the passed ax"
+	# Something should have been drawn on ax2; the IC is zero for a
+	# uniform PWM but plot_logo still sets axis labels.
+	assert ax2.get_ylabel() == "Information Content (Bits)"
+	# ax1 should be untouched.
+	assert ax1.get_ylabel() == ""
+
+
+def test_plot_pwm_defaults_to_gca():
+	pwm = numpy.full((4, 6), 0.25)
+
+	fig, ax = plt.subplots()
+	plt.sca(ax)
+	returned = plot_pwm(pwm)
+	assert returned is ax
+
+
+def test_plot_pwm_does_not_call_show(monkeypatch):
+	# plot_pwm no longer calls plt.show() unconditionally.
+	called = []
+	monkeypatch.setattr(plt, "show", lambda *a, **k: called.append(True))
+
+	pwm = numpy.full((4, 6), 0.25)
+	fig, ax = plt.subplots()
+	plot_pwm(pwm, ax=ax)
+
+	assert called == [], "plot_pwm should not call plt.show()"

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -127,3 +127,37 @@ def test_plot_pwm_smoke():
 		[0.1, 0.1, 0.1, 0.7],
 	]).T
 	plot_pwm(pwm, name="toy")
+
+
+def test_place_new_box_does_not_mutate_input():
+	from tangermeme.plot import place_new_box
+	from matplotlib.transforms import Bbox
+
+	box = Bbox.from_extents(0.0, 0.0, 10.0, 5.0)
+	original = (box.x0, box.y0, box.x1, box.y1)
+
+	# Empty box_list path: should still return a (shifted) result without
+	# mutating the input.
+	new_box, _ = place_new_box(box, [])
+	assert (box.x0, box.y0, box.x1, box.y1) == original, \
+		"place_new_box mutated the caller's box on the empty path"
+	assert new_box is not box, "expected a fresh Bbox to be returned"
+
+	# Non-empty box_list path: same guarantee under the overlap loop.
+	overlap = Bbox.from_extents(0.0, -5.0, 10.0, 0.0)
+	box2 = Bbox.from_extents(0.0, 0.0, 10.0, 5.0)
+	original2 = (box2.x0, box2.y0, box2.x1, box2.y1)
+	new_box, _ = place_new_box(box2, [overlap])
+	assert (box2.x0, box2.y0, box2.x1, box2.y1) == original2
+
+
+def test_place_new_bar_does_not_mutate_input():
+	from tangermeme.plot import place_new_bar
+	from matplotlib.transforms import Bbox
+
+	box = Bbox.from_extents(0.0, 5.0, 10.0, 5.0)
+	original = (box.x0, box.y0, box.x1, box.y1)
+
+	new_box, _ = place_new_bar(box, [], y_step=1.0)
+	assert (box.x0, box.y0, box.x1, box.y1) == original
+	assert new_box is not box


### PR DESCRIPTION
## Summary

Four plot-module bug fixes that each addressed an unwanted side effect, drawn from the deferred list in PR #62.

### 1. `place_new_box` and `place_new_bar` no longer mutate the caller's Bbox

Both helpers wrote directly to `box.y0` / `box.y1` of the input, then returned the same now-shifted object. Internal callers in `plot_logo` rebind the return value to a new name so the mutation was hidden — but a caller that wanted to reuse the input Bbox would find it silently moved. Now both functions take a defensive copy via `Bbox.from_extents(...)` and operate on that; the caller's Bbox is guaranteed untouched.

### 2. `plot_categorical_scatter` respects a user-supplied `ax=`

The function declared a return type of `matplotlib.axes.Axes` but had no `ax=` parameter and drew via the module-level `plt.scatter(...)`, ignoring whatever axes the caller might want. Add `ax: matplotlib.axes.Axes | None = None` — if provided, draw on it; otherwise fall back to `plt.gca()` — and return the axes. Also tightened the `X` parameter's stale `pandas.DataFrame` type hint to `torch.Tensor`.

### 3. `plot_pwm` gains `ax=`, drops self-managed figure (**breaking change**)

Previously created its own `plt.figure(figsize=(8, 2.5))`, drew two subplots (forward + RC), called `plt.tight_layout()` and `plt.show()`, returned None. Impossible to compose into a larger layout. Now matches the convention used by `plot_logo` and `plot_categorical_scatter`:

- Takes `ax: matplotlib.axes.Axes | None = None` (defaults to `plt.gca()`).
- Draws a single information-content-weighted logo on that axes.
- No self-managed figure, no second RC subplot, no `plt.show()`.
- Returns the axes.

For RC visualization, callers now call `plot_pwm(pwm[::-1, ::-1])`.

**This is intentionally a breaking change**: anyone relying on the dual-subplot behavior or the implicit `plt.show()` will need to adjust. The new single-axes contract is simpler and consistent with the rest of the plot module.

### 4. `plot_attributions` honors the `func=` argument

The function advertised "any function can be used as long as it has the same signature" via a `func=deep_lift_shap` parameter, but the inner loop hard-coded a call to `deep_lift_shap(...)` and ignored `func` entirely. Anyone passing `func=pisa` or a custom attribution callable silently got DeepLIFT/SHAP instead. Fixed to actually call `func(...)`.

## Test plan

- [x] `uv run pytest` — 886 passed, 2 skipped (was 878; +8 new regression tests: place_new_box/bar non-mutation, plot_pwm ax + show + gca, plot_categorical_scatter ax + gca, plot_attributions honors func).
- [x] Each test added in the same commit as the relevant fix; verified to fail before the fix where applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)