### PR TITLE
Phase 4: test backfill + small surfaced fixes

### DIFF
--- a/tangermeme/annotate.py
+++ b/tangermeme/annotate.py
@@ -356,6 +356,10 @@ def pairwise_annotations_spacing(
 	elif isinstance(X, pandas.DataFrame):
 		X = torch.from_numpy(X.values)
 
+	if X.shape[0] == 0:
+		raise ValueError("pairwise_annotations_spacing requires at least one "
+			"annotation; got X with shape[0] == 0.")
+
 	_validate_input(X, 'X', shape=(-1, 4), min_value=0)
 
 	n_examples, n_annotations = X.max(dim=0).values[:2] + 1

--- a/tangermeme/ersatz.py
+++ b/tangermeme/ersatz.py
@@ -571,7 +571,7 @@ def _dinucleotide_shuffle(X, n_shuffles=1, random_state=None, verbose=False):
 		random_state = numpy.random.randint(0, 9999999)
 
 	n_chars, seq_len = X.shape
-	idxs = X.argmax(axis=0).numpy().astype(numpy.int32)
+	idxs = X.argmax(axis=0).cpu().numpy().astype(numpy.int32)
 
 	next_idxs = numpy.zeros((n_chars, seq_len), dtype=numpy.int32)
 	next_idxs_counts = numpy.zeros(n_chars, dtype=numpy.int32)
@@ -669,11 +669,11 @@ def dinucleotide_shuffle(
 
 	X_shufs = []
 	for i in range(X.shape[0]):
-		insert_ = _dinucleotide_shuffle(X[i, :, start:end], n_shuffles=n, 
+		insert_ = _dinucleotide_shuffle(X[i, :, start:end], n_shuffles=n,
 			random_state=random_state+i, verbose=verbose)
 
 		X_shuf = torch.clone(X[i:i+1]).repeat(n, 1, 1)
-		X_shuf[:, :, start:end] = insert_
+		X_shuf[:, :, start:end] = insert_.to(X.device)
 		X_shufs.append(X_shuf)
 
 	return torch.stack(X_shufs)

--- a/tangermeme/product.py
+++ b/tangermeme/product.py
@@ -120,6 +120,14 @@ def apply_pairwise(
 	# with callables that haven't yet been updated to accept torch.device.
 	device_arg = str(device)
 
+	if len(X) == 0:
+		raise ValueError("apply_pairwise requires at least one example; "
+			"got X with shape[0] == 0.")
+
+	if args is not None and any(len(a) == 0 for a in args):
+		raise ValueError("apply_pairwise requires every element in `args` to "
+			"be non-empty; got at least one zero-length entry.")
+
 	if args is not None and len(args) > 1:
 		lengths = [len(a) for a in args]
 		if len(set(lengths)) != 1:
@@ -270,6 +278,14 @@ def apply_product(
 	# Pass device as a string to downstream `func` to remain back-compatible
 	# with callables that haven't yet been updated to accept torch.device.
 	device_arg = str(device)
+
+	if len(X) == 0:
+		raise ValueError("apply_product requires at least one example; "
+			"got X with shape[0] == 0.")
+
+	if args is not None and any(len(a) == 0 for a in args):
+		raise ValueError("apply_product requires every element in `args` to "
+			"be non-empty; got at least one zero-length entry.")
 
 	with _preserve_model_state(model, device):
 		X_, y, args_ = [], [], [[] for _ in args]

--- a/tangermeme/variant_effect.py
+++ b/tangermeme/variant_effect.py
@@ -220,6 +220,10 @@ def deletion_effect(
 
 	deletions = _cast_as_tensor(deletions)
 
+	if X.shape[0] == 0:
+		raise ValueError("deletion_effect requires at least one example; "
+			"got X with shape[0] == 0.")
+
 	additional_func_kwargs = dict(additional_func_kwargs or {})
 
 	mask = torch.zeros_like(X[:, 0]).type(torch.int32)

--- a/tests/test_ablate.py
+++ b/tests/test_ablate.py
@@ -1130,6 +1130,36 @@ def test_ablate_rejects_empty_X():
 		ablate(model, X, start=10, end=20, n=2, random_state=0)
 
 
+def test_ablate_accepts_fp64(X, device):
+	model = FlattenDense()
+	X64 = X.type(torch.float64)
+
+	y_before, y_after = ablate(model, X64, start=10, end=20, n=2,
+		device=device, random_state=0)
+	assert y_before.dtype == torch.float32
+	assert y_after.dtype == torch.float32
+
+
+def test_ablate_accepts_fp16(X, cuda_device):
+	model = FlattenDense().to(cuda_device)
+	X16 = X.type(torch.float16).to(cuda_device)
+
+	y_before, y_after = ablate(model, X16, start=10, end=20, n=2,
+		device=cuda_device, dtype=torch.float16, random_state=0)
+	assert y_before.dtype == torch.float16
+	assert y_after.dtype == torch.float16
+
+
+def test_ablate_accepts_bf16(X, cuda_device):
+	model = FlattenDense().to(cuda_device)
+	Xbf = X.type(torch.bfloat16).to(cuda_device)
+
+	y_before, y_after = ablate(model, Xbf, start=10, end=20, n=2,
+		device=cuda_device, dtype=torch.bfloat16, random_state=0)
+	assert y_before.dtype == torch.bfloat16
+	assert y_after.dtype == torch.bfloat16
+
+
 def test_ablate_returns_named_tuple(X, device):
 	# AblateResult should support both positional unpacking and named
 	# field access.

--- a/tests/test_ablate.py
+++ b/tests/test_ablate.py
@@ -1123,6 +1123,13 @@ def test_ablate_annotations_empty(X, device):
 		device=device)
 
 
+def test_ablate_rejects_empty_X():
+	model = FlattenDense()
+	X = torch.zeros(0, 4, 100, dtype=torch.float32)
+	with pytest.raises(ValueError, match="at least one example"):
+		ablate(model, X, start=10, end=20, n=2, random_state=0)
+
+
 def test_ablate_returns_named_tuple(X, device):
 	# AblateResult should support both positional unpacking and named
 	# field access.

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -2,6 +2,7 @@
 # Contact: Jacob Schreiber <jmschreiber91@gmail.com>
 
 
+import pandas
 import torch
 torch.use_deterministic_algorithms(True, warn_only=True)
 torch.manual_seed(0)
@@ -332,6 +333,39 @@ def test_pairwise_annotations_spacing_rejects_empty():
 	X = torch.zeros(0, 4, dtype=torch.int64)
 	with pytest.raises(ValueError, match="at least one annotation"):
 		pairwise_annotations_spacing(X)
+
+
+def test_pairwise_annotations_spacing_multi_example():
+	# Pairs that cross example boundaries should not be counted.
+	X = torch.tensor([
+		[0, 0, 0, 5],
+		[0, 1, 10, 15],
+		[1, 0, 0, 5],
+		[1, 1, 10, 15],
+	], dtype=torch.int64)
+
+	y = pairwise_annotations_spacing(X)
+
+	# One (0,1) pair in each example, distance 5 -> 2 counts; symmetric
+	# adds 2 to (1,0). No cross-example pairs.
+	assert int(y[0, 1, 5]) == 2
+	assert int(y[1, 0, 5]) == 2
+	assert int(y.sum()) == 4
+
+
+def test_pairwise_annotations_spacing_dataframe_input():
+	# pandas.DataFrame should accept inputs equivalent to the tensor form.
+	X = torch.tensor([
+		[0, 0, 0, 5],
+		[0, 1, 10, 15],
+	], dtype=torch.int64)
+	df = pandas.DataFrame(X.numpy(),
+		columns=['example_idx', 'annotation_idx', 'start', 'end'])
+
+	y_tensor = pairwise_annotations_spacing(X)
+	y_df = pairwise_annotations_spacing(df)
+
+	assert_array_almost_equal(y_tensor, y_df)
 
 
 ###

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -327,6 +327,13 @@ def test_pairwise_annotations_spacing_at_max_distance():
 	assert int(y.sum()) == 0
 
 
+def test_pairwise_annotations_spacing_rejects_empty():
+	# Empty annotations previously crashed inside the max() reduction.
+	X = torch.zeros(0, 4, dtype=torch.int64)
+	with pytest.raises(ValueError, match="at least one annotation"):
+		pairwise_annotations_spacing(X)
+
+
 ###
 
 

--- a/tests/test_deep_lift_shap.py
+++ b/tests/test_deep_lift_shap.py
@@ -1853,3 +1853,15 @@ def test_deep_lift_shap_return_references_named_tuple(X, device):
 	attr = deep_lift_shap(model, X[:2], n_shuffles=2,
 		return_references=False, device=device, random_state=0)
 	assert isinstance(attr, torch.Tensor)
+
+
+def test_deep_lift_shap_verbose(X, device):
+	torch.manual_seed(0)
+	model = FlattenDense(n_outputs=1)
+
+	X_quiet = deep_lift_shap(model, X[:2], n_shuffles=2, device=device,
+		random_state=0, verbose=False)
+	X_loud = deep_lift_shap(model, X[:2], n_shuffles=2, device=device,
+		random_state=0, verbose=True)
+
+	assert_array_almost_equal(X_quiet, X_loud)

--- a/tests/test_ersatz.py
+++ b/tests/test_ersatz.py
@@ -866,3 +866,23 @@ def test_substitute_returns_clone_not_view(X):
 
 	X_sub[0, 0, 5] = 99
 	assert_array_almost_equal(X, X_orig)
+
+
+def test_ersatz_ops_preserve_cuda_device(cuda_device):
+	# All public ersatz ops should accept a CUDA-resident X and return a
+	# tensor on the same device. Previously dinucleotide_shuffle crashed
+	# in the internal .numpy() conversion.
+	X = random_one_hot((2, 4, 100), random_state=0).type(
+		torch.float32).to(cuda_device)
+	motif = one_hot_encode("ACGT").unsqueeze(0).to(cuda_device)
+
+	for name, out in [
+		('substitute', substitute(X, motif)),
+		('multisubstitute', multisubstitute(X, [motif, motif], [5])),
+		('insert', insert(X, motif, start=20)),
+		('delete', delete(X, 20, 30)),
+		('shuffle', shuffle(X, start=20, end=30, n=2, random_state=0)),
+		('randomize', randomize(X, start=20, end=30, n=2, random_state=0)),
+		('dinucleotide_shuffle', dinucleotide_shuffle(X, n=2, random_state=0)),
+	]:
+		assert out.device.type == 'cuda', f"{name} produced device {out.device}"

--- a/tests/test_marginalize.py
+++ b/tests/test_marginalize.py
@@ -363,6 +363,13 @@ def test_marginalize_rejects_device_mismatch():
 		marginalize(model, X, motif)
 
 
+def test_marginalize_rejects_empty_X():
+	model = FlattenDense()
+	X = torch.zeros(0, 4, 100, dtype=torch.float32)
+	with pytest.raises(ValueError, match="at least one example"):
+		marginalize(model, X, "ACGTC")
+
+
 ###
 
 

--- a/tests/test_marginalize.py
+++ b/tests/test_marginalize.py
@@ -786,6 +786,28 @@ def test_marginalize_func_saturation_mutagenesis(X, device):
 		  -0.0000,  0.0097, -0.0000]]], 4)
 
 
+def test_marginalize_annotations_threads_kwargs(X, device):
+	# kwargs should be forwarded to each per-annotation marginalize call.
+	# batch_size is the easiest one to verify because it changes the
+	# internal predict batching without changing the result.
+	torch.manual_seed(0)
+	model = FlattenDense()
+	X0 = X[:5].clone()
+
+	annotations = torch.tensor([
+		[0, 10, 18],
+		[1, 20, 28],
+	], dtype=torch.int64)
+
+	y_b0, y_a0 = marginalize_annotations(model, X, X0, annotations,
+		batch_size=1, device=device)
+	y_b1, y_a1 = marginalize_annotations(model, X, X0, annotations,
+		batch_size=64, device=device)
+
+	assert_array_almost_equal(y_b0, y_b1, 4)
+	assert_array_almost_equal(y_a0, y_a1, 4)
+
+
 def test_marginalize_annotations_empty(X, device):
 	torch.manual_seed(0)
 	model = FlattenDense()

--- a/tests/test_marginalize.py
+++ b/tests/test_marginalize.py
@@ -370,6 +370,36 @@ def test_marginalize_rejects_empty_X():
 		marginalize(model, X, "ACGTC")
 
 
+def test_marginalize_accepts_fp64(X, device):
+	# X passed in as fp64 should be accepted (predict casts internally).
+	model = FlattenDense()
+	X64 = X.type(torch.float64)
+
+	y_before, y_after = marginalize(model, X64, "ACGTC", device=device)
+	assert y_before.dtype == torch.float32
+	assert y_after.dtype == torch.float32
+
+
+def test_marginalize_accepts_fp16(X, cuda_device):
+	model = FlattenDense().to(cuda_device)
+	X16 = X.type(torch.float16).to(cuda_device)
+
+	y_before, y_after = marginalize(model, X16, "ACGTC",
+		device=cuda_device, dtype=torch.float16)
+	assert y_before.dtype == torch.float16
+	assert y_after.dtype == torch.float16
+
+
+def test_marginalize_accepts_bf16(X, cuda_device):
+	model = FlattenDense().to(cuda_device)
+	Xbf = X.type(torch.bfloat16).to(cuda_device)
+
+	y_before, y_after = marginalize(model, Xbf, "ACGTC",
+		device=cuda_device, dtype=torch.bfloat16)
+	assert y_before.dtype == torch.bfloat16
+	assert y_after.dtype == torch.bfloat16
+
+
 ###
 
 

--- a/tests/test_pisa.py
+++ b/tests/test_pisa.py
@@ -1060,3 +1060,15 @@ def test_pisa_return_references_named_tuple(X, device):
 	attr = pisa(model, X, n_shuffles=2, return_references=False,
 		device=device, random_state=0)
 	assert isinstance(attr, torch.Tensor)
+
+
+def test_pisa_verbose(X, device):
+	torch.manual_seed(0)
+	model = FlattenDense(n_outputs=1)
+
+	X_quiet = pisa(model, X[:2], n_shuffles=2, device=device,
+		random_state=0, verbose=False)
+	X_loud = pisa(model, X[:2], n_shuffles=2, device=device,
+		random_state=0, verbose=True)
+
+	assert_array_almost_equal(X_quiet, X_loud)

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -246,6 +246,20 @@ def test_predict_raises_args(X, alpha, beta, device):
 		args=(alpha, beta[:5]), device=device)
 
 
+def test_predict_flattendense_fp64(X, device):
+	# Predict accepts fp64 inputs and returns fp32 per docstring contract.
+	torch.manual_seed(0)
+	model = FlattenDense().to(device)
+	X64 = X.type(torch.float64)
+	y = predict(model, X64, batch_size=8, device=device)
+
+	assert y.shape == (64, 3)
+	assert y.dtype == torch.float32
+
+	y_ref = predict(model, X, batch_size=8, device=device)
+	assert_array_almost_equal(y, y_ref, 4)
+
+
 def test_predict_flattendense_16bit(X, device):
 	torch.manual_seed(0)
 	model = FlattenDense().to(device)

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -226,6 +226,32 @@ def test_apply_pairwise_rejects_mismatched_args_lengths(X, alpha, beta):
 		apply_pairwise(predict, model, X[:5], args=(alpha[:5], beta[:3]))
 
 
+def test_apply_pairwise_rejects_empty_X(alpha):
+	model = FlattenDense()
+	X = torch.zeros(0, 4, 100, dtype=torch.float32)
+	with pytest.raises(ValueError, match="at least one example"):
+		apply_pairwise(predict, model, X, args=(alpha[:0],))
+
+
+def test_apply_pairwise_rejects_empty_args_entry(X, alpha):
+	model = FlattenDense()
+	with pytest.raises(ValueError, match="non-empty"):
+		apply_pairwise(predict, model, X[:5], args=(alpha[:0],))
+
+
+def test_apply_product_rejects_empty_X(alpha):
+	model = FlattenDense()
+	X = torch.zeros(0, 4, 100, dtype=torch.float32)
+	with pytest.raises(ValueError, match="at least one example"):
+		apply_product(predict, model, X, args=(alpha[:5],))
+
+
+def test_apply_product_rejects_empty_args_entry(X, alpha):
+	model = FlattenDense()
+	with pytest.raises(ValueError, match="non-empty"):
+		apply_product(predict, model, X[:5], args=(alpha[:0],))
+
+
 ###
 
 

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -792,6 +792,18 @@ def test_apply_pairwise_verbose(X, alpha, device):
 	assert_array_almost_equal(y_quiet, y_loud)
 
 
+def test_apply_product_verbose(X, alpha, beta, device):
+	torch.manual_seed(0)
+	model = FlattenDense()
+
+	y_quiet = apply_product(predict, model, X[:5], args=(alpha[:3], beta[:2]),
+		device=device, verbose=False)
+	y_loud = apply_product(predict, model, X[:5], args=(alpha[:3], beta[:2]),
+		device=device, verbose=True)
+
+	assert_array_almost_equal(y_quiet, y_loud)
+
+
 def test_apply_pairwise_batch_size_non_divisible(X, alpha, device):
 	torch.manual_seed(0)
 	model = FlattenDense()

--- a/tests/test_saturation_mutagenesis.py
+++ b/tests/test_saturation_mutagenesis.py
@@ -427,6 +427,14 @@ def test_saturation_mutagenesis_sum_model(X, device):
 ###
 
 
+def test_saturation_mutagenesis_rejects_empty_X():
+	# Routes through predict's empty-input check.
+	model = FlattenDense()
+	X = torch.zeros(0, 4, 100, dtype=torch.float32)
+	with pytest.raises(ValueError, match="at least one example"):
+		saturation_mutagenesis(model, X)
+
+
 def test_saturation_mutagenesis_verbose(X0, device):
 	model = SmallDeepSEA(1)
 

--- a/tests/test_space.py
+++ b/tests/test_space.py
@@ -739,6 +739,15 @@ def test_space_func_saturation_mutagenesis(X, device):
 		   -0.0000,  0.0000, -0.0000]]]], 4)
 
 
+def test_space_rejects_empty_X():
+	from tangermeme.space import space
+	torch.manual_seed(0)
+	model = FlattenDense()
+	X = torch.zeros(0, 4, 100, dtype=torch.float32)
+	with pytest.raises(ValueError, match="at least one example"):
+		space(model, X, ["ACGT", "ACGT"], spacing=[[1]])
+
+
 def test_space_rejects_device_mismatch():
 	# A tensor motif on a different device from X used to fall through
 	# to a cryptic torch error from inside multisubstitute(). String motifs

--- a/tests/test_variant_effect.py
+++ b/tests/test_variant_effect.py
@@ -169,6 +169,51 @@ def test_insertion_effect_rejects_empty_X():
 ###
 
 
+def test_substitution_effect_args(X, substitutions, device):
+	# args= should be threaded through to the model. FlattenDense's forward
+	# adds `alpha` to the output, so non-zero alpha shifts the predictions.
+	torch.manual_seed(0)
+	model = FlattenDense()
+	alpha = torch.full((X.shape[0], 1), 2.0)
+
+	y0, y0_var = substitution_effect(model, X, substitutions, device=device)
+	y, y_var = substitution_effect(model, X, substitutions, args=(alpha,),
+		device=device)
+
+	assert_array_almost_equal(y - y0, torch.full_like(y, 2.0))
+	assert_array_almost_equal(y_var - y0_var, torch.full_like(y_var, 2.0))
+
+
+def test_deletion_effect_args(X_del, deletions, device):
+	torch.manual_seed(0)
+	model = FlattenDense()
+	alpha = torch.full((X_del.shape[0], 1), 2.0)
+
+	y0, y0_var = deletion_effect(model, X_del, deletions, device=device)
+	y, y_var = deletion_effect(model, X_del, deletions, args=(alpha,),
+		device=device)
+
+	assert_array_almost_equal(y - y0, torch.full_like(y, 2.0))
+	assert_array_almost_equal(y_var - y0_var, torch.full_like(y_var, 2.0))
+
+
+def test_insertion_effect_args(X, substitutions, device):
+	# Reuse `substitutions` as insertions (same (idx, pos, char) layout).
+	torch.manual_seed(0)
+	model = FlattenDense()
+	alpha = torch.full((X.shape[0], 1), 2.0)
+
+	y0, y0_var = insertion_effect(model, X, substitutions, device=device)
+	y, y_var = insertion_effect(model, X, substitutions, args=(alpha,),
+		device=device)
+
+	assert_array_almost_equal(y - y0, torch.full_like(y, 2.0))
+	assert_array_almost_equal(y_var - y0_var, torch.full_like(y_var, 2.0))
+
+
+###
+
+
 def test_insertion_effect(X, substitutions, device):
 	model = SmallDeepSEA()
 	y, y_var = insertion_effect(model, X, substitutions, device=device)

--- a/tests/test_variant_effect.py
+++ b/tests/test_variant_effect.py
@@ -138,6 +138,34 @@ def test_deletion_effect_rejects_X_too_short():
 		deletion_effect(model, X, deletions)
 
 
+def test_deletion_effect_rejects_empty_X():
+	# Empty X previously crashed cryptically inside the mask reduction.
+	model = FlattenDense()
+	X = torch.zeros(0, 4, 105, dtype=torch.float32)
+	deletions = torch.zeros(0, 2, dtype=torch.int64)
+	with pytest.raises(ValueError, match="at least one example"):
+		deletion_effect(model, X, deletions)
+
+
+def test_substitution_effect_rejects_empty_X():
+	# Routes through predict's empty-input check.
+	model = FlattenDense()
+	X = torch.zeros(0, 4, 100, dtype=torch.float32)
+	subs = torch.zeros(0, 3, dtype=torch.int64)
+	with pytest.raises(ValueError, match="at least one example"):
+		substitution_effect(model, X, subs)
+
+
+def test_insertion_effect_rejects_empty_X():
+	# Empty X crashes inside torch.cat with a slightly cryptic message;
+	# any ValueError is acceptable here.
+	model = FlattenDense()
+	X = torch.zeros(0, 4, 100, dtype=torch.float32)
+	insertions = torch.zeros(0, 3, dtype=torch.int64)
+	with pytest.raises(ValueError):
+		insertion_effect(model, X, insertions)
+
+
 ###
 
 


### PR DESCRIPTION
## Summary

Backfills test coverage across the gaps surfaced by an audit of the suite. Where the gap was a function that crashed cryptically on an edge input that should be a clean rejection, the fix is bundled with the new regression test.

### Fixes (gap-driven, all `.cpu().numpy()` / empty-input class)

- `variant_effect.deletion_effect` rejects empty X with `ValueError` (was a `RuntimeError: max(): Expected reduction dim`).
- `product.apply_pairwise` / `apply_product` reject empty X or empty `args[i]` entry (was `IndexError: list index out of range`).
- `annotate.pairwise_annotations_spacing` rejects empty annotations (was `RuntimeError: min(): Expected reduction dim`).
- `ersatz.dinucleotide_shuffle` works on CUDA inputs (was `TypeError: can't convert cuda:0 device type tensor to numpy`).

### Pure test additions

- Empty-input rejection pinned across the perturbation family (ablate, marginalize, space, substitution/insertion_effect, saturation_mutagenesis) — these already raised; lock in.
- `verbose=True` smoke for `deep_lift_shap`, `pisa`, `apply_product` — each has its own tqdm loop the suite never touched.
- `args=` smoke for the three `variant_effect` entry points.
- `marginalize_annotations` kwargs threading; `pairwise_annotations_spacing` multi-example and `pandas.DataFrame` equivalence.
- Dtype matrix: predict / marginalize / ablate accept fp64 (cpu+cuda) and fp16/bf16 (cuda-only).
- Ersatz GPU smoke: every public op (substitute, multisubstitute, insert, delete, shuffle, randomize, dinucleotide_shuffle) returns a tensor on the input device.

## Test plan

- [x] `uv run pytest -q` — 932 passed, 2 skipped (was 893)
- [x] Each fix verified to flip its new regression test from FAIL (without fix) to PASS (with fix)