### PR TITLE
Phase 2 deferred: io chrom-end and match GC-bin 0 spillover

### DIFF
--- a/tangermeme/io.py
+++ b/tangermeme/io.py
@@ -461,7 +461,7 @@ def extract_loci(
 		end = mid + max(out_width, in_width) + max_jitter
 
 		# Does it fall off the end of a chromosome?
-		if start < 0 or end >= chrom_lengths[str(chrom)]:
+		if start < 0 or end > chrom_lengths[str(chrom)]:
 			kept_mask.append(False)
 			continue
 

--- a/tangermeme/match.py
+++ b/tangermeme/match.py
@@ -568,7 +568,7 @@ def extract_matching_loci(
 				break
 
 			idx = i - offset
-			if idx > 0:
+			if idx >= 0:
 				count = min(bg_bin_count[idx], loci_bin_count[i])
 				bg_bin_count[idx] -= count
 				loci_bin_count[i] -= count

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -625,6 +625,27 @@ def test_extract_loci_seq_jitter(loci_seqs):
 	assert_array_almost_equal(X[:, :, 20:-20], loci_seqs[1:])
 
 
+def test_extract_loci_keeps_locus_ending_at_chrom_length():
+	# A locus whose extracted window ends exactly at chrom_length is valid
+	# (end is exclusive); previously dropped by `end >= chrom_lengths[chrom]`.
+	# chr2 in tests/data/test.fa is 211bp long; with in_window=10 and
+	# max_jitter=0 the extracted window is [mid-5, mid+5), so mid=206 yields
+	# a window of [201, 211), which fits exactly. A window of [202, 212)
+	# (mid=207) genuinely runs off the end and should still be dropped.
+	loci = pandas.DataFrame({
+		'chrom': ['chr2', 'chr2'],
+		'start': [201, 202],
+		'end':   [211, 212],
+	})
+	fasta = "tests/data/test.fa"
+
+	X, mask = extract_loci(loci, fasta, in_window=10, return_mask=True)
+
+	# The boundary locus is kept; the one that overruns is dropped.
+	assert mask.tolist() == [True, False]
+	assert X.shape == (1, 4, 10)
+
+
 def test_extract_loci_seq_alphabet(loci_seqs):
 	loci = "tests/data/test.bed"
 	fasta = "tests/data/test.fa"

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -339,13 +339,36 @@ def test_extract_matching_loci_end_edge():
 		'end': [270, 280, 290]
 	})
 
-	regions = extract_matching_loci(peaks, "tests/data/test.fa", 
+	regions = extract_matching_loci(peaks, "tests/data/test.fa",
 		chroms=['chr1'], in_window=10, out_window=10, random_state=0)
 	assert regions.shape == (2, 3)
 
 
-	regions = extract_matching_loci(peaks, "tests/data/test.fa", 
+	regions = extract_matching_loci(peaks, "tests/data/test.fa",
 		chroms=['chr1'], in_window=20, out_window=10, random_state=0)
+	assert regions.shape == (1, 3)
+
+
+def test_extract_matching_loci_bin_0_spillover(tmp_path):
+	# bin 0 (the lowest GC bin) previously couldn't receive spillover from
+	# a peak in a higher bin: the spillover loop guarded with `idx > 0`
+	# instead of `>= 0`. Construct a chromosome where the only available
+	# backgrounds are at GC=0 and the lone peak is at GC=1.0, so the
+	# matching algorithm has nowhere else to go.
+	fa_path = tmp_path / "tiny.fa"
+	fa_path.write_text(">chr1\n" + "A"*100 + "G"*10 + "A"*90 + "\n")
+
+	peaks = pandas.DataFrame({
+		'chrom': ['chr1'],
+		'start': [100],
+		'end':   [110],
+	})
+
+	regions = extract_matching_loci(peaks, str(fa_path), in_window=10,
+		out_window=10, max_n_perc=1.0, random_state=0)
+
+	# Without the fix this returns zero rows; with the fix the peak finds
+	# a GC=0 background to match against.
 	assert regions.shape == (1, 3)
 
 


### PR DESCRIPTION
## Summary

Two off-by-one bugs that silently produced wrong output.

- **`io.extract_loci` was dropping loci whose window ends exactly at `chrom_length`.** BED end coordinates are exclusive, so a window with `end == chrom_length` is valid and should be kept. The filter used `end >= chrom_length` instead of `end >`.
- **`match.extract_matching_loci` could not spill peaks into GC-bin 0.** The matching loop's spillover-to-lower-bin branch guarded with `if idx > 0`, so the bottom bin (`idx == 0`) was never a legitimate destination. A peak in a high-GC bin with no nearby backgrounds would silently drop instead of pairing with GC=0 backgrounds.

Each commit lands a fix plus a regression test that fails without the fix.

### Seqlet bugs deferred again

The two seqlet edits originally on this list (`seqlet.py` slice fix and `l-1`→`l` boundary fix) trace to dead code paths: the unmarked position and broader masking are both already at 1.0 from initialization, so neither fix changes observable output for any input I could construct. Skipped per discussion; a related observable bug on the seqlet end-coordinate clamp is logged for a future PR.

## Test plan

- [x] `uv run pytest -q` — 893 passed, 2 skipped
- [x] Each fix verified to flip the new regression test from FAIL (without fix) to PASS (with fix)