### PR TITLE
DOC fix docstring drift across 18 modules

### DIFF
--- a/tangermeme/ablate.py
+++ b/tangermeme/ablate.py
@@ -82,10 +82,11 @@ def ablate(
 	shuffle_fn: function
 		A function that will shuffle a portion of the sequence. This can be
 		`ersatz.shuffle`, `ersatz.dinucleotide_shuffle`, or any other function
-		with the signature func(X, start, end, random_state) where `X` is a
+		with the signature func(X, start, end, n, random_state) where `X` is a
 		tensor with shape (-1, len(alphabet), length), `start` and `end` are
-		coordinates on that sequence, and `random_state` is a seed to use to
-		ensure determinism. Default is `ersatz.shuffle`. 
+		coordinates on that sequence, `n` is the number of shuffles to produce,
+		and `random_state` is a seed to use to ensure determinism. Default is
+		`ersatz.shuffle`.
 
 	args: tuple or None, optional
 		An optional set of additional arguments to pass into the model. If
@@ -120,16 +121,17 @@ def ablate(
 	Returns
 	-------
 	y_before: torch.Tensor or list of torch.Tensors
-		The predictions from the model before shuffling the region. If the
-		output from the model's forward function is a single tensor, it will
-		return that. If the model outputs a list of tensors, it will return
-		those.
+		The predictions from the model before shuffling the region, with shape
+		(batch, ...). If the output from the model's forward function is a
+		single tensor, it will return that. If the model outputs a list of
+		tensors, it will return those.
 
 	y_after: torch.Tensor or list of torch.Tensors
-		The predictions from the model after shuffling the region. If the
-		output from the model's forward function is a single tensor, it will
-		return that. If the model outputs a list of tensors, it will return
-		those.
+		The predictions from the model after shuffling the region, with shape
+		(batch, n, ...) — an extra `n` axis is inserted for the n shuffles. If
+		the output from the model's forward function is a single tensor, it
+		will return that. If the model outputs a list of tensors, it will
+		return those.
 	"""
 
 	_validate_input(X, "X", shape=(-1, -1, -1), ohe=True, allow_N=True)
@@ -203,13 +205,18 @@ def ablate_annotations(
 	Returns
 	-------
 	y_befores: torch.Tensor or list of torch.Tensors
-		The application of `func` from the model BEFORE ablating the annotation.
+		The application of `func` from the model BEFORE ablating the
+		annotation, stacked over annotations as the leading axis (shape
+		`(n_annotations, 1, ...)` since each call is on a single example).
 		If the output from the model's forward function is a single tensor, it
 		will return that. If the model outputs a list of tensors, it will return
 		those.
 
 	y_afters: torch.Tensor or list of torch.Tensors
-		The application of `func` from the model AFTER ablating the annotation.
+		The application of `func` from the model AFTER ablating the
+		annotation, stacked over annotations as the leading axis (shape
+		`(n_annotations, 1, n, ...)` since each call is on a single example
+		with `n` shuffles).
 		If the output from the model's forward function is a single tensor, it
 		will return that. If the model outputs a list of tensors, it will return
 		those.

--- a/tangermeme/annotate.py
+++ b/tangermeme/annotate.py
@@ -92,7 +92,7 @@ def annotate_seqlets(
 def count_annotations(
 	X: torch.Tensor | pandas.DataFrame,
 	dtype: torch.dtype = torch.uint8,
-	shape: tuple[int, ...] | None = None,
+	shape: tuple[int, int] | None = None,
 	dim: int | None = None,
 ) -> torch.Tensor:
 	"""A method for counting the annotations for each example.
@@ -112,9 +112,12 @@ def count_annotations(
 		the second column is the annotation_idx. Both should be integers. 
 
 	dtype: torch.dtype, optional
-		The dtype of the returned matrix. Default is torch.uint8.
+		The dtype of the returned matrix. Default is torch.uint8. Note that
+		counts above 255 will silently overflow under the default dtype; pass
+		a wider dtype (e.g. `torch.int32`) if any (example, annotation) pair
+		may occur more than 255 times.
 
-	shape: tuple or None, optional
+	shape: tuple of (int, int) or None, optional
 		A user-defined shape of the returned count matrix. Use this if you are
 		not sure whether all examples or annotations are observed in `X` but you
 		want to have a constant shape. If None, derive shape from the maximum
@@ -188,7 +191,7 @@ def pairwise_annotations(
 	dtype: torch.dtype = torch.int64,
 	unique: bool = True,
 	symmetric: bool = True,
-	shape: tuple[int, ...] | None = None,
+	shape: int | None = None,
 ) -> torch.Tensor:
 	"""Returns the number of times pairs of annotations occur in an example.
 
@@ -218,8 +221,10 @@ def pairwise_annotations(
 
 	symmetric: bool, optional
 		Whether to return a symmetric matrix or one where the row is the first
-		element in `X` and the column is the subsequent element in `X`. If
-		symmetric, the diagonal is NOT double counted. Default is True.
+		element in `X` and the column is the subsequent element in `X` (i.e.
+		ordering follows the order rows appear in `X`, not the spatial layout
+		of the annotations). If symmetric, the diagonal is NOT double counted.
+		Default is True.
 
 	shape: int or None, optional
 		The number of rows and columns to use in the matrix. If None, infer the
@@ -283,7 +288,7 @@ def pairwise_annotations_spacing(
 	max_distance: int = 100,
 	dtype: torch.dtype = torch.uint8,
 	symmetric: bool = True,
-	shape: tuple[int, ...] | None = None,
+	shape: int | None = None,
 ) -> torch.Tensor:
 	"""Finds the number of times each annotation pair occurs at each distance.
 
@@ -316,12 +321,18 @@ def pairwise_annotations_spacing(
 		consider. Default is 100.
 
 	dtype: torch.dtype, optional
-		The dtype of the returned matrix. Default is torch.uint8.
+		The dtype of the returned matrix. Default is torch.uint8. Note that
+		counts above 255 will silently overflow under the default dtype; pass
+		a wider dtype (e.g. `torch.int32`) if any (motif_a, motif_b, distance)
+		bin may occur more than 255 times.
 
 	symmetric: bool, optional
-		Whether to return a symmetric matrix or one where the row is the first
-		element in `X` and the column is the subsequent element in `X`. If
-		symmetric, the diagonal is NOT double counted. Default is True.
+		Whether to return a symmetric matrix or one where the row is the
+		spatially leftmost annotation of the pair and the column is the
+		spatially rightmost (i.e. ordering is determined by `start` position
+		within each example, NOT by the order rows appear in `X`; this
+		differs from `pairwise_annotations`). If symmetric, the diagonal is
+		NOT double counted. Default is True.
 
 	shape: int or None, optional
 		The number of rows and columns to use in the matrix. If None, infer the

--- a/tangermeme/deep_lift_shap.py
+++ b/tangermeme/deep_lift_shap.py
@@ -292,13 +292,16 @@ def deep_lift_shap(
 		is 32.
 
 	references: func or torch.Tensor, optional
-		If a function is passed in, this function is applied to each sequence
-		with the provided random state and number of shuffles. This function
-		should serve to transform a sequence into some form of signal-null
+		If a function is passed in, the function must accept `(X, n=...)` and
+		(when `random_state` is not None) `(X, n=..., random_state=...)`. It is
+		called with `n=1` per shuffle and once per `(example, shuffle_idx)` pair
+		when seeded, or once per batch when not. It should return a tensor
+		shaped `(batch, 1, *X.shape[1:])` (the second axis is squeezed off).
+		The function should transform a sequence into some form of signal-null
 		background, such as by shuffling it. If a torch.Tensor is passed in,
 		that tensor must have shape `(len(X), n_shuffles, *X.shape[1:])`, in
 		that for each sequence a number of shuffles are provided. Default is
-		the function `dinucleotide_shuffle`. 
+		the function `dinucleotide_shuffle`.
 
 	n_shuffles: int, optional
 		The number of shuffles to use if a function is given for `references`.
@@ -306,8 +309,8 @@ def deep_lift_shap(
 
 	return_references: bool, optional
 		Whether to return the references that were generated during this
-		process. Only use if `references` is not a torch.Tensor. Default is 
-		False. 
+		process. Only use if `references` is not a torch.Tensor. Default is
+		False.
 
 	hypothetical: bool, optional
 		Whether to return attributions for all possible characters at each
@@ -344,8 +347,9 @@ def deep_lift_shap(
 
 	only_warn: bool, optional
 		Whether to only warn when a violation is recorded instead of raise a
-		terminating error. This allows users to indicate that they know what they
-		are doing. Default is False.
+		terminating error. This applies to input validation on `X` and (if
+		passed) `references`; it does NOT suppress the runtime convergence-delta
+		warnings emitted from the DeepLIFT computation itself. Default is False.
 
 	dtype: str or torch.dtype or None, optional
 		The dtype to use with mixed precision autocasting. If None, use the dtype of
@@ -357,9 +361,11 @@ def deep_lift_shap(
 		None, use CUDA when available and fall back to CPU otherwise. Default
 		is None.
 
-	random_state: int or None or numpy.random.RandomState, optional
-		The random seed to use to ensure determinism. If None, the
-		process is not deterministic. Default is None.
+	random_state: int or None, optional
+		The random seed to use to ensure determinism. Must be an int (or None);
+		the value is added to per-shuffle offsets when calling `references`, so
+		`numpy.random.RandomState` instances are not supported here. If None,
+		the process is not deterministic. Default is None.
 
 	verbose: bool, optional
 		Whether to display a progress bar. Default is False.
@@ -376,7 +382,7 @@ def deep_lift_shap(
 	references: torch.tensor, optional
 		The references used for each input sequence, with the shape
 		(n_input_sequences, n_shuffles, 4, length). Only returned if
-		`return_references = True`. 
+		`return_references = True`.
 	"""
 
 	_validate_input(X, "X", shape=(-1, -1, -1), ohe=True, only_warn=only_warn)
@@ -589,13 +595,15 @@ def _captum_deep_lift_shap(
 	random_state: int | numpy.random.RandomState | None = None,
 	verbose: bool = False,
 ) -> torch.Tensor | AttributionReferencesResult:
-	"""Calculate attributions using DeepLift/Shap and a given model. 
+	"""Calculate attributions using captum's DeepLiftShap and a given model.
 
 	This function will calculate DeepLift/Shap attributions on a set of
-	sequences. It assumes that the model returns "logits" in the first output,
-	not softmax probabilities, and count predictions in the second output.
-	It will create GC-matched negatives to use as a reference and proceed
-	using the given batch size.
+	sequences by delegating to captum's `DeepLiftShap` and using a user-
+	supplied (or default `dinucleotide_shuffle`) reference function or
+	pre-computed reference tensor, the same `references` contract used by
+	`deep_lift_shap`. It does NOT make any assumption about the structure of
+	the model output (no BPNet logits/counts split) and it does NOT generate
+	GC-matched negatives.
 
 	This is an internal/debugging function that is mostly meant to be used to
 	check for differences with the `deep_lift_shap` method.
@@ -634,13 +642,15 @@ def _captum_deep_lift_shap(
 		is 32.
 
 	references: func or torch.Tensor, optional
-		If a function is passed in, this function is applied to each sequence
-		with the provided random state and number of shuffles. This function
-		should serve to transform a sequence into some form of signal-null
-		background, such as by shuffling it. If a torch.Tensor is passed in,
-		that tensor must have shape `(len(X), n_shuffles, *X.shape[1:])`, in
-		that for each sequence a number of shuffles are provided. Default is
-		the function `dinucleotide_shuffle`. 
+		If a function is passed in, the function must accept `(X, n=...,
+		random_state=...)`. It is called once per example with `n=n_shuffles`
+		and should return a tensor shaped `(1, n_shuffles, *X.shape[1:])`
+		(the leading axis is indexed off). The function should transform a
+		sequence into some form of signal-null background, such as by
+		shuffling it. If a torch.Tensor is passed in, that tensor must have
+		shape `(len(X), n_shuffles, *X.shape[1:])`, in that for each sequence
+		a number of shuffles are provided. Default is the function
+		`dinucleotide_shuffle`.
 
 	n_shuffles: int, optional
 		The number of shuffles to use if a function is given for `references`.
@@ -648,8 +658,8 @@ def _captum_deep_lift_shap(
 
 	return_references: bool, optional
 		Whether to return the references that were generated during this
-		process. Only use if `references` is not a torch.Tensor. Default is 
-		False. 
+		process. Only use if `references` is not a torch.Tensor. Default is
+		False.
 
 	hypothetical: bool, optional
 		Whether to return attributions for all possible characters at each
@@ -663,9 +673,10 @@ def _captum_deep_lift_shap(
 		None, use CUDA when available and fall back to CPU otherwise. Default
 		is None.
 
-	random_state: int or None or numpy.random.RandomState, optional
-		The random seed to use to ensure determinism. If None, the
-		process is not deterministic. Default is None.
+	random_state: int or None, optional
+		The random seed to use to ensure determinism. Passed through to the
+		`references` callable; `numpy.random.RandomState` instances are not
+		supported. If None, the process is not deterministic. Default is None.
 
 	verbose: bool, optional
 		Whether to display a progress bar. Default is False.
@@ -680,7 +691,7 @@ def _captum_deep_lift_shap(
 	references: torch.tensor, optional
 		The references used for each input sequence, with the shape
 		(n_input_sequences, n_shuffles, 4, length). Only returned if
-		`return_references = True`. 
+		`return_references = True`.
 	"""
 
 	from captum.attr import DeepLiftShap as CaptumDeepLiftShap

--- a/tangermeme/design.py
+++ b/tangermeme/design.py
@@ -95,11 +95,14 @@ def screen(
 		torch.nn.MSELoss().
 
 	tol: float, optional
-		A threshold on how small the loss should be before terminating the screening
-		procedure. Default is 1e-3.
+		A threshold on the loss below which the screening procedure terminates.
+		Termination requires the loss of the *worst* kept candidate (i.e. the
+		`n_best`-th best so far) to fall below `tol` — when `n_best > 1` the
+		current best may have been below `tol` for many iterations before this
+		condition triggers. Default is 1e-3.
 
 	max_iter: int, optional
-		The maximum number of iterations to run before terminating the procedure. 
+		The maximum number of iterations to run before terminating the procedure.
 		Set to -1 for no limit. Default is -1.
 
 	args: tuple or list or None, optional
@@ -115,7 +118,10 @@ def screen(
 		observed across all generation batches. Default is 1.
 
 	batch_size: int, optional
-		The number of examples to make predictions for at a time. Default is 32.
+		The number of sequences to generate (via `func`) and evaluate per
+		iteration. This controls the size of each generation/screening batch;
+		it is NOT forwarded to `predict`'s own batch_size (which retains its
+		default). Default is 32.
 
 	func: function, optional
 		The function to use to generate sequences. The signature of this function
@@ -142,7 +148,9 @@ def screen(
 
 	random_state: int or None, optional
 		The random seed to use to ensure determinism of the generation function.
-		If None, not deterministic. Default is None.
+		The seed is incremented by 1 at the end of each iteration so successive
+		iterations draw different sequences while remaining reproducible. If
+		None, not deterministic. Default is None.
 
 	verbose: bool, optional
 		Whether to display a progress bar during predictions. Default is False.
@@ -283,7 +291,11 @@ def greedy_substitution(
 
 	max_iter: int, optional
 		The maximum number of iterations to run before terminating the
-		procedure. Set to -1 for no limit. Default is -1.
+		procedure. The loop condition is `iteration < max_iter`, so any
+		non-positive value (including the `-1` default) causes the loop body
+		to never execute and the original `X` to be returned unchanged. Pass
+		a positive integer (or a large sentinel such as `10**9`) for actual
+		iteration. Default is -1.
 
 	args: tuple or list or None, optional
 		An optional set of additional arguments to pass into the model. If
@@ -321,7 +333,7 @@ def greedy_substitution(
 	tic = time.time()
 	iteration = 0
 
-	X = torch.clone(X)	
+	X = torch.clone(X)
 	y_orig = predict(model, X, args=args, batch_size=batch_size, device=device, 
 		verbose=False)
 

--- a/tangermeme/ersatz.py
+++ b/tangermeme/ersatz.py
@@ -650,13 +650,22 @@ def dinucleotide_shuffle(
 		Whether to use a specific random seed when generating the shuffle,
 		to ensure reproducibility. If None, do not use a reproducible seed.
 		Unlike other methods, cannot be a numpy.random.RandomState object.
+		Note: the seed used for the i-th sequence in the batch is
+		`random_state + i`, so the per-sequence stream depends on batch
+		position. Two calls with the same `random_state` but different batch
+		sizes will agree on the leading prefix of sequences (positions where
+		both batches contain that index) but diverge otherwise; this also
+		means sequence 0 of one batch is reproduced as sequence 0 of any
+		other batch that uses the same `random_state`.
 		Default is None.
 
 
 	Returns
 	-------
-	shuffled_sequences: torch.tensor, shape=(-1, n, k, -1)
-		The shuffled sequences.
+	shuffled_sequences: torch.tensor, shape=(-1, n, len(alphabet), length)
+		The shuffled sequences. Dtype and device match the input `X` (the
+		internal float32 buffer is cast on assignment back into a clone of
+		`X`).
 	"""
 
 	_validate_input(X, "X", shape=(-1, -1, -1), ohe=True, ohe_dim=1)

--- a/tangermeme/io.py
+++ b/tangermeme/io.py
@@ -211,6 +211,14 @@ def _extract_locus_signal(signals, chrom, start, end):
 	-------
 	values: list of numpy.ndarrays, shape=(len(signals), end-start)
 		The extracted signal from each of the signal files.
+
+	Notes
+	-----
+	When `signal` is a dict, each `signal[chrom]` is assumed to be a 1-D
+	array indexable by genomic position. Passing a `(n_tracks, length)`
+	array under a single chromosome key will silently slice the first axis
+	instead of positions and yield mis-shaped output; provide one signal
+	dict per track in the outer `signals` list instead.
 	"""
 
 	if not isinstance(signals, (list, tuple)):
@@ -616,19 +624,26 @@ def read_vcf(filename: str) -> pandas.DataFrame:
 
 	This function takes in the name of a file that is VCF formatted and returns
 	a pandas DataFrame with the comments filtered out. This will only return the
-	columns that are most commonly provided in VCF files.
+	first 9 columns (CHROM, POS, ID, REF, ALT, QUAL, FILTER, INFO, FORMAT); any
+	per-sample genotype columns past column 9 are silently dropped.
+
+	Compressed VCFs are read transparently when pandas detects the compression
+	from the filename extension (e.g., `.vcf.gz` works via `pandas.read_csv`).
+	BCF (binary VCF) files are NOT supported by this function.
 
 
 	Parameters
 	----------
 	filename: str
-		The path to the VCF-formatted file to read in.
+		The path to the VCF-formatted file to read in. May be plain `.vcf` or
+		gzip-compressed `.vcf.gz`.
 
 
 	Returns
 	-------
 	vcf: pandas.DataFrame
-		A pandas DataFrame containing the rows.
+		A pandas DataFrame containing the rows, with columns CHROM, POS, ID,
+		REF, ALT, QUAL, FILTER, INFO, FORMAT.
 	"""
 
 	names = ["CHROM", "POS", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO", 

--- a/tangermeme/kmers.py
+++ b/tangermeme/kmers.py
@@ -207,7 +207,9 @@ def gapped_kmers(
 
 	max_gkmers: int, optional
 		The maximum number of gapped k-mers to return per example, ranked by
-		absolute score. Default is 10.
+		absolute score. Any gapped k-mers beyond this cap are silently
+		dropped from the output sparse matrix; raise this if your example
+		may contain more than 10 meaningful gapped k-mers. Default is 10.
 
 	max_pos: int or None, optional
 		If provided, only consider the top `max_pos` positions per example

--- a/tangermeme/marginalize.py
+++ b/tangermeme/marginalize.py
@@ -65,9 +65,11 @@ def marginalize(
 	X: torch.tensor, shape=(-1, len(alphabet), length)
 		A one-hot encoded set of sequences to have a motif inserted into.
 
-	motif: torch.tensor, shape=(-1, len(alphabet), motif_length)
-		A one-hot encoded version of a short motif to insert into the set of
-		sequences.
+	motif: torch.tensor or str
+		Either a one-hot encoded short motif with shape
+		`(-1, len(alphabet), motif_length)` to insert into the set of
+		sequences, or a string that will be one-hot encoded internally using
+		`alphabet` (and the `N` ignore convention from `ersatz.substitute`).
 
 	start: int or None, optional
 		The starting position of where to insert the motif. If None, insert the

--- a/tangermeme/match.py
+++ b/tangermeme/match.py
@@ -428,10 +428,12 @@ def extract_matching_loci(
 		from this bigwig. If None, do not filter based on signal strength.
 		Default is None.
 
-	signal_beta: float or None, optional
+	signal_beta: float, optional
 		A multiplier of the robust minimum signal calculated from `loci` that
-		each background region must have fewer reads then. Only relevant if a
-		bigwig is passed in. Default is 0.5.
+		each background region must have fewer reads than. Only relevant if a
+		bigwig is passed in. Must be a number when `bigwig` is set (the code
+		computes `robust_min * signal_beta`); passing `None` together with a
+		`bigwig` raises a `TypeError`. Default is 0.5.
 
 	chroms: list, tuple, or None, optional
 		A set of chromosomes to use when choosing matching loci. If None, only

--- a/tangermeme/pisa.py
+++ b/tangermeme/pisa.py
@@ -164,6 +164,19 @@ def pisa(
         The references used for each input sequence, with the shape
         (n_input_sequences, n_shuffles, 4, length). Only returned if
         `return_references = True`.
+
+    Notes
+    -----
+    `n_outputs` is inferred from the *last* axis of the model's output
+    (`predict(model, X[:1]).shape[-1]`). Profile-style models that return
+    `(batch, n_tasks, length)` will therefore be attributed over `length`
+    only — to attribute over tasks instead, wrap the model in a small
+    adapter that transposes or flattens the output.
+
+    The returned `attributions` and `references` tensors are produced via
+    `torch.stack` over per-example accumulators and may live on the input
+    device rather than CPU in some return paths; explicit `.cpu()` is
+    advisable when consuming results on a non-CUDA host.
     """
 
     _validate_input(X, "X", shape=(-1, -1, -1), ohe=True)

--- a/tangermeme/plot.py
+++ b/tangermeme/plot.py
@@ -608,10 +608,11 @@ def plot_pwm(
 ) -> matplotlib.axes.Axes:
 	"""Plot an information-content weighted PWM as a sequence logo.
 
-	This function takes in a PWM, where the sum across all values in the
-	alphabet is equal to 1, and plots the information-content weighted
-	version of it. To visualize the reverse complement, call this function
-	a second time with `pwm[::-1, ::-1]`.
+	This function takes in a PWM with shape `(len(alphabet), length)`,
+	where each column (position) sums to 1 across the alphabet axis, and
+	plots the information-content weighted version of it. To visualize
+	the reverse complement, call this function a second time with
+	`pwm[::-1, ::-1]`.
 
 	The function no longer creates its own figure or calls `plt.show()`;
 	it draws on the provided `ax` (or `plt.gca()` if none is given) and
@@ -622,7 +623,8 @@ def plot_pwm(
 	Parameters
 	----------
 	pwm: torch.Tensor or numpy.ndarray, shape=(len(alphabet), length)
-		The PWM to visualize. The rows must sum to 1.
+		The PWM to visualize. Each *column* (i.e. position) must sum to 1
+		across the alphabet axis.
 
 	ax: matplotlib.axes.Axes or None, optional
 		The axes to draw on. If None, use the current axes via

--- a/tangermeme/predict.py
+++ b/tangermeme/predict.py
@@ -56,7 +56,10 @@ def predict(
 		provided, each element in the tuple or list is one input to the model
 		and the element must be formatted to be the same batch size as `X`. If
 		None, no additional arguments are passed into the forward function.
-		Default is None.
+		Each per-batch slice is cast to `dtype` before being passed to the
+		model — integer index tensors and boolean masks will be silently
+		coerced to float, so pre-cast them or pass non-floating-point
+		auxiliary inputs through a model wrapper instead. Default is None.
 
 	func: function or None, optional 
 		A function to apply to a batch of predictions after they have been made.
@@ -82,12 +85,13 @@ def predict(
 
 	Returns
 	-------
-	y: torch.Tensor or list/tuple of torch.Tensors
+	y: torch.Tensor or list of torch.Tensors
 		The output from the model for each input example. The precise format
 		is determined by the model. If the model outputs a single tensor,
 		y is a single tensor concatenated across all batches. If the model
-		outputs multiple tensors, y is a list of tensors which are each
-		concatenated across all batches.
+		outputs multiple tensors (list or tuple), y is always returned as a
+		list (the original tuple container type is not preserved) of tensors
+		which are each concatenated across all batches.
 	"""
 
 	if X.shape[0] == 0:

--- a/tangermeme/product.py
+++ b/tangermeme/product.py
@@ -92,8 +92,12 @@ def apply_pairwise(
 		This is provided as an alternate path to route arguments into the
 		function in case they overlap, name-wise, with those in this function,
 		or if you want to be absolutely sure that the arguments are making
-		their way into the function. The dict is not modified in place. Default
-		is None.
+		their way into the function. The dict is not modified in place. Note
+		that overlap between keys of `additional_func_kwargs` and `**kwargs`
+		raises `TypeError: multiple values for keyword argument` from
+		Python's call-site dict-unpacking; only collisions with *this*
+		function's named parameters are resolved by routing through
+		`additional_func_kwargs`. Default is None.
 
 	verbose: bool, optional
 		Whether to display a progress bar as examples are processed. Default
@@ -251,8 +255,12 @@ def apply_product(
 		This is provided as an alternate path to route arguments into the
 		function in case they overlap, name-wise, with those in this function,
 		or if you want to be absolutely sure that the arguments are making
-		their way into the function. The dict is not modified in place. Default
-		is None.
+		their way into the function. The dict is not modified in place. Note
+		that overlap between keys of `additional_func_kwargs` and `**kwargs`
+		raises `TypeError: multiple values for keyword argument` from
+		Python's call-site dict-unpacking; only collisions with *this*
+		function's named parameters are resolved by routing through
+		`additional_func_kwargs`. Default is None.
 
 	verbose: bool, optional
 		Whether to display a progress bar as examples are processed. Default

--- a/tangermeme/saturation_mutagenesis.py
+++ b/tangermeme/saturation_mutagenesis.py
@@ -63,20 +63,26 @@ def _attribution_score(y0, y_hat, target):
 @numba.njit("void(int8[:, :, :], int32, int32)")
 def _edit_distance_one(X, start, end):
 	"""An internal function for generating all sequences of edit distance 1
-	
+
 	This internal function, which is meant to be used for ISM, will take in a
 	one-hot encoded sequence and return all sequences that have an edit distance
-	of one. 
-	
-	
+	of one.
+
+	Note: the inner loop iterates over all 4 alphabet characters at each
+	mutated position, *including* the character already at that position.
+	One of the four "variants" per position is therefore an identity
+	substitution (a no-op); it contributes a zero into the per-position
+	mean used by `_attribution_score`. Callers wanting strict
+	edit-distance-1 outputs should mask or skip those rows.
+
 	Parameters
 	----------
 	X: torch.Tensor, shape=(length*len(alphabet), len(alphabet), length)
 		A single one-hot encoded sequence.
-	
+
 	start: int
 		The first nucleotide to begin making edits on, inclusive.
-	
+
 	end: int
 		The end of the span. Edits are not made on this nucleotide at this
 		index. Can be negative indexes.
@@ -147,9 +153,12 @@ def saturation_mutagenesis(
 		Default is 0.
 	
 	end: int, optional
-		The end of where to make perturbations to the sequence. If end is
-		positive, it is non-inclusive. If end is negative, it is inclusive.
-		Default is -1, meaning the entire sequence.
+		The end of where to make perturbations to the sequence. Positive
+		values follow standard Python slice semantics (non-inclusive).
+		Negative values are remapped via `end = length + 1 + end` so that
+		`end=-1` maps to `length` and the *last* nucleotide is included.
+		Note this differs from Python's `X[start:-1]` (which would drop the
+		last element). Default is -1, meaning the entire sequence.
 	
 	batch_size: int, optional
 		The number of examples to make predictions for at a time. Default is 32.

--- a/tangermeme/seqlet.py
+++ b/tangermeme/seqlet.py
@@ -114,8 +114,8 @@ def _iterative_extract_seqlets(X_sum, window_size, flank, suppress):
 	Returns
 	-------
 	seqlets: list
-		A list of tuples containing the example index, the start of the seqlet,
-		the end of the seqlet, and the sum of attributions within the seqlet.
+		A list of 3-tuples `(example_index, start, end)`. The sum of
+		attributions within the seqlet is NOT included in this output.
 	"""
 
 	n, d = X_sum.shape

--- a/tangermeme/space.py
+++ b/tangermeme/space.py
@@ -71,7 +71,9 @@ def space(
 		and each column is the spacing between an adjacent pair of motifs.
 		Specifically, the 1st column corresponds to the spacing between the
 		first and second motif, the 2nd column corresponds to the spacing
-		between the second and third motif, etc. 
+		between the second and third motif, etc. Must be 2-D; scalar/1-D
+		`spacing` is rejected here (unlike `multisubstitute`, which accepts a
+		single int and broadcasts it).
 
 	start: int or None, optional
 		The starting position of where to insert the first motif. If None, the
@@ -95,12 +97,17 @@ def space(
 		This is provided as an alternate path to route arguments into the
 		function in case they overlap, name-wise, with those in this function,
 		or if you want to be absolutely sure that the arguments are making
-		their way into the function. The dict is not modified in place. Default
-		is None.
+		their way into the function. The dict is not modified in place. Note
+		that overlap between keys of `additional_func_kwargs` and `**kwargs`
+		raises `TypeError: multiple values for keyword argument` from
+		Python's call-site dict-unpacking; only collisions with *this*
+		function's named parameters are resolved by routing through
+		`additional_func_kwargs`. Default is None.
 
 	verbose: bool, optional
-		Whether to display a progress bar as spacings are evaluated. Default
-		is False.
+		Whether to display a progress bar as spacings are evaluated. Only
+		drives the outer spacing-loop progress bar; it is NOT forwarded to
+		inner `func` calls. Default is False.
 
 	kwargs: optional
 		Additional named arguments that will get passed into the function when
@@ -110,13 +117,14 @@ def space(
 	Returns
 	-------
 	y_before: torch.Tensor or list of torch.Tensors
-		The predictions from the model before inserting the motifs in. If the
-		output from the model's forward function is a single tensor, it will
-		return that. If the model outputs a list of tensors, it will return
-		those.
+		The predictions from the model before inserting the motifs in, with
+		shape `(batch, ...)`. If the output from the model's forward function
+		is a single tensor, it will return that. If the model outputs a list
+		of tensors, it will return those.
 
 	y_afters: torch.Tensor or list of torch.Tensors
-		The predictions from the model after inserting the motifs in. If the
+		The predictions from the model after inserting the motifs in, stacked
+		over spacings as axis 1: shape `(batch, n_spacings, ...)`. If the
 		output from the model's forward function is a single tensor, it will
 		return that. If the model outputs a list of tensors, it will return
 		those.

--- a/tangermeme/utils.py
+++ b/tangermeme/utils.py
@@ -541,6 +541,16 @@ def reverse_complement(
 	-------
 	rev_comp: str or torch.Tensor w/ shape (alphabet_size, length)
 		The reverse complemented string or tensor, matching the type of `seq`.
+
+	Notes
+	-----
+	The tensor path is 2-D only (shape `(alphabet_size, length)`). Passing a
+	batched tensor with shape `(N, A, L)` is NOT rejected but produces silently
+	wrong output: `torch.flip(..., dims=(-1,))` flips the last axis as
+	intended, but the subsequent `[idxs]` indexing permutes the *first* axis,
+	which on a batched input is the batch dimension instead of the alphabet
+	axis. Iterate over the batch (or unsqueeze and call once per row) until a
+	proper batched path is added.
 	"""
 
 	if isinstance(seq, str):
@@ -719,11 +729,13 @@ def unchunk(
 		A set of fixed-length tensors for any number of outputs. Usually the
 		result of applying `chunk` and then some form of model.
 
-	lengths: list or numpy.ndarray or torch.tensor, shape=(-1,) or None
+	lengths: list or numpy.ndarray or torch.tensor, shape=(-1,)
 		The *original lengths* of the elements that were chunked. This is not
 		the number of chunks produced, which will be influenced by the overlap,
-		but the actual length in bp of the original sequences. If None, assume
-		that all chunks in `X` come from a single variable-length sequence.
+		but the actual length in bp of the original sequences. Note: the
+		signature also lists `None` as the type, but the current
+		implementation calls `_validate_input(_cast_as_tensor(lengths), ...)`
+		which rejects `None`; a length tensor must be provided in practice.
 		Default is None.
 
 	overlap: int, optional

--- a/tangermeme/variant_effect.py
+++ b/tangermeme/variant_effect.py
@@ -66,7 +66,10 @@ def substitution_effect(
 		variant, the first column is the index in `X`, the second index is the
 		position in that example, and the third index is the index into the
 		alphabet that should be present at that position (overriding whatever
-		is currently there). 
+		is currently there). Note: multiple rows targeting the same
+		`(example, position)` pair are applied in row order via tensor
+		assignment, so the *last* row wins. Order your rows accordingly if
+		you intend to chain edits at the same position.
 
 	args: tuple or None, optional
 		An optional set of additional arguments to pass into the model. If
@@ -84,8 +87,12 @@ def substitution_effect(
 		This is provided as an alternate path to route arguments into the
 		function in case they overlap, name-wise, with those in this function,
 		or if you want to be absolutely sure that the arguments are making
-		their way into the function. The dict is not modified in place. Default
-		is None.
+		their way into the function. The dict is not modified in place. Note
+		that overlap between keys of `additional_func_kwargs` and `**kwargs`
+		raises `TypeError: multiple values for keyword argument` from
+		Python's call-site dict-unpacking; only collisions with *this*
+		function's named parameters are resolved by routing through
+		`additional_func_kwargs`. Default is None.
 
 	kwargs: optional
 		Additional named arguments that will get passed into the function when
@@ -201,8 +208,12 @@ def deletion_effect(
 		This is provided as an alternate path to route arguments into the
 		function in case they overlap, name-wise, with those in this function,
 		or if you want to be absolutely sure that the arguments are making
-		their way into the function. The dict is not modified in place. Default
-		is None.
+		their way into the function. The dict is not modified in place. Note
+		that overlap between keys of `additional_func_kwargs` and `**kwargs`
+		raises `TypeError: multiple values for keyword argument` from
+		Python's call-site dict-unpacking; only collisions with *this*
+		function's named parameters are resolved by routing through
+		`additional_func_kwargs`. Default is None.
 
 	kwargs: optional
 		Additional named arguments that will get passed into the function when
@@ -212,7 +223,12 @@ def deletion_effect(
 	Returns
 	-------
 	y_before: torch.Tensor
-		The output from `func` before variants are included.
+		The output from `func` on a trimmed slice of `X` — NOT on the raw
+		input. Specifically, `X` is reduced to `model_length` columns by
+		dropping `max_deletions_per_example` characters from the left when
+		`left=True` (otherwise from the right) so the slice fed to the model
+		has the same shape as the post-deletion sequence. Use the same
+		`left` value the model was trained on.
 
 	y_after: torch.Tensor
 		The output from `func` after the variants are included.
@@ -338,8 +354,12 @@ def insertion_effect(
 		This is provided as an alternate path to route arguments into the
 		function in case they overlap, name-wise, with those in this function,
 		or if you want to be absolutely sure that the arguments are making
-		their way into the function. The dict is not modified in place. Default
-		is None.
+		their way into the function. The dict is not modified in place. Note
+		that overlap between keys of `additional_func_kwargs` and `**kwargs`
+		raises `TypeError: multiple values for keyword argument` from
+		Python's call-site dict-unpacking; only collisions with *this*
+		function's named parameters are resolved by routing through
+		`additional_func_kwargs`. Default is None.
 
 	kwargs: optional
 		Additional named arguments that will get passed into the function when


### PR DESCRIPTION
## Summary
- 18 doc-only commits, one per module, addressing docstring/behavior drift surfaced during the package review
- No runtime behavior changes — only docstrings, inline comments, and type annotations narrowed to match actual code paths
- Full test suite passes (932 passed, 2 skipped), matching the main-branch baseline

## Highlights per module
- `ablate` — corrected `shuffle_fn` contract and `(batch, n, ...)` return shape
- `annotate` — narrowed `shape` types; documented uint8 overflow and symmetric divergence
- `deep_lift_shap` — rewrote `references` callable contract; narrowed `only_warn`/`random_state`
- `design` — clarified `tol`, `batch_size`, `random_state`, and `max_iter=-1` semantics
- `ersatz` — documented `dinucleotide_shuffle` per-sequence seed offset and dtype/device passthrough
- `io` — `_extract_locus_signal` 1-D assumption; `read_vcf` 9-col limit and gzip/BCF scope
- `kmers` — flagged silent `max_gkmers=10` truncation
- `marginalize` — documented motif string acceptance
- `match` — narrowed `signal_beta` to float-only; documented None+bigwig TypeError
- `pisa` — `n_outputs` last-axis assumption and device caveat
- `plot` — fixed `plot_pwm` row/column normalization claim
- `predict` — documented `args` dtype coercion footgun; narrowed Returns to list-only
- `product` — documented `additional_func_kwargs` vs `**kwargs` collision
- `saturation_mutagenesis` — explicit negative-end mapping; identity-substitution note
- `seqlet` — fixed `_iterative_extract_seqlets` Returns tuple arity
- `space` — documented `(batch, n_spacings, ...)` return; spacing 2-D requirement; kwarg collision
- `utils` — `reverse_complement` batched-tensor footgun; `unchunk(lengths=None)` non-functional
- `variant_effect` — `substitution_effect` last-write-wins; `deletion_effect` trimmed `y_before`; kwarg collision

## Test plan
- [x] `uv run pytest` — 932 passed, 2 skipped
- [x] No code paths touched; all changes are within docstrings/comments/type hints
- [ ] Reviewer spot-check that documented behavior matches code

🤖 Generated with [Claude Code](https://claude.com/claude-code)