### PR TITLE
Phase 3C: cross-tensor consistency checks

### DIFF
--- a/tangermeme/ablate.py
+++ b/tangermeme/ablate.py
@@ -133,6 +133,14 @@ def ablate(
 	"""
 
 	_validate_input(X, "X", shape=(-1, -1, -1), ohe=True, allow_N=True)
+
+	if args is not None:
+		for i, a in enumerate(args):
+			if a.device != X.device:
+				raise ValueError(
+					f"args[{i}] and X must be on the same device; got "
+					f"args[{i}] on {a.device} and X on {X.device}.")
+
 	additional_func_kwargs = dict(additional_func_kwargs or {})
 	if 'random_state' in inspect.signature(func).parameters.keys():
 		if 'random_state' not in additional_func_kwargs:

--- a/tangermeme/marginalize.py
+++ b/tangermeme/marginalize.py
@@ -116,6 +116,11 @@ def marginalize(
 	_validate_input(X, "X", shape=(-1, len(alphabet), -1), ohe=True, allow_N=True)
 	additional_func_kwargs = dict(additional_func_kwargs or {})
 
+	if isinstance(motif, torch.Tensor) and motif.device != X.device:
+		raise ValueError(
+			f"`motif` and `X` must be on the same device; got motif on "
+			f"{motif.device} and X on {X.device}.")
+
 	X_perturb = substitute(X, motif, start=start, alphabet=alphabet)
 	y_before = func(model, X, **kwargs, **additional_func_kwargs)
 	y_after = func(model, X_perturb, **kwargs, **additional_func_kwargs)

--- a/tangermeme/product.py
+++ b/tangermeme/product.py
@@ -120,6 +120,14 @@ def apply_pairwise(
 	# with callables that haven't yet been updated to accept torch.device.
 	device_arg = str(device)
 
+	if args is not None and len(args) > 1:
+		lengths = [len(a) for a in args]
+		if len(set(lengths)) != 1:
+			raise ValueError("apply_pairwise requires every element in `args` "
+				"to have the same length (they are paired index-wise). Got "
+				f"lengths {lengths}; use `apply_product` for the cartesian "
+				"product instead.")
+
 	with _preserve_model_state(model, device):
 		X_, y, args_ = [], [], [[] for _ in args]
 		for x in tqdm(itertools.product(X, zip(*args)), disable=not verbose):

--- a/tangermeme/space.py
+++ b/tangermeme/space.py
@@ -126,6 +126,12 @@ def space(
 		"spacing", shape=(-1, len(motifs)-1))
 	X = _validate_input(X, "X", shape=(-1, len(alphabet), -1))
 
+	for i, motif in enumerate(motifs):
+		if isinstance(motif, torch.Tensor) and motif.device != X.device:
+			raise ValueError(
+				f"motifs[{i}] and X must be on the same device; got "
+				f"motifs[{i}] on {motif.device} and X on {X.device}.")
+
 	additional_func_kwargs = dict(additional_func_kwargs or {})
 
 	y_before = func(model, X, **kwargs, **additional_func_kwargs)

--- a/tangermeme/variant_effect.py
+++ b/tangermeme/variant_effect.py
@@ -224,7 +224,16 @@ def deletion_effect(
 
 	mask = torch.zeros_like(X[:, 0]).type(torch.int32)
 	mask[deletions[:, 0], deletions[:, 1]] = 1
-	
+
+	max_deletions = int(mask.sum(dim=-1).max())
+	if max_deletions >= X.shape[-1]:
+		raise ValueError(
+			f"deletion_effect requires X.shape[-1] > max deletions per example "
+			f"to leave at least one position for the model; got "
+			f"X.shape[-1]={X.shape[-1]} and max deletions per example "
+			f"={max_deletions}. Each sequence must be of length "
+			f"`model_length + max_deletions_per_sequence`.")
+
 	counts = mask.sum(dim=-1)
 	counts = abs(counts - counts.max())
 

--- a/tests/test_ablate.py
+++ b/tests/test_ablate.py
@@ -1101,6 +1101,19 @@ def test_ablate_func_saturation_mutagenesis(X, device):
 		   -0.0000,  0.0000, -0.0011]]]], 4)
 
 
+def test_ablate_rejects_args_device_mismatch():
+	# args on a different device from X used to fall through to a cryptic
+	# torch error from inside the model. Surface a clear ValueError up
+	# front. We use the `meta` device so the test works without CUDA.
+	torch.manual_seed(0)
+	model = FlattenDense()
+	X = random_one_hot((2, 4, 100), random_state=0).type(torch.float32)
+	alpha_meta = torch.zeros(2, 1, device='meta')
+
+	with pytest.raises(ValueError, match="same device"):
+		ablate(model, X, start=10, end=20, n=2, args=(alpha_meta,))
+
+
 def test_ablate_annotations_empty(X, device):
 	torch.manual_seed(0)
 	model = FlattenDense()

--- a/tests/test_marginalize.py
+++ b/tests/test_marginalize.py
@@ -347,8 +347,20 @@ def test_marginalize_raises_args(X, alpha, beta, device):
 		args=alpha, device=device)
 	assert_raises(ValueError, marginalize, model, X, "ACGTC", batch_size=2, 
 		args=(alpha[:5],), device=device)
-	assert_raises(ValueError, marginalize, model, X, "ACGTC", batch_size=2, 
+	assert_raises(ValueError, marginalize, model, X, "ACGTC", batch_size=2,
 		args=(alpha, beta[:5]), device=device)
+
+
+def test_marginalize_rejects_device_mismatch():
+	# A motif on a different device from X previously crashed with a cryptic
+	# torch error from inside substitute(). Surface a clear ValueError up
+	# front. We use the `meta` device so the test works without CUDA.
+	model = FlattenDense()
+	X = random_one_hot((2, 4, 100), random_state=0).type(torch.float32)
+	motif = torch.zeros(1, 4, 5, device='meta')
+
+	with pytest.raises(ValueError, match="same device"):
+		marginalize(model, X, motif)
 
 
 ###

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -217,6 +217,15 @@ def test_apply_pairwise_predict_convdense_alpha(X, alpha, device):
 		 [-0.2375, -0.0069,  0.0835]]], 4)
 
 
+def test_apply_pairwise_rejects_mismatched_args_lengths(X, alpha, beta):
+	# apply_pairwise pairs entries in args index-wise; mismatched lengths
+	# previously silently truncated to the shorter via zip(*args).
+	model = FlattenDense()
+
+	with pytest.raises(ValueError, match="same length"):
+		apply_pairwise(predict, model, X[:5], args=(alpha[:5], beta[:3]))
+
+
 ###
 
 

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -739,6 +739,21 @@ def test_space_func_saturation_mutagenesis(X, device):
 		   -0.0000,  0.0000, -0.0000]]]], 4)
 
 
+def test_space_rejects_device_mismatch():
+	# A tensor motif on a different device from X used to fall through
+	# to a cryptic torch error from inside multisubstitute(). String motifs
+	# bypass the check (they're encoded on CPU inside substitute). We use
+	# `meta` so the test works without CUDA.
+	torch.manual_seed(0)
+	model = FlattenDense()
+	X = random_one_hot((2, 4, 100), random_state=0).type(torch.float32)
+	motif_meta = torch.zeros(1, 4, 5, device='meta')
+	motif_str = "ACGTC"
+
+	with pytest.raises(ValueError, match="same device"):
+		space(model, X, [motif_str, motif_meta], spacing=[[1]])
+
+
 def test_space_returns_named_tuple(X, device):
 	from tangermeme.space import SpaceResult
 

--- a/tests/test_variant_effect.py
+++ b/tests/test_variant_effect.py
@@ -126,6 +126,18 @@ def test_deletion_effect_summodel(X_del, substitutions, device):
 	assert_array_almost_equal(y, X_del[:, :, :100].sum(dim=-1))
 
 
+def test_deletion_effect_rejects_X_too_short():
+	# X.shape[-1] must exceed the max deletion count per example so the model
+	# is left with at least one position to consume. Previously this fell
+	# through to a cryptic empty-tensor / model crash.
+	model = FlattenDense()
+	X = random_one_hot((2, 4, 5)).type(torch.float32)
+	deletions = torch.tensor([[0, 0], [0, 1], [0, 2], [0, 3], [0, 4]])
+
+	with pytest.raises(ValueError, match="max deletions per example"):
+		deletion_effect(model, X, deletions)
+
+
 ###
 
 


### PR DESCRIPTION
## Summary

Cross-tensor consistency checks that surface clear `ValueError`s where the library previously fell through to cryptic torch errors or silent wrong output.

- **`apply_pairwise` rejects mismatched `args` lengths.** Index-wise pairing via `zip(*args)` silently truncated to the shortest sequence when lengths differed. Validate up front and point users at `apply_product` for the cartesian-product case.
- **`deletion_effect` rejects X shorter than the max deletions per example.** The docstring requires `X.shape[-1] == model_length + max_deletions_per_sequence`, but the function never validated it; an X that's too short fell through to an empty-tensor model crash.
- **`marginalize` rejects motif/X device mismatch.** A tensor motif on a different device from X fell through to a `RuntimeError` from inside `substitute`. String motifs are unaffected.
- **`space` rejects motif/X device mismatch.** Same idea, but walks the motif list and reports which entry disagrees. String motifs are unaffected.
- **`ablate` rejects args/X device mismatch.** ablate doesn't take a motif; the analogous cross-tensor coupling is `args` flowing into the model alongside `X`.

All five additions are purely defensive — valid inputs that worked before still work, and no regression values change. Net +5 tests (886 → 891).

## Test plan

- [x] `uv run pytest -q` — 891 passed, 2 skipped
- [x] New tests use the `meta` device so they exercise the device-mismatch paths without requiring CUDA