### PR TITLE
ADD bundled Claude Code skill and installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,22 @@ uv run pytest -m "not cmd"
 
 This installs the package in editable mode along with the testing toolchain (`pytest`, `captum`, `ruff`, `build`, `twine`).
 
+## Claude Code Skill
+
+tangermeme ships an [Agent Skill](https://docs.claude.com/en/docs/claude-code/skills) for [Claude Code](https://claude.com/claude-code) that teaches the agent how to use the library correctly — the API contracts, the footguns (e.g., `deep_lift_shap` needs `target=` for multi-task models, `extract_loci` has a variable-length return), and the multi-step workflows. It is bundled with the package but, because Claude Code does not scan installed Python packages, you install it once into your personal skills directory:
+
+```bash
+tangermeme-install-skills
+```
+
+This copies the skill to `~/.claude/skills/tangermeme/`, where it is available to Claude Code in **every** project. Re-run with `--force` after upgrading tangermeme to refresh it. Once installed, just ask Claude Code to do tangermeme tasks ("compute DeepLIFT/SHAP attributions on these peaks", "marginalize this motif", "set up a notebook to inspect what my model learned") and the skill is consulted automatically. The skill is a router (`SKILL.md`) that points to detailed reference files loaded on demand, so it adds essentially no context cost until it is used.
+
+If you would rather not copy files into your home directory, point Claude Code at the bundled copy in place instead:
+
+```bash
+export CLAUDE_SKILLS_PATH="$(tangermeme-install-skills --print-path)"
+```
+
 ## Roadmap
 
 This first release focused on the core prediction-based functionality (e.g., marginalizations, ISM, etc..) that subsequent releases will build on. Although my focus will largely follow my research projects and the feedback I receive from the community, here is a roadmap for what I currently plan to focus on in the next few releases.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,18 @@ Contributors should clone the repository and use ``uv`` to create a reproducible
     uv run pytest -m "not cmd"
 
 
+Claude Code Skill
+-----------------
+
+tangermeme ships an `Agent Skill <https://docs.claude.com/en/docs/claude-code/skills>`_ for `Claude Code <https://claude.com/claude-code>`_ that teaches the agent how to use the library correctly — the API contracts, the common footguns, and the multi-step workflows. It is bundled with the package, but because Claude Code does not scan installed Python packages you install it once into your personal skills directory:
+
+.. code-block:: bash
+
+    tangermeme-install-skills
+
+This copies the skill to ``~/.claude/skills/tangermeme/``, where it is available to Claude Code in every project (re-run with ``--force`` after upgrading to refresh it). Once installed, simply ask Claude Code to perform tangermeme tasks and the skill is consulted automatically. To instead point Claude Code at the bundled copy in place, set ``CLAUDE_SKILLS_PATH`` to the output of ``tangermeme-install-skills --print-path``.
+
+
 Thank You
 =========
 

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -6,6 +6,18 @@ Release History
 ===============
 
 
+Version 1.3.0
+=============
+
+*Unreleased.*
+
+Claude Code skill
+-----------------
+
+	- Bundles a `Claude Code <https://claude.com/claude-code>`_ Agent Skill (a ``SKILL.md`` router plus on-demand reference files) that documents tangermeme's API contracts, footguns, and multi-step workflows for coding agents.
+	- Adds the ``tangermeme-install-skills`` console script, which copies the bundled skill into ``~/.claude/skills/`` so it is available to Claude Code in every project. Use ``--force`` to refresh after upgrading or ``--print-path`` for the ``CLAUDE_SKILLS_PATH`` route.
+
+
 Version 1.2.0
 =============
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ docs = [
     "nbconvert>=7.0",
 ]
 
+[project.scripts]
+tangermeme-install-skills = "tangermeme._skills.install:main"
+
 [project.urls]
 Homepage      = "https://github.com/jmschrei/tangermeme"
 Repository    = "https://github.com/jmschrei/tangermeme"

--- a/tangermeme/_skills/__init__.py
+++ b/tangermeme/_skills/__init__.py
@@ -1,0 +1,9 @@
+# _skills
+# Contact: Jacob Schreiber <jmschreiber91@gmail.com>
+
+"""Bundled Claude Code Agent Skill and its installer.
+
+This subpackage keeps the tangermeme Agent Skill (the ``data/`` directory) and the
+command that installs it (``install.py``) together and out of the main module
+namespace. See ``install.py`` for usage.
+"""

--- a/tangermeme/_skills/data/SKILL.md
+++ b/tangermeme/_skills/data/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: tangermeme
+description: Use for any task involving the tangermeme library — post-training analysis of genomic sequence-to-function (S2F) deep learning models. Triggers on predictions, DeepLIFT/SHAP attributions, marginalization/ablation/spacing of motifs, saturation mutagenesis (ISM), variant effect scoring, sequence design, seqlet calling, loading loci/FASTA/bigWig/MEME/VCF, or wrapping a PyTorch genomic model for these analyses. This is a router skill — read the relevant file under references/ for details and footguns before writing tangermeme code.
+---
+
+# tangermeme
+
+`tangermeme` answers the "what did my genomic model learn, and what do I do with
+it after training" question. It provides atomic sequence operations, batched
+prediction, attribution, perturbation experiments, and sequence design — all
+deliberately assumption-free (any PyTorch model, any alphabet, raw outputs
+returned rather than distances).
+
+This skill is a **router**. Each topic below has a detailed reference file with
+the exact signatures and footguns. **Read the relevant reference file before 
+writing code** — do not rely on memory of the API, because several functions 
+have non-obvious defaults (silent wrong-output selection, variable-length returns, 
+reproducibility traps).
+
+## Two cross-cutting concepts (read these first if unsure)
+
+- **[The `func=` plug-point](references/func-pattern.md)** — `ablate`,
+  `marginalize`, `space`, `variant_effect.*`, and `product.*` all accept
+  `func(model, X, args=, **kwargs)`. Swapping `predict` for
+  `deep_lift_shap` turns a "predictions before/after" experiment into an
+  "attributions before/after" one. Covers the `additional_func_kwargs` collision
+  trap. **This is what makes the library compose.**
+
+- **[Wrapping models](references/model-wrapping.md)** — tangermeme assumes
+  `y = model(X)` returns a single tensor with layout `(batch, channels, length)`.
+  Real multi-input / multi-output models must be wrapped first. Read this before
+  attribution or design on any non-trivial model. Data preprocessing or output
+  post-processing should be handled in custom wrappers rather than in custom
+  functions.
+
+## Task → reference file
+
+| If the task is… | Read |
+|---|---|
+| **starting from scratch** — set up a notebook to load a model and run predictions → attributions → seqlets → motif tests, end to end | [references/notebook-walkthrough.md](references/notebook-walkthrough.md) |
+| attribution via **DeepLIFT/SHAP** — "which bases drive this prediction", attribution logos, hypothetical contributions for CWMs | [references/deep_lift_shap.md](references/deep_lift_shap.md) |
+| attribution via **ISM / saturation mutagenesis** — the forward-pass alternative; use it when DeepLIFT/SHAP convergence deltas are too high, an op can't be registered, or the model is massively multi-task | [references/saturation_mutagenesis.md](references/saturation_mutagenesis.md) |
+| comparing predictions/attributions **across N models** (replicates, architectures, ensembles) | [references/comparing-models.md](references/comparing-models.md) |
+| effect of a motif / region: marginalize, ablate, spacing between motifs | [references/motif-effects.md](references/motif-effects.md) |
+| scoring **variant effects** (substitution / deletion / insertion, from a VCF) | [references/variant-effect.md](references/variant-effect.md) |
+| **calling seqlets** from attributions (recursive / TF-MoDISco) | [references/seqlets.md](references/seqlets.md) |
+| **annotating / counting motifs** — TOMTOM/FIMO labels, co-occurrence, spacing | [references/annotate.md](references/annotate.md) |
+| running a function over a **product of inputs** (sequence × cell-state × …) | [references/product.md](references/product.md) |
+| **plotting logos** and drawing seqlet/motif annotations on them | [references/plot.md](references/plot.md) |
+| composing predict / deep_lift_shap / saturation_mutagenesis through a perturbation fn | [references/func-pattern.md](references/func-pattern.md) |
+| adapting a multi-input/output PyTorch model to the tangermeme contract | [references/model-wrapping.md](references/model-wrapping.md) |
+| loading sequences/signals at loci, reading FASTA/bigWig/BED/MEME/VCF | [references/io-loci.md](references/io-loci.md) |
+| designing sequences to hit a target output (screen / greedy substitution) | [references/design.md](references/design.md) |
+
+## Quick orientation (the rest of the library)
+
+These are well-covered by the official tutorials and are mostly single-call ops —
+no dedicated reference file, but here is where to look:
+
+- `tangermeme.predict.predict` — batched, memory-efficient inference; always
+  returns float32; multi-output models return a list. Satisfies the `func=` contract.
+- `tangermeme.ersatz` — atomic sequence ops: `insert`, `substitute`,
+  `multisubstitute`, `delete`, `shuffle`, `dinucleotide_shuffle` (most motif-add
+  ops *substitute*, preserving length; `start`/`end` confine shuffles to a region).
+- `tangermeme.utils` — `one_hot_encode` (returns int8), `characters`,
+  `random_one_hot`, `reverse_complement` (single sequence), `pwm_consensus`,
+  `set_seed`, `gc_content`, etc.
+- `tangermeme.pisa.pisa` — per-position (PISA) attribution reusing the DLS hooks.
+  Footgun: some paths return tensors on the **input device**, not CPU.
+- `tangermeme.kmers` — k-mer counts, batched k-mers, gapped k-mers.
+
+(Motif *scanning* — FIMO/TOMTOM — is not in tangermeme; it lives in the external
+`memelite` / memesuite-lite package. `annotate_seqlets` wraps TOMTOM internally.)
+
+## Conventions used throughout
+
+- Tensor layout: `(batch, channels, length)`; channels = one-hot alphabet axis
+  (default `['A','C','G','T']`).
+- Variable naming: `X`/`y` observed, `X_bar`/`y_bar` designed/target,
+  `y_hat` predictions, `X_attr` attributions.
+- Device defaults: `predict`, `deep_lift_shap`, `pisa`, `design.*`,
+  `saturation_mutagenesis`, `product.*` take `device=None` → CUDA if available
+  else CPU; the model's original device + training mode are restored afterward.
+- Perturbation functions return NamedTuples (`PerturbationResult`, etc.) — unpack
+  positionally or by attribute; `isinstance(result, tuple)` is True.

--- a/tangermeme/_skills/data/references/annotate.md
+++ b/tangermeme/_skills/data/references/annotate.md
@@ -1,0 +1,101 @@
+# Annotating and counting motifs (tangermeme.annotate)
+
+Once you have spans of interest (seqlets, or FIMO hits), `tangermeme.annotate`
+labels them with motif identities and counts how they occur and co-occur.
+
+## The annotation tensor format
+
+Two conventions show up:
+
+- **Region annotations** `(n, 3)` = `(example_idx, start, end)` (0-indexed, end
+  exclusive). This is what `ablate_annotations` / `marginalize_annotations` consume
+  (see [motif-effects.md](motif-effects.md)).
+- **Counting input** `(n, 2)` = `(example_idx, annotation_idx)` for `count_annotations`
+  / `pairwise_annotations`, or `(n, 4)` = `(example_idx, annotation_idx, start, end)`
+  for spacing.
+
+## annotate_seqlets — assign a motif to each seqlet (TOMTOM)
+
+```python
+from tangermeme.annotate import annotate_seqlets
+
+# returns TWO tensors, each shape (len(seqlets), n_nearest):
+motif_idxs, pvals = annotate_seqlets(X, seqlets, "motifs.meme", n_nearest=1)
+```
+
+- Returns `(idxs, p_values)` — **motif indices and their TOMTOM p-values**, not
+  names (the function's own type hint is wrong about this). A `-1` index means no
+  match passed the threshold. Map indices to names yourself, e.g.
+  `names = list(read_meme(path).keys()); [names[i] for i in motif_idxs[:, 0]]`.
+- `motifs` is a MEME-file path **or** a `{name: PWM}` dict. Matching uses TOMTOM
+  (from the external `memelite`), which handles overhangs — so it is the right tool
+  for **seqlets** (short spans).
+- Returns the `n_nearest` best matches per seqlet. **This only *appears* to dedupe a
+  redundant motif DB** — with a non-deduplicated database, near-identical motifs are
+  silently split/dropped, so don't trust raw match counts from a redundant DB. Use a
+  merged/deduped motif set if counts matter.
+
+### Scanning long sequences instead of seqlets → FIMO (external)
+
+FIMO is **not** in tangermeme; it lives in `memelite` (the memesuite-lite package).
+Use it to scan whole sequences (it does not handle overhangs well, so it's for
+scanning, not seqlets), then attach attribution by summing `X_attr` over each hit's
+span and thresholding. Beware: a redundant DB yields many overlapping hits over the
+same span, and attribution-thresholded hits can **double-count** the same span under
+several similar motifs — unlike seqlet calling, which assigns one label per seqlet.
+
+## count_annotations — per-example motif counts
+
+```python
+from tangermeme.annotate import count_annotations
+
+counts = count_annotations((seqlets['example_idx'], motif_idxs[:, 0]))  # (n_examples, n_motifs)
+```
+
+- Accepts a `(n, 2)` tensor or a tuple of two vectors.
+- **Default dtype is `uint8`** — counts saturate at 255; pass `dtype=torch.int32` if
+  a motif can occur more often.
+- `shape=(n_examples, n_motifs)` pins the output dims (needed when stacking matrices
+  across models/runs that don't all see every motif). `dim=0`/`dim=1` reduces without
+  materializing the full matrix.
+
+## pairwise_annotations — co-occurrence matrix
+
+```python
+from tangermeme.annotate import pairwise_annotations
+
+co = pairwise_annotations(df_example_motif, shape=n_motifs)   # (n_motifs, n_motifs)
+```
+
+- Default `symmetric=True`: entry counts pairs in both orders (sum = 2×pairs −
+  diagonal; take a triangle for the pair count). `symmetric=False` gives an
+  **ordered** matrix (row = motif earlier in the sequence, col = later) — input row
+  order is then meaningful.
+
+## pairwise_annotations_spacing — co-occurrence by distance
+
+```python
+from tangermeme.annotate import pairwise_annotations_spacing
+
+sp = pairwise_annotations_spacing(df4, max_distance=100)   # (n_motifs, n_motifs, max_distance)
+```
+
+- Input is the `(n, 4)` form `(example_idx, annotation_idx, start, end)`. **Sort by
+  `example_idx` then `start`**, and pass it as a **single DataFrame** so the motif
+  index stays aligned with its coordinates after sorting.
+- Distance is **absolute** (end-of-left to start-of-right), capped at `max_distance`
+  (default 100 — raise for long-range). Memory grows as `n_motifs² × max_distance`.
+
+## The discovery pipeline
+
+attributions → [seqlets.md](seqlets.md) (`recursive_seqlets`) →
+`annotate_seqlets` → `count_annotations` / `pairwise_annotations` /
+`pairwise_annotations_spacing`. For a method-selection view (TF-MoDISco vs
+marginalize vs seqlet+TOMTOM vs FIMO), see the "Inspecting what cis-regulatory
+features a model has learned" vignette.
+
+## Related references
+
+[seqlets.md](seqlets.md) (producing the spans), [io-loci.md](io-loci.md)
+(`read_meme`), [motif-effects.md](motif-effects.md) (the `*_annotations`
+perturbation variants), [plot.md](plot.md) (drawing annotations on logos).

--- a/tangermeme/_skills/data/references/comparing-models.md
+++ b/tangermeme/_skills/data/references/comparing-models.md
@@ -1,0 +1,97 @@
+# Comparing predictions and attributions across N models
+
+Running tangermeme over several models (replicates, architectures, an ensemble, a
+fine-tuning sweep) is mostly "loop the single-model calls" — `predict` and
+`deep_lift_shap` move each model to `device` and restore its state per call, so
+iterating is safe. The traps are not in the looping; they are in making the
+results **comparable**. This file covers the four that bite.
+
+Start from the single-model flow in [notebook-walkthrough.md](notebook-walkthrough.md);
+everything here assumes you already know how to run one model.
+
+## 1. Fair attribution comparison needs shared references (the big one)
+
+`deep_lift_shap` attributes relative to *random* shuffled backgrounds (default
+`references=dinucleotide_shuffle`, `n_shuffles=20`). If you let each model draw its
+own backgrounds, you are comparing models **and** reference noise. Hold the
+references fixed across models.
+
+Best: precompute references once and pass them to every model.
+
+```python
+from tangermeme.ersatz import dinucleotide_shuffle
+from tangermeme.deep_lift_shap import deep_lift_shap
+
+refs = dinucleotide_shuffle(X, n=20, random_state=0)   # (n, 20, 4, length)
+attrs = {
+    name: deep_lift_shap(model, X, target=0, references=refs, device=device)
+    for name, model in models.items()
+}
+```
+
+A fixed `random_state=0` on each call is the lighter-weight alternative, but
+explicit shared `references=` is unambiguous and also lets `only_warn=True` paths
+work (see [deep_lift_shap.md](deep_lift_shap.md)).
+
+## 2. Harmonize outputs before correlating
+
+Models rarely agree on shape. Before any concordance metric:
+
+- **Output window:** different `out_window` / cropping — slice all predictions to a
+  common genomic window centered the same way.
+- **Task identity:** `target`/output index `k` may mean different assays in
+  different models — map by name, don't assume aligned columns.
+- **Input length:** if input windows differ, re-`extract_loci` per model at its own
+  `in_window` from the *same loci* rather than reusing one `X`
+  (see [io-loci.md](io-loci.md)).
+
+```python
+preds = {name: predict(m, X, batch_size=64, device=device)
+         for name, m in models.items()}
+totals = {name: y_hat.sum(dim=-1) for name, y_hat in preds.items()}   # (n, n_tasks)
+```
+
+## 3. Normalize attribution scale before comparing logos/heatmaps
+
+Attribution magnitudes are not comparable across models (different output scales,
+different reference gaps). For visual or quantitative comparison, normalize per
+model — e.g. divide each example's attributions by its per-example L2 norm, or
+z-score — before stacking into a logo grid or computing cross-model similarity.
+
+```python
+def _norm(a):                      # a: (n, 4, length)
+    return a / a.flatten(1).norm(dim=1)[:, None, None].clamp_min(1e-8)
+
+sim = {                            # cosine similarity of projected attributions
+    (i, j): torch.nn.functional.cosine_similarity(
+        _norm(attrs[i]).flatten(1), _norm(attrs[j]).flatten(1)).mean()
+    for i in attrs for j in attrs if i < j
+}
+```
+
+## 4. Keep N models on CPU; let `device=` shuttle them
+
+Because every `predict` / `deep_lift_shap` call moves the model to `device` for the
+duration and restores its original device afterward, you do **not** need all N
+models resident on the GPU. Build/load them on CPU, keep them in a dict, and pass
+`device=device` to each call — only one model occupies GPU memory at a time. This
+is what makes a large sweep fit.
+
+```python
+models = {name: torch.load(p, weights_only=False) for name, p in paths.items()}
+# all on CPU; each call below moves one over and back
+```
+
+## Concordance / ensembling (generic — brief)
+
+Once predictions are harmonized, the comparison itself is ordinary analysis:
+per-task Spearman/Pearson across loci, prediction deltas per locus to find where
+models disagree, or a mean/median ensemble. These are not tangermeme-specific, so
+use whatever you normally would (`scipy.stats`, `numpy`).
+
+## Related references
+
+[notebook-walkthrough.md](notebook-walkthrough.md) (the single-model spine),
+[deep_lift_shap.md](deep_lift_shap.md) (references / `random_state`),
+[io-loci.md](io-loci.md) (per-model windows),
+[model-wrapping.md](model-wrapping.md) (aligning heterogeneous model outputs).

--- a/tangermeme/_skills/data/references/deep_lift_shap.md
+++ b/tangermeme/_skills/data/references/deep_lift_shap.md
@@ -1,0 +1,162 @@
+# DeepLIFT/SHAP attributions in tangermeme
+
+`tangermeme.deep_lift_shap.deep_lift_shap` runs a model "backwards" to score the
+contribution of each input base to an output. It corrects several issues found in
+other DeepLIFT/SHAP implementations and supports custom non-linearities.
+
+## Signature (defaults that matter)
+
+```python
+deep_lift_shap(
+    model, X,
+    args=None,
+    target=0,                       # WHICH output — see below
+    batch_size=32,                  # example-REFERENCE pairs, not examples — see below
+    references=dinucleotide_shuffle,# callable OR a precomputed tensor
+    n_shuffles=20,                  # references per example when references is a fn
+    return_references=False,
+    hypothetical=False,
+    warning_threshold=0.001,        # additivity (convergence-delta) check
+    additional_nonlinear_ops=None,
+    print_convergence_deltas=False,
+    raw_outputs=False,
+    only_warn=False,
+    dtype=None, device=None,        # device None -> CUDA if available else CPU
+    random_state=None,
+    verbose=False,
+)
+```
+
+## Footgun #1 — `target=` is mandatory for multi-task models
+
+`target` defaults to `0`. If your model emits multiple outputs in one tensor and
+you forget `target=`, you will silently get attributions for output 0, not an
+error. Always set it explicitly for multi-task models:
+
+```python
+X_attr = deep_lift_shap(model, X, target=267, random_state=0)
+```
+
+If the model returns *multiple tensors* (a list), `target` cannot select among
+them — wrap the model so its forward returns a single tensor first (see
+[model-wrapping.md](model-wrapping.md)).
+
+## Footgun #2 — reproducibility needs `random_state=`
+
+The default `references=dinucleotide_shuffle` draws `n_shuffles` random
+backgrounds per example, so attributions vary run to run. Pass `random_state=` to
+make them deterministic (required when capturing regression values). For comparing
+attributions **across tasks or models**, holding `random_state` *and* `n_shuffles`
+fixed is mandatory — otherwise each call attributes against different backgrounds
+and the differences you see are noise, not signal (see
+[comparing-models.md](comparing-models.md)). A custom `references=` callable has the
+signature `f(X, n, random_state) -> (n_examples, n, len(alphabet), length)`; if you
+only shuffle a sub-span, attributions are exactly `0` outside it — don't interpret
+those positions.
+
+## Footgun #3 — `only_warn=True` still raises inside shuffling
+
+`only_warn=True` downgrades validation errors on `X`, but the internal
+`dinucleotide_shuffle` re-validates and will still raise on a malformed `X`.
+Workaround: precompute references from a valid one-hot input and pass them in. Note
+the standalone `dinucleotide_shuffle` parameter is `n=` (the `n_shuffles` name is
+`deep_lift_shap`'s own), and a precomputed `references=` tensor must have shape
+`(batch, n_shuffles, len(alphabet), length)`:
+
+```python
+refs = dinucleotide_shuffle(X_valid, n=20, random_state=0)  # (batch, 20, 4, length)
+X_attr = deep_lift_shap(model, X, references=refs, only_warn=True)
+```
+
+## `batch_size` counts example-reference pairs
+
+`batch_size` is the number of example×reference pairs run at once, not the number
+of examples. With the default `n_shuffles=20`, a single example already expands to
+20 forward/backward passes, so `batch_size=32` does **not** mean 32 examples in
+flight. If you hit OOM, lower `batch_size` (or `n_shuffles`); the attributions are
+unchanged, only the per-step memory differs.
+
+## Convergence deltas — the correctness signal (read this)
+
+DeepLIFT/SHAP has an additive property: per-example attributions should sum to the
+prediction difference between the sequence and its references. The convergence
+delta measures the violation, and its **magnitude tells you the cause**:
+
+- **delta > ~0.01**: a non-linearity the hooks don't handle is unregistered — a
+  real **correctness bug**. Fix it (below), don't ship the attributions.
+- **delta ~1e-3 to 1e-5 (often 1e-7 on CPU)**: benign floating-point error.
+  Architecture-dependent; safe to ignore.
+
+tangermeme auto-warns above `warning_threshold`; use `print_convergence_deltas=True`
+to see per example-reference-pair values.
+
+**High deltas do NOT produce garbage logos — this is the dangerous part.** A model
+with an unregistered op can still highlight motif-shaped patterns that look real but
+*vanish* once the op is registered. Motif-shaped ≠ correct; only low deltas are.
+Cross-check a suspicious logo against the actual prediction.
+
+### Registering a custom non-linearity
+
+```python
+from tangermeme.deep_lift_shap import _nonlinear
+X_attr = deep_lift_shap(model, X, additional_nonlinear_ops={MyActivation: _nonlinear})
+```
+
+The built-in hooks cover ReLU/sigmoid/tanh/softmax/maxpool. The catch:
+`_nonlinear` divides `delta_out / delta_in`, so it **must be registered on a layer
+with equal input and output shape**. If your op also reduces (e.g. a profile head
+that does `logits * softmax(logits)` then `.sum()`), split it: put the elementwise,
+shape-preserving part in its own `nn.Module`, register *that*, and do the reduction
+in the parent wrapper. Registering the reducing layer raises a size-mismatch error.
+
+### Precision: CPU vs CUDA, and the fp64 escape hatch
+
+The same model gives **higher deltas on CUDA than CPU** (parallel reductions reorder
+float sums) — thresholds tuned on CPU may need raising on GPU. To disambiguate
+"unregistered op" from "precision noise," re-run a few examples on CPU. For
+genuinely precision-driven deltas, `deep_lift_shap(model.double(), X.double(),
+references=refs.double(), ...)` drops them to ~1e-16 (slower; fp64).
+
+When you can't get deltas down (an op that can't be expressed as a shape-preserving
+hook), switch to ISM — see [saturation_mutagenesis.md](saturation_mutagenesis.md).
+
+## hypothetical vs projected attributions
+
+- Default (`hypothetical=False`): attributions are projected onto the observed
+  bases — what you plot as a logo of the actual sequence.
+- `hypothetical=True`: per-base hypothetical contributions across all four bases.
+  Use these to build motif patterns / contribution-weight matrices (CWMs)
+  downstream — **not** as the seqlet-caller input.
+
+Seqlet calling (`tangermeme.seqlet.recursive_seqlets` / `tfmodisco_seqlets`)
+consumes **projected** attributions summed to one value per position — i.e. the
+default (`hypothetical=False`) output collapsed over the channel axis,
+`X_attr.sum(dim=1)`, shape `(n, length)`. Feeding hypothetical attributions to the
+seqlet callers is a common mistake.
+
+## Return type
+
+Returns a tensor shaped like `X` (e.g. `(batch, 4, length)`). With
+`return_references=True` it returns an `AttributionReferencesResult(attributions,
+references)` NamedTuple — unpack positionally or by attribute.
+
+## Plotting
+
+```python
+from tangermeme.plot import plot_logo
+plot_logo(X_attr[0], ax=ax)   # tangermeme has its own logo plotting (no logomaker)
+```
+
+## Composing with perturbations
+
+`deep_lift_shap` satisfies the `func=` contract, so it drops into `marginalize`,
+`ablate`, `variant_effect.*`, etc. to get attributions before/after an edit —
+route attribution kwargs via `additional_func_kwargs` (see
+[func-pattern.md](func-pattern.md)).
+
+## Related references
+
+[saturation_mutagenesis.md](saturation_mutagenesis.md) (the forward-pass
+alternative), [seqlets.md](seqlets.md) (consuming projected attributions),
+[model-wrapping.md](model-wrapping.md) (single-tensor requirement),
+[comparing-models.md](comparing-models.md) (shared references across models).

--- a/tangermeme/_skills/data/references/design.md
+++ b/tangermeme/_skills/data/references/design.md
@@ -1,0 +1,100 @@
+# Sequence design with tangermeme.design
+
+`tangermeme.design` builds sequences that produce a desired model output. It is
+discrete/combinatorial (screening and greedy motif insertion). For gradient-based
+minimal edits of a template, use the sibling `ledidi` library instead — see the
+end of this file.
+
+## Naming (matches the project conventions)
+
+- `X_bar` — designed sequences (what these functions return).
+- `y_bar` — the desired/target output (passed as `y=`).
+
+## screen — random generate, keep the best
+
+```python
+from tangermeme.design import screen
+
+X_bar = screen(model, shape=(4, 2114), y=y_bar, batch_size=1000, n_best=1, random_state=0)
+```
+
+- `shape` is the **per-sequence** shape `(len(alphabet), length)` — it **excludes
+  the batch dimension**. `batch_size` is how many candidates are drawn and screened
+  per iteration (it is *not* forwarded to `predict`'s own batch_size).
+- Generates candidates (default `func=random_one_hot`), scores each against `y` with
+  `loss`, keeps the top `n_best`. Loops until `loss < tol` (set a positive
+  `max_iter` as a safety cap). Simplest baseline; seed/sanity-check before greedy.
+
+## greedy_substitution — build toward a goal with a motif library
+
+```python
+from tangermeme.design import greedy_substitution
+
+X_bar = greedy_substitution(model, X, y=y_bar, motifs=motif_list,
+                            reverse_complement=True, max_iter=10)
+```
+
+- Each round, tries substituting every motif at candidate positions and keeps the
+  single edit that most reduces `loss`; repeats until `loss < tol` or `max_iter`
+  motifs have been placed.
+- **`max_iter` defaults to `-1`, which is a silent no-op** — the loop is
+  `iteration < max_iter`, so a non-positive value runs zero iterations and returns
+  `X` unchanged. The greedy functions require a **positive `max_iter`**.
+- **`X` must have batch size 1** — it designs one sequence at a time.
+- `reverse_complement=True` also considers each motif's reverse complement.
+- `input_mask` restricts which positions may be edited (e.g. the middle 200 bp →
+  ~10× speedup); `output_mask` restricts which outputs the loss is computed over.
+- **Two modes from one function:** pass real motifs → greedy motif implantation;
+  pass `['A', 'C', 'G', 'T']` as `motifs` → greedy single-nucleotide (ISM-style)
+  design that escapes a motif library (use `reverse_complement=False` and expect
+  many more iterations).
+- **Elimination is automatic** — set a low target and the same function removes
+  harmful motifs without being told which are bad; add/remove can interleave.
+
+## greedy_marginalize — build a construct against backgrounds
+
+```python
+from tangermeme.design import greedy_marginalize
+construct = greedy_marginalize(model, X_backgrounds, y=y_delta, motifs=motif_list,
+                               max_iter=5)   # positive max_iter required (see above)
+```
+
+Semantics differ from `greedy_substitution` in three ways that are easy to miss:
+
+- `y` is the **desired change** `f(X + construct) − f(X)`, *not* a target prediction.
+- `X` is a **set of background sequences**, not one sequence to edit.
+- it returns a **variable-width one-hot construct** (e.g. `(4, 51)`), not a full
+  sequence — decode with `characters(construct, allow_N=True)`; it contains `N`
+  where overlapping motifs cancel. `max_spacing` (default 12) bounds the search.
+
+## The loss / target contract (footgun)
+
+- `loss` defaults to `torch.nn.MSELoss(reduction='none')`. **`reduction='none'`
+  is required** — design needs a per-candidate / per-example loss vector to rank
+  edits, not a single scalar. PyTorch losses average over the batch by default, which
+  hides which example is best; a custom `loss(y, y_hat)` must take `y` of shape
+  `(n, ...)` and return a per-example `(n, ...)` (don't reduce it yourself either).
+- **Balancing-losses idiom:** instead of `output_mask`-ing off-target tasks, set
+  `y = predict(model, X)` and overwrite only the tasks you want to change — this
+  holds the others near baseline rather than ignoring them.
+- `y` (the target `y_bar`) and `loss` must be shaped consistently with the model
+  output. For multi-output models, either pass a list `y` matching the outputs or
+  wrap the model to a single objective head (see [model-wrapping.md](model-wrapping.md)),
+  and use `output_mask` to focus the loss.
+- The choice of loss + target *is* the design objective — get these right before
+  worrying about iterations. Euclidean/MSE is the usual default; supply a custom
+  callable for subtler objectives (e.g. maximize one head while holding another).
+
+## When to use ledidi instead
+
+`tangermeme.design` is discrete and greedy. When you want **gradient-based,
+minimal edits** to a specific template sequence to hit precise output
+characteristics, reach for the `ledidi` library — it optimizes a continuous
+relaxation and tends to find smaller, more targeted edits than greedy
+substitution.
+
+## Related references
+
+[model-wrapping.md](model-wrapping.md) (collapsing multi-output models to a design
+objective), [func-pattern.md](func-pattern.md) (the `func=` candidate generator in
+`screen`).

--- a/tangermeme/_skills/data/references/func-pattern.md
+++ b/tangermeme/_skills/data/references/func-pattern.md
@@ -1,0 +1,91 @@
+# The `func=` plug-point in tangermeme
+
+tangermeme's perturbation functions are built around one contract so any analysis
+can be swapped for any other. Master this and the rest of the library composes.
+
+## The contract
+
+Any function passed as `func=` must satisfy:
+
+```python
+func(model, X, args=None, **kwargs) -> torch.Tensor | list[torch.Tensor]
+```
+
+Three library functions already satisfy it and can be passed directly:
+
+- `tangermeme.predict.predict` — the default; returns model predictions.
+- `tangermeme.deep_lift_shap.deep_lift_shap` — returns attributions.
+- `tangermeme.saturation_mutagenesis.saturation_mutagenesis` — returns ISM scores.
+
+## Where `func=` is accepted
+
+```python
+ablate(model, X, start, end, func=...)
+marginalize(model, X, motif, func=...)
+space(model, X, motifs, spacing, func=...)
+variant_effect.substitution_effect(model, X, subs, func=...)
+variant_effect.deletion_effect(...)   ;  variant_effect.insertion_effect(...)
+product.apply_pairwise(func, model, X, ...)   # func is FIRST positional here
+product.apply_product(func, model, X, ...)
+```
+
+The default `func` is `predict` everywhere above.
+
+**Exception — `design.screen` also has a `func=`, but a different contract.** There
+it is a *sequence generator* `func(shape_tuple, random_state=, **kwargs)` (default
+`random_one_hot`) that produces candidates, **not** the `func(model, X)` predictor
+contract above. Don't pass `predict`/`deep_lift_shap` to `screen`'s `func`.
+
+## The key idea: the return type follows `func`
+
+The outer function returns whatever `func` returns, before and after the edit.
+`marginalize` with the default `predict` gives predictions before/after; swap in
+`deep_lift_shap` and you get *attributions* before/after — same call, same
+`PerturbationResult(y_before, y_after)` container.
+
+```python
+from tangermeme.marginalize import marginalize
+from tangermeme.deep_lift_shap import deep_lift_shap
+
+# Effect of a motif on PREDICTIONS
+y_before, y_after = marginalize(model, X, "CTCAGTGATG")
+
+# Effect of the same motif on ATTRIBUTIONS
+attr_before, attr_after = marginalize(model, X, "CTCAGTGATG", func=deep_lift_shap)
+```
+
+## The collision footgun: `additional_func_kwargs`
+
+Extra `**kwargs` on the outer function are forwarded to `func`. This breaks when
+a kwarg name means different things to the outer function and to `func` (e.g.
+`random_state`, `batch_size`, `target`). Disambiguate by routing kwargs meant for
+`func` through `additional_func_kwargs=`:
+
+```python
+# Tell deep_lift_shap to attribute output #3, not the marginalize-level kwargs
+marginalize(model, X, motif, func=deep_lift_shap,
+            additional_func_kwargs={'target': 3, 'n_shuffles': 50})
+```
+
+- Default is `None`, **not** `{}`.
+- The dict is copied defensively in `ablate`, `marginalize`, `space`,
+  `product.*`, `variant_effect.*`, and `design.screen` — passing it will not
+  mutate your caller-side dict.
+- Anything in `additional_func_kwargs` goes only to `func`; bare `**kwargs` may
+  be consumed by the outer function first.
+
+Rule of thumb: if a name could plausibly belong to either layer, put it in
+`additional_func_kwargs` to be explicit.
+
+## Multi-input models
+
+`args=(tensor, ...)` carries extra model inputs through the whole stack; the i-th
+example is paired with the i-th row of each arg. It flows from the outer function
+into `func` into `model(X, *args)`.
+
+## Related references
+
+[motif-effects.md](motif-effects.md) for marginalize/ablate/space specifics,
+[deep_lift_shap.md](deep_lift_shap.md) and
+[saturation_mutagenesis.md](saturation_mutagenesis.md) for the attribution
+methods, [model-wrapping.md](model-wrapping.md) for adapting multi-output models.

--- a/tangermeme/_skills/data/references/io-loci.md
+++ b/tangermeme/_skills/data/references/io-loci.md
@@ -1,0 +1,104 @@
+# Loading data with tangermeme.io
+
+`tangermeme.io` turns genomic files into the tensors the rest of the library
+consumes. The central footgun is that `extract_loci` returns a **different number
+of elements depending on which arguments you set** — unpacking blindly is the #1
+mistake.
+
+## extract_loci — the variable return
+
+```python
+from tangermeme.io import extract_loci
+
+extract_loci(
+    loci,                 # BED/narrowPeak path, DataFrame, or list of them
+    sequences,            # FASTA path, pyfaidx.Fasta, or {chrom: tensor} dict
+    signals=None,         # list of bigWig paths/objects -> OUTPUT signal tensor
+    in_signals=None,      # list of bigWig -> INPUT signal tensor (e.g. controls)
+    chroms=None,
+    in_window=2114,       # input window length (sequence + in_signals)
+    out_window=1000,      # output window length (signals)
+    max_jitter=0,         # EXPANDS windows for downstream jittering; not applied here
+    min_counts=None, max_counts=None, target_idx=0,
+    n_loci=None, summits=False,
+    alphabet=['A','C','G','T'], ignore=['N'],
+    exclusion_lists=None,
+    return_mask=False,
+    verbose=False,
+)
+```
+
+### Return order (this is the footgun)
+
+The result is a list assembled in this fixed order, and a **bare object** (not a
+list) is returned when only one element is present:
+
+1. `X` — one-hot sequences `(n, len(alphabet), in_window)`, dtype **int8** (memory;
+   call `.float()` before most models) — **always present**
+2. `y` — output signals `(n, n_signals, out_window)` (single signal still gets a
+   signal axis; order = file order) — only if `signals` is given
+3. `X_in` — input signals — only if `in_signals` is given
+4. `mask` — kept-locus boolean tensor — only if `return_mask=True`
+
+So unpack to match exactly what you requested:
+
+```python
+X = extract_loci(loci, fasta)                                  # 1 -> bare tensor
+X, y = extract_loci(loci, fasta, signals=bws)                  # 2
+X, y, mask = extract_loci(loci, fasta, signals=bws, return_mask=True)  # 3
+X, y, X_in, mask = extract_loci(loci, fasta, signals=bws,
+                                in_signals=ctrls, return_mask=True)     # 4
+```
+
+Get the count wrong and you will silently bind a tensor to the wrong variable.
+
+### Why returned rows may not match input loci
+
+Loci are dropped when they fall off chromosome ends (after jitter), sit on
+chromosomes not in `chroms`, fail `min_counts`/`max_counts` (measured on
+`signals[target_idx]`), or hit an `exclusion_lists` region. **Use
+`return_mask=True` whenever you need to align results back to the input rows** —
+the mask tells you which loci survived.
+
+### Multiple loci files are interleaved, not concatenated
+
+Passing a list of BED/narrowPeak files **interleaves** them round-robin until the
+shortest is exhausted, then appends the remainder — it does not concatenate them in
+order. `n_loci` then truncates that interleaved list. Useful for mixing a
+locus-of-interest with genomic background; surprising if you expected file-order
+concatenation.
+
+### Window semantics
+
+`in_window` (sequence + `in_signals`) and `out_window` (`signals`) are centered on
+each locus, independent of the locus's own width. `summits=True` centers on the
+narrowPeak summit instead of the region midpoint. `max_jitter` *expands* both
+windows so a downstream data generator can jitter cheaply — it does not jitter the
+returned data itself.
+
+## read_meme — motif PWMs
+
+```python
+from tangermeme.io import read_meme
+motifs = read_meme("motifs.meme")        # dict: name -> PWM tensor (4, length)
+```
+
+Wraps the memelite reader. Note: FIMO/Tomtom scanning moved out of tangermeme to
+`memesuite-lite` — use that package for motif scanning.
+
+## read_vcf — variants
+
+```python
+from tangermeme.io import read_vcf
+vcf = read_vcf("variants.vcf")           # pandas DataFrame, comments stripped
+```
+
+Feed variants into `tangermeme.variant_effect.*` to score substitution / deletion
+/ insertion effects.
+
+## Related references
+
+[notebook-walkthrough.md](notebook-walkthrough.md) (loading is step 3 of the
+end-to-end flow), [model-wrapping.md](model-wrapping.md) (the
+`(batch, channels, length)` layout the loaded `X` follows),
+[motif-effects.md](motif-effects.md) (consuming the loaded sequences).

--- a/tangermeme/_skills/data/references/model-wrapping.md
+++ b/tangermeme/_skills/data/references/model-wrapping.md
@@ -1,0 +1,100 @@
+# Wrapping models for tangermeme
+
+tangermeme is deliberately assumption-free, which pushes one requirement onto
+you: most analysis functions assume a model whose forward returns a **single
+tensor**. Wrapping is the productivity hack that makes everything else work.
+
+## The contracts
+
+- **Input layout:** `X` is `(batch, len(alphabet), length)` — default
+  `(batch, 4, length)` for DNA. Channels are the one-hot alphabet axis.
+- **Forward:** `y = model(X)` must work; broadcasting is supported where possible.
+- **Single tensor vs list:** `predict` tolerates a model that returns a *list* of
+  tensors (multi-output) and returns a list back. But `deep_lift_shap`,
+  `saturation_mutagenesis`, and `design` need a **single tensor** — wrap to pick
+  one head before calling them.
+- **target= vs wrapping:** if multiple outputs live in *one tensor*
+  `(batch, n_tasks)`, select with `target=`. If they are *separate tensors* in a
+  list, you must wrap to return just one.
+
+## Recipe: select one output head
+
+```python
+import torch
+
+class TaskWrapper(torch.nn.Module):
+    def __init__(self, model, task):
+        super().__init__()
+        self.model = model
+        self.task = task
+
+    def forward(self, X, *args):
+        y = self.model(X, *args)          # may be a list or a multi-task tensor
+        return y[self.task]               # -> single tensor
+
+attr = deep_lift_shap(TaskWrapper(model, 0), X, target=0)
+```
+
+## Recipe: profile head -> scalar (e.g. BPNet counts)
+
+A common pattern is summing a profile to a total-count scalar, or cropping to a
+center window, so attribution/design has a single target to optimize:
+
+```python
+class CountWrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, X, *args):
+        profile, counts = self.model(X, *args)   # BPNet-style two heads
+        return profile.sum(dim=-1, keepdim=True) # or return counts
+```
+
+## More recipes (from the "Wrappers are Productivity Hacks" vignette)
+
+- **Reverse-complement averaging** — average predictions on `X` and its RC
+  (`torch.flip(X, dims=(-1, -2))`, flipping both length and the ACGT axis).
+  **Footgun:** this silently mishandles **stranded** outputs — those must also be
+  flipped along the output axis. It's only correct as-is for strand-agnostic outputs
+  (e.g. counts).
+- **Bake in a control track** — wrap a model that needs a control input so it
+  supplies an all-zeros control automatically, removing the need to thread `args=`.
+- **Concatenate inputs the function won't split** — when a function accepts only one
+  tensor (no `args=`), wrap the model to take a single concatenated tensor (e.g.
+  4-channel sequence + 2-channel control = 6 channels) and split it inside `forward`.
+- **Fix a non-standard layout** — some models (e.g. `enformer_pytorch`) expect
+  length-first input; wrap with `X.permute(0, 2, 1)`. Same place to do dict-indexed
+  outputs (`y['human']`) or bin-summing (`y.sum(dim=-2)`).
+- **Harmonize length across models** — pad or trim wrappers let you compare models
+  with different input windows on the same loci (also see
+  [comparing-models.md](comparing-models.md)). Padding with N pushes sequences
+  out-of-distribution if the model wasn't trained on N; trimming discards flanks.
+- **Squish N models into one** — a wrapper that runs several models and concatenates
+  their outputs feeds straight into `marginalize` / `saturation_mutagenesis` as a
+  single model. Wrappers stack: `CountWrapper(ControlWrapper(model))`.
+
+## Multi-input models: use `args=`, don't bake inputs into the wrapper
+
+Extra model inputs (cell-state vectors, control tracks, etc.) flow through every
+tangermeme function via `args=(tensor, ...)`. The i-th example is paired with the
+i-th row of each arg, so each arg's batch dimension must match `X`. The wrapper's
+forward should accept `*args` and forward them:
+
+```python
+y = predict(model, X, args=(controls,), batch_size=64)
+```
+
+## What you do NOT need to handle
+
+`predict`, `deep_lift_shap`, `pisa`, `saturation_mutagenesis`, `design.*`, and
+`product.*` already move the model to `device`, switch to eval mode, run without
+gradients where appropriate, and restore the model's original device + training
+mode afterward. Your wrapper only needs a correct `forward`.
+
+## Related references
+
+[func-pattern.md](func-pattern.md) (how wrapped models flow through
+perturbations), [deep_lift_shap.md](deep_lift_shap.md) and
+[saturation_mutagenesis.md](saturation_mutagenesis.md) (why a single-tensor
+forward is required there).

--- a/tangermeme/_skills/data/references/motif-effects.md
+++ b/tangermeme/_skills/data/references/motif-effects.md
@@ -1,0 +1,117 @@
+# Measuring motif effects (marginalize / ablate / space)
+
+These are tangermeme's flagship "what has the model learned" tools. All three
+apply a function before and after a sequence edit and return both, so you compute
+the effect as the delta. (Start with the vignette "Inspecting what Cis-Regulatory
+Features a Model has Learned" — it is the canonical use case.)
+
+## marginalize — add a motif into backgrounds
+
+```python
+from tangermeme.marginalize import marginalize
+
+y_before, y_after = marginalize(model, X, "CTCAGTGATG")   # PerturbationResult
+effect = y_after - y_before
+```
+
+- `motif` may be a string or a one-hot tensor; it is **substituted** (length
+  preserved). `start=` is the **first position** of the substitution (not the
+  center); the default centers the motif.
+- `X` should be background sequences so the delta reflects the motif "in isolation".
+
+### Choosing backgrounds — the GC mirage (important)
+
+Uniformly random sequences are **much higher in GC content** than real genomic DNA,
+and models are sensitive to local GC — so substituting a motif into the wrong
+background can produce a "mirage" effect driven entirely by the GC change, not the
+motif. In order of preference:
+
+1. Real inactive regions matched on GC/dinucleotide content (best).
+2. `random_one_hot(..., probs=...)` with genomic base frequencies (e.g. hg38 chr1
+   ≈ `[0.291, 0.209, 0.209, 0.292]`), or `dinucleotide_shuffle` of real sequences.
+3. Uniform random — prototyping only.
+
+Returns diminish past ~100 backgrounds.
+
+## ablate — shuffle out a region
+
+```python
+from tangermeme.ablate import ablate
+
+y_before, y_after = ablate(model, X, start=990, end=1010, n=20, random_state=0)
+```
+
+- Replaces `[start:end]` with `n` shuffles and reports before/after.
+- The internal shuffle is **non-deterministic without `random_state=`** — always
+  pass a seed when you need reproducible / regression values.
+- Conceptual opposite of marginalize: ablate removes signal from real sequences;
+  marginalize adds signal into backgrounds.
+
+## space — distance dependence between motifs
+
+```python
+from tangermeme.space import space
+
+y_before, y_afters = space(model, X, motifs=["GATA", "TAL1"],
+                           spacing=[5, 10, 20, 40])   # SpaceResult
+```
+
+Returns `SpaceResult(y_before, y_afters)` where `y_afters` covers each spacing —
+use it to find cooperative/competitive distance preferences (output axis is
+`(n_examples, n_spacings, ...)`).
+
+- **`spacing` shape is `(n_spacings, n_motifs-1)`** — entry `[i, j]` is the gap in
+  experiment `i` between motif `j` and `j+1`. Even a single two-motif experiment
+  needs the nested form `[[10]]`. Sweep one gap with `torch.arange(50)[:, None]`.
+- Characters **inside the gaps are left as background** (not overwritten).
+
+## Multi-task and multi-input models
+
+- **Multi-task:** when the model returns multiple outputs, `y_before`/`y_after`
+  come back as a **list of tensors**, one per output. Index before subtracting.
+- **Multi-input:** pass extra model inputs through `args=(tensor, ...)` (ablate)
+  or kwargs forwarded to `func`; each arg's batch dim aligns with `X`.
+
+## Return type
+
+`marginalize` and `ablate` return `PerturbationResult(y_before, y_after)`;
+`space` returns `SpaceResult(y_before, y_afters)`. Both are NamedTuples — unpack
+positionally (`y_before, y_after = ...`) or by attribute (`r.y_before`), and
+`isinstance(r, tuple)` is True.
+
+### Annotation variants (per-region, in batch)
+
+`marginalize_annotations(model, X, X0, annotations)` (X0 = backgrounds) and
+`ablate_annotations(model, X, annotations)` apply the effect to each annotated
+region individually and return `PerturbationAnnotationsResult(y_befores, y_afters)`.
+`annotations` is a `(n_annotations, 3)` tensor `(example_idx, start, end)`. The
+output carries **extra leading axes** — e.g. `ablate_annotations` gives
+`(n_annotations, n_examples, n_shuffles, ...)` — so index carefully before taking
+deltas. See [annotate.md](annotate.md) for building the annotation tensor.
+
+## Attributions instead of predictions
+
+All three take `func=`. Swap in `deep_lift_shap` to see the effect on
+attributions rather than predictions; route attribution kwargs through
+`additional_func_kwargs=` (see [func-pattern.md](func-pattern.md)):
+
+```python
+from tangermeme.deep_lift_shap import deep_lift_shap
+attr_before, attr_after = marginalize(model, X, "CTCAGTGATG", func=deep_lift_shap,
+                                      additional_func_kwargs={'target': 0})
+```
+
+- **Set `target` explicitly** — `deep_lift_shap`'s default is output 0, so on a
+  multi-task model you silently attribute the wrong head.
+- **Cost blows up:** attribution runs before *and* after, each building `n_shuffles`
+  (default 20) references — 5 examples ≈ 200 forward/backward passes. Shrink the
+  attributed window via `additional_func_kwargs={'start': ..., 'end': ...}`.
+- **Backgrounds-as-references trick:** `func=deep_lift_shap` with `n_shuffles=1` over
+  many background sequences trades per-example reference averaging for more examples,
+  giving cleaner aggregate attributions cheaply.
+
+## Related references
+
+[func-pattern.md](func-pattern.md), [deep_lift_shap.md](deep_lift_shap.md),
+[saturation_mutagenesis.md](saturation_mutagenesis.md),
+[model-wrapping.md](model-wrapping.md).

--- a/tangermeme/_skills/data/references/notebook-walkthrough.md
+++ b/tangermeme/_skills/data/references/notebook-walkthrough.md
@@ -1,0 +1,149 @@
+# A starter notebook: model → predictions → attributions → seqlets
+
+This is a runnable scaffold for the most common tangermeme workflow: take a
+trained sequence-to-function model and a set of peaks, sanity-check its
+predictions, attribute, call seqlets, and test motif hypotheses. Paste the cells
+into a notebook and edit the paths / model loading for your setup.
+
+It is a **spine**, not a tutorial — each step links to the reference file with the
+exact signatures and footguns. Read those before relying on a step.
+
+Assumed layout: a one-hot input of shape `(batch, 4, length)`, a model where
+`y = model(X)` returns a single tensor (wrap yours first if not — see
+[model-wrapping.md](model-wrapping.md)).
+
+```python
+# === Cell 1: setup ===
+import torch
+import numpy
+import matplotlib.pyplot as plt
+
+from tangermeme.utils import set_seed
+
+set_seed(0)
+device = "cuda" if torch.cuda.is_available() else "cpu"
+```
+
+```python
+# === Cell 2: load the model ===
+# Load your own trained model however you normally do; it just needs eval-able
+# forward where y = model(X). tangermeme moves it to `device` and restores its
+# original device + train/eval state after each call, so no .to()/.eval() needed.
+model = torch.load("model.pt", weights_only=False)
+
+# If the model is multi-output (returns a list) or multi-input, wrap it so that
+# forward returns a single tensor before attribution/design. See model-wrapping.md.
+# class Wrapper(torch.nn.Module):
+#     def __init__(self, model): super().__init__(); self.model = model
+#     def forward(self, X, *args): return self.model(X, *args)[0]
+# model = Wrapper(model)
+```
+
+```python
+# === Cell 3: load peaks + sequence (and observed signal) ===
+# extract_loci returns a VARIABLE number of objects depending on which kwargs are
+# set — here (sequences + signals) it returns two. See io-loci.md for the full
+# return-order rules and the counts/exclusion filters.
+from tangermeme.io import extract_loci
+
+X, y = extract_loci(
+    "peaks.narrowPeak",          # BED / narrowPeak path or a pandas DataFrame
+    "genome.fa",                 # FASTA path or pyfaidx.Fasta
+    signals=["signal.bw"],       # observed bigWig(s) -> y
+    in_window=2114,              # match your model's input length
+    out_window=1000,             # match your model's output length
+)
+X = X.float()
+print(X.shape, y.shape)
+```
+
+```python
+# === Cell 4: predictions on the peaks, vs observed ===
+# predict batches to `device` and back, runs under eval()+no_grad, returns float32.
+# Multi-output models return a list. See the predict bullet in SKILL.md.
+from tangermeme.predict import predict
+
+y_hat = predict(model, X, batch_size=64, device=device)
+
+plt.scatter(y.sum(dim=-1).log1p(), y_hat.sum(dim=-1).log1p(), s=2, alpha=0.3)
+plt.xlabel("observed (log total counts)")
+plt.ylabel("predicted (log total counts)")
+plt.gca().spines[["top", "right"]].set_visible(False)
+plt.show()
+```
+
+```python
+# === Cell 5: attributions at loci of interest ===
+# Pick a few loci to inspect (here the highest-signal peaks). For a multi-task
+# model you MUST pass target= or you silently attribute output 0. random_state=
+# makes the shuffled references reproducible. See deep_lift_shap.md.
+from tangermeme.deep_lift_shap import deep_lift_shap
+from tangermeme.plot import plot_logo
+
+idx = y.sum(dim=-1).argsort(descending=True)[:4]
+X_attr = deep_lift_shap(model, X[idx], target=0, random_state=0, device=device)
+
+fig, axes = plt.subplots(len(idx), 1, figsize=(12, 2 * len(idx)))
+for ax, attr in zip(axes, X_attr):
+    plot_logo(attr[:, 900:1200], ax=ax)   # zoom into the center
+plt.tight_layout()
+plt.show()
+```
+
+```python
+# === Cell 6 (optional): ISM as a cross-check / fallback ===
+# Use ISM if DeepLIFT/SHAP convergence deltas are high, an op can't be registered,
+# or the model is massively multi-task. Restrict to a window — cost scales with
+# length. See saturation_mutagenesis.md.
+from tangermeme.saturation_mutagenesis import saturation_mutagenesis
+
+X_ism = saturation_mutagenesis(model, X[idx], start=900, end=1200, target=0,
+    device=device)
+plot_logo(X_ism[0], ax=plt.gca())
+plt.show()
+```
+
+```python
+# === Cell 7: call seqlets from the attributions ===
+# recursive_seqlets takes per-position PROJECTED attribution sums, shape
+# (n, length) — collapse the channel axis. Returns a DataFrame sorted by p-value
+# with columns example_idx / start / end / attribution / p-value. See seqlets.md;
+# label/count the seqlets with annotate.md, draw them with plot.md.
+from tangermeme.seqlet import recursive_seqlets
+
+# Attribute the whole batch first (here just the few loci; scale up as needed).
+X_attr_all = deep_lift_shap(model, X[idx], target=0, random_state=0, device=device)
+attr_sums = X_attr_all.sum(dim=1)            # (n, length)
+
+seqlets = recursive_seqlets(attr_sums, threshold=0.01)
+print(seqlets.head())
+```
+
+```python
+# === Cell 8: test a motif hypothesis with marginalization ===
+# Did a motif you found in the seqlets actually drive the model? Insert it into
+# shuffled backgrounds and measure the delta. See motif-effects.md.
+from tangermeme.ersatz import dinucleotide_shuffle
+from tangermeme.marginalize import marginalize
+
+X_bg = dinucleotide_shuffle(X[:64], random_state=0)[:, 0]   # one shuffle each
+y_before, y_after = marginalize(model, X_bg, "CTCAGTGATG", device=device)
+
+delta = (y_after.sum(dim=-1) - y_before.sum(dim=-1))
+print("mean marginal effect:", delta.mean().item())
+```
+
+## Where to go next
+
+- **Multiple models / comparisons** — loop the same `predict` / `deep_lift_shap`
+  calls over a list of models; the device/state handling is per-call and safe. To
+  keep the results *comparable* (shared references, output harmonization, scale
+  normalization, memory), see [comparing-models.md](comparing-models.md).
+- **Variant effects** — `tangermeme.variant_effect.*` with variants from
+  `io.read_vcf` (see [variant-effect.md](variant-effect.md)).
+- **Spacing / cooperativity** — `tangermeme.space.space` (see motif-effects.md).
+- **Sequence design** — [design.md](design.md).
+- **Any perturbation as attributions** — pass `func=deep_lift_shap` into
+  marginalize/ablate/etc. ([func-pattern.md](func-pattern.md)).
+
+Each step above links to its deep-dive file inline; see those for the footguns.

--- a/tangermeme/_skills/data/references/plot.md
+++ b/tangermeme/_skills/data/references/plot.md
@@ -1,0 +1,61 @@
+# Plotting logos and annotations (tangermeme.plot)
+
+`plot_logo` draws attribution/PWM logos (it replaces logomaker). The function call
+itself is simple; the **annotation subsystem** is where the non-obvious behavior
+lives, and it is the connective tissue between seqlets/FIMO and the figure.
+
+```python
+from tangermeme.plot import plot_logo
+
+ax = plot_logo(X_attr[i], ax=ax, start=900, end=1200)
+```
+
+- Pass `X_attr` of shape `(len(alphabet), length)` (one example). Positive
+  characters stack up, negative stack down, ordered by magnitude.
+- For a **probability PWM** (columns sum to 1), use `plot_pwm` instead — it draws
+  the information-content-weighted logo. `plot_logo` is for attributions/weights.
+- It draws **only the logo panel** — add titles/labels/limits with normal matplotlib
+  afterward. It will make an `ax` if you don't pass one.
+- `start`/`end` subset the plotted window **and** are required for annotation
+  coordinates to line up, because annotations use absolute coordinates.
+
+## Annotations contract
+
+`annotations=` is a pandas DataFrame with columns `motif_name`, `start`, `end`,
+`strand` (currently unused), `score`. Coordinates are 0-indexed; `score` is both
+shown and used to order overlapping annotations. Extra columns are ignored.
+
+```python
+plot_logo(X_attr[i], ax=ax, annotations=hits, start=900, end=1200)
+```
+
+### Seqlet footgun: set score_key and filter per example
+
+Seqlet DataFrames use the column `attribution`, not `score`, so pass
+`score_key='attribution'`. And a seqlet DataFrame holds **all examples in one
+frame** — filter to the example you're plotting first, or you'll draw another
+example's coordinates:
+
+```python
+s = seqlets[seqlets['example_idx'] == i]
+plot_logo(X_attr[i], ax=ax, annotations=s, score_key='attribution',
+          start=900, end=1200)
+```
+
+## Three interoperable annotation sources
+
+The same `annotations=` arg accepts: a hand-built DataFrame, FIMO hits (from the
+external `memelite` package — `fimo(motifs, X, dim=1)[i]`), and seqlets from
+`recursive_seqlets` / `tfmodisco_seqlets`.
+
+## Track packing
+
+Overlapping annotations are greedily packed into rows; past `n_tracks` (default 4)
+they collapse into a compact gray name-only strip. `show_extra=False` hides the
+overflow; raise `n_tracks` to show more. `color=` sets a single uniform character
+color (handy for cross-model overlays); `ylim=` fixes the y-axis for comparison.
+
+## Related references
+
+[seqlets.md](seqlets.md) and [annotate.md](annotate.md) (producing annotations),
+[deep_lift_shap.md](deep_lift_shap.md) (producing `X_attr`).

--- a/tangermeme/_skills/data/references/product.md
+++ b/tangermeme/_skills/data/references/product.md
@@ -1,0 +1,55 @@
+# Cartesian product over inputs (apply_pairwise / apply_product)
+
+`tangermeme.product` applies any `func` across combinations of `X` and additional
+inputs — e.g. running a single-cell model over (sequence × cell-state × read-depth).
+Both take `func` as the **first positional argument** and satisfy the `func=`
+contract themselves.
+
+```python
+from tangermeme.product import apply_pairwise, apply_product
+from tangermeme.predict import predict
+
+apply_pairwise(predict, model, X, args=(cell_states, read_depths))
+apply_product(predict, model, X, args=(cell_states, read_depths))
+```
+
+## pairwise vs product is a CORRECTNESS choice, not a perf choice
+
+- **`apply_pairwise`** zips the args: example `i` is run with `args[0][i]`,
+  `args[1][i]`, … — the paired metadata that belong **together** (e.g. the cell
+  state and read depth measured from the *same* cell). Output gains **one** axis,
+  length = `len(args[0])`.
+- **`apply_product`** takes the full Cartesian product: every `(X_i, a_j, b_k)`.
+  Output gains **one axis per arg**.
+
+Using `apply_product` on metadata that is actually paired is a **silent scientific
+bug** — it fabricates examples where the read depth and cell state come from
+different cells. Reach for product only when the axes are genuinely independent.
+
+## Output indexing trap
+
+The extra axes mean a batch-of-one arg still adds a length-1 axis. To recover plain
+`predict`-shaped output you must index it away:
+
+```python
+y = apply_pairwise(predict, model, X, args=(a,))[:, 0]        # one paired arg
+y = apply_product(predict, model, X, args=(a, b))[:, 0, 0]    # two product args
+```
+
+## Composing and nesting
+
+Any `func` works — `predict`, `deep_lift_shap`, even `marginalize` (which returns
+its `(y_before, y_after)` pair through the product). To nest, route the inner
+function through `additional_func_kwargs` so the outer product doesn't intercept it:
+
+```python
+apply_pairwise(marginalize, model, X, args=(cell_states,),
+               additional_func_kwargs={'func': deep_lift_shap}, motif="TGACGTCA")
+```
+
+Batches are built iteratively, so the full product is never materialized in memory.
+
+## Related references
+
+[func-pattern.md](func-pattern.md) (the `func`/`additional_func_kwargs` contract),
+[model-wrapping.md](model-wrapping.md) (passing per-example extra inputs).

--- a/tangermeme/_skills/data/references/saturation_mutagenesis.md
+++ b/tangermeme/_skills/data/references/saturation_mutagenesis.md
@@ -1,0 +1,100 @@
+# Saturation mutagenesis (ISM) in tangermeme
+
+`tangermeme.saturation_mutagenesis.saturation_mutagenesis` is an attribution
+method, alongside [deep_lift_shap.md](deep_lift_shap.md). In-silico saturation
+mutagenesis (ISM) mutates every position to every base and measures the change in
+the model's output. It is **purely forward-pass**, so it sidesteps the gradient /
+custom-backward machinery entirely.
+
+Every forward pass is run through `predict`, so inference happens under
+`model.eval()` and `torch.no_grad()` — no autograd graph is built and
+dropout/batchnorm run in eval mode, for maximum throughput. Your model's original
+training mode and device are restored afterward, so you never need to set (or
+reset) `.eval()` yourself.
+
+## Signature (defaults that matter)
+
+```python
+saturation_mutagenesis(
+    model, X,
+    args=None,
+    start=0, end=-1,                # restrict to a window — see cost note
+    batch_size=32,
+    target=None,                    # int | slice | None; None = average ALL tasks
+    hypothetical=False,
+    raw_outputs=False,
+    dtype=None, device=None,        # device None -> CUDA if available else CPU
+    verbose=False,
+)
+```
+
+## When to use ISM instead of DeepLIFT/SHAP
+
+- **DeepLIFT/SHAP convergence deltas are too high** and can't be fixed with
+  `additional_nonlinear_ops` — ISM has no additivity assumption to violate, so it
+  is trustworthy where DLS is not.
+- **the model uses an op that can't be registered** for the custom backward pass.
+- **the model is massively multi-task** — ISM runs the perturbed sequences through
+  the model once and reads off all outputs, so N outputs cost ~the same as 1.
+  DeepLIFT/SHAP attributes one `target` at a time and scales with the number of
+  outputs you want.
+
+## The trade-off: cost scales with sequence length
+
+ISM does one forward pass per single-base edit, so cost grows with the length of
+the region being mutated (≈ `(end - start) * (len(alphabet) - 1)` perturbed
+sequences per example). Restrict it to the region of interest with `start`/`end`
+rather than scanning a whole long input.
+
+Windowed ISM is **bit-identical** to running the full sequence and slicing (edits
+are independent), so there is no accuracy cost — only speed (~15× faster for ~5% of
+the sequence). Triage pattern: loop windowed ISM over a list of motif-hit
+coordinates and sum `(X_ism * X)` over each window to rank which hits actually drive
+the prediction.
+
+## Single-tensor requirement
+
+Like DeepLIFT/SHAP and design, ISM needs a model whose forward returns a **single
+tensor**. The tensor may have multiple outputs (`(batch, n_targets)`), but the
+model must not return a *list* of tensors. `target=None` (the default) averages the
+attribution across **all** tasks; for a model with thousands of heterogeneous heads
+(binding + expression + histone) that average is noisy and uninterpretable, so pass
+an int or slice to subset to the output(s) you care about first, or wrap the model —
+see [model-wrapping.md](model-wrapping.md). `target=N` is exactly equivalent to a
+single-task slice wrapper.
+
+## Return type
+
+- Default (`raw_outputs=False`, `hypothetical=False`): an attribution tensor shaped
+  like `X` (`(batch, len(alphabet), end-start)`), **projected** onto the observed
+  bases. It is built from the per-edit prediction differences, mean-centered across
+  the bases at each position and averaged over the selected task(s) — not a raw
+  Euclidean distance. Collapse over the channel axis (`.sum(dim=1)`) for a
+  per-position track. It deliberately does **not** Z-score-normalize (unlike
+  TF-MoDISco-style scores): Z-scoring would flatten magnitude differences between
+  regions, so you could no longer compare a strong region head-to-head with a weak
+  one.
+- `hypothetical=True`: the same scores across all four bases, *before* projecting
+  onto the observed sequence (feeds CWM construction).
+- `raw_outputs=True`: a `SaturationMutagenesisRawResult(y0, y_hat)` NamedTuple —
+  `y0` the original predictions and `y_hat` the per-edit predictions — when you
+  want to aggregate the effect yourself.
+
+## Composing with perturbations
+
+`saturation_mutagenesis` satisfies the `func=` contract, so it drops into
+`marginalize`, `ablate`, `variant_effect.*`, etc. to get ISM scores before/after
+an edit — route ISM kwargs via `additional_func_kwargs` (see
+[func-pattern.md](func-pattern.md)).
+
+## Plotting
+
+```python
+from tangermeme.plot import plot_logo
+plot_logo(X_ism[0], ax=ax)
+```
+
+## Related references
+
+[deep_lift_shap.md](deep_lift_shap.md) (the gradient-based attribution method),
+[model-wrapping.md](model-wrapping.md), [func-pattern.md](func-pattern.md).

--- a/tangermeme/_skills/data/references/seqlets.md
+++ b/tangermeme/_skills/data/references/seqlets.md
@@ -1,0 +1,72 @@
+# Seqlet calling (recursive_seqlets / tfmodisco_seqlets)
+
+Seqlets are contiguous spans of high attribution — the "where are the motifs"
+step. `tangermeme.seqlet` has two callers with genuinely different behavior.
+
+## The #1 footgun: input is a 2D projected track
+
+Both callers take **per-position projected attribution sums**, shape `(n, length)`
+— i.e. the default (`hypothetical=False`) `deep_lift_shap` output collapsed over the
+channel axis:
+
+```python
+attr_sums = X_attr.sum(dim=1)        # (n, 4, length) -> (n, length)
+```
+
+Do **not** pass the `(n, 4, length)` attributions or hypothetical attributions.
+(See [deep_lift_shap.md](deep_lift_shap.md): hypothetical is for building CWMs, not
+for seqlet calling.)
+
+## recursive_seqlets — sharp, p-value based
+
+```python
+from tangermeme.seqlet import recursive_seqlets
+
+seqlets = recursive_seqlets(attr_sums, threshold=0.01, additional_flanks=0)
+# DataFrame columns: example_idx, start, end, attribution, p-value (sorted by p-value)
+```
+
+- Returns **positive seqlets only**. For negative ones, run on `attr_sums.abs()` and
+  re-extract signed attribution from the returned boundaries.
+- `threshold` is a p-value; it effectively requires ~`1/threshold` candidate spans,
+  so the right value **depends on how many examples/positions you pass**. Large runs
+  often use `0.001`.
+- `min_seqlet_len` (default 4) is also the smallest span the recursive property must
+  hold over — **don't set it to 1**. `max_seqlet_len` (default 25) raises cost.
+- `additional_flanks` is **cosmetic**: it pads the reported `start`/`end` but does
+  **not** change `attribution`/`p-value`, and these flanks may overlap neighbors
+  even though the cores cannot.
+- **Over-calls on a single example** (it can't fit a null from one sequence) — pass
+  many examples, or threshold by magnitude.
+
+## tfmodisco_seqlets — longer, discovery-oriented
+
+```python
+from tangermeme.seqlet import tfmodisco_seqlets
+
+seqlets = tfmodisco_seqlets(attr_sums, window_size=21, flank=10)
+# DataFrame columns: example_idx, start, end, attribution (positive + negative sets)
+```
+
+- Replicates TF-MoDISco's caller: seqlets are **longer and less sensitive** by
+  design (local context helps motif discovery; flanks get trimmed downstream).
+- **Adaptively lowers its threshold to hit a minimum count → it over-calls**; expect
+  to filter the results by attribution afterward.
+- Boundaries are **left-offset/asymmetric** because each position is replaced by the
+  sum of the window to its right (the chosen position is the left edge).
+
+## Which to use
+
+`recursive_seqlets` for sharp, minimal spans and per-seqlet p-values;
+`tfmodisco_seqlets` when feeding a motif-discovery pipeline that wants generous
+spans. Both flow straight into annotation and plotting.
+
+## Related references
+
+- **Label / count seqlets** → [annotate.md](annotate.md) (`annotate_seqlets`,
+  `count_annotations`, `pairwise_annotations`).
+- **Plot seqlets** → [plot.md](plot.md): `plot_logo(attr, annotations=seqlets,
+  score_key='attribution')`, filtered to one example
+  (`seqlets[seqlets['example_idx'] == i]`).
+- **Where the attributions come from** → [deep_lift_shap.md](deep_lift_shap.md)
+  (projected vs hypothetical).

--- a/tangermeme/_skills/data/references/variant-effect.md
+++ b/tangermeme/_skills/data/references/variant-effect.md
@@ -1,0 +1,85 @@
+# Variant effect scoring (substitution / deletion / insertion)
+
+`tangermeme.variant_effect` scores what a sequence edit does to a model's output.
+All three functions apply `func` (default `predict`) before and after the edit and
+return `PerturbationResult(y_before, y_after)` — there is **no built-in distance**,
+you compute your own (Euclidean, log-fold, etc.). They ride on `predict`, so
+multi-output models return lists and `args=` carries extra inputs; swap
+`func=deep_lift_shap` to get attributions before/after instead.
+
+Alphabet indices are positions in `alphabet` (default A=0, C=1, G=2, T=3).
+
+## substitution_effect — change characters in place
+
+```python
+from tangermeme.variant_effect import substitution_effect
+
+# substitutions: COO tensor, shape (-1, 3) = (example_idx, position, new_char_idx)
+subs = torch.tensor([[0, 1050, 2]])          # example 0, pos 1050 -> 'G'
+y_before, y_after = substitution_effect(model, X, subs)
+```
+
+**`position` is relative to the extracted window `X`, not a genomic coordinate.** A
+variant at genome position `g` in a window starting at `w` goes at `position = g - w`
+(account for any `max_jitter` expansion). Off-by-window errors silently mis-score.
+
+### Footgun #1 — edits are per-example, not per-variant (the collision trap)
+
+Rows are grouped by `example_idx` and **all applied to that one sequence at once**;
+they do not each yield an independent result. Two rows on example 0 give you the
+*combined* effect, not two scores. To score N variants **independently**, replicate
+the example N times and put each variant on its own copy:
+
+```python
+Xr = X[0:1].repeat(N, 1, 1)
+subs = torch.stack([torch.tensor([i, pos[i], alt[i]]) for i in range(N)])  # one per copy
+y_before, y_after = substitution_effect(model, Xr, subs)
+```
+
+Multiple rows targeting the **same `(example, position)`** are applied in row order
+by tensor assignment — the **last row wins**. Order rows accordingly if chaining.
+
+## deletion_effect — remove characters (needs over-length input)
+
+```python
+from tangermeme.variant_effect import deletion_effect
+
+# deletions: shape (-1, 2) = (example_idx, position)  — no char needed
+dels = torch.tensor([[0, 1050], [0, 1051]])
+y_before, y_after = deletion_effect(model, X_long, dels, left=False)
+```
+
+- Deleting shortens the sequence, but the model needs a fixed window, so **`X` must
+  be `model_length + max_deletions_per_example`** wide (raises otherwise). Every
+  sequence is padded to the same over-length even if it has fewer deletions.
+- `left=` chooses which side to trim back to `model_length` (`False`/right is
+  default). Use whichever side matches how the model was trained.
+- **`y_before` is computed on the *trimmed* slice of `X`, not the raw input** — so
+  the before/after delta isolates the deletion. Don't expect `y_before` to equal a
+  prediction on full-length `X`.
+
+## insertion_effect — add characters (trim after)
+
+```python
+from tangermeme.variant_effect import insertion_effect
+
+# insertions: shape (-1, 3) = (example_idx, position, char_idx)
+ins = torch.tensor([[0, 1050, 0]])           # insert 'A' at pos 1050
+y_before, y_after = insertion_effect(model, X, ins, left=False)
+```
+
+- Mirror image of deletions: pass **model-length** `X`; the insertion lengthens it
+  and the result is trimmed back to `model_length`, with `left=` choosing the side.
+
+## From a VCF
+
+Read variants with `io.read_vcf` (see [io-loci.md](io-loci.md)) and build the COO
+`substitutions` tensor (`example_idx`, `position` relative to your extracted window,
+`alt` allele index). Remember one row per variant **and one example copy per variant**
+if you want per-variant scores.
+
+## Related references
+
+[func-pattern.md](func-pattern.md) (swapping `func`/`additional_func_kwargs`),
+[io-loci.md](io-loci.md) (`read_vcf`, extracting the windows),
+[model-wrapping.md](model-wrapping.md) (multi-output / multi-input models).

--- a/tangermeme/_skills/install.py
+++ b/tangermeme/_skills/install.py
@@ -1,0 +1,149 @@
+# install.py
+# Contact: Jacob Schreiber <jmschreiber91@gmail.com>
+
+"""Install the bundled tangermeme Agent Skill for Claude Code.
+
+This module exposes the ``tangermeme-install-skills`` console script. It copies
+the Agent Skill that ships inside the installed package into a location where
+Claude Code discovers skills, so that a coding agent gains tangermeme-specific
+guidance (API contracts and footguns) in every project, not just this repository.
+
+Claude Code does not scan Python ``site-packages`` for skills; it only looks in a
+small set of fixed roots. The personal root, ``~/.claude/skills/``, makes a skill
+available across all of a user's projects, so that is the default destination. The
+skill itself is one self-contained directory -- a ``SKILL.md`` router plus a
+``references/`` folder of detailed topic files that are read on demand -- bundled
+here under ``data/``, so installation is simply copying that directory.
+
+The copy is deliberately opt-in via this command rather than being performed on
+import or install, because silently writing into a user's home configuration would
+be surprising and invasive.
+
+Run ``tangermeme-install-skills`` to install, or ``--print-path`` to see where the
+bundled source lives (useful with the ``CLAUDE_SKILLS_PATH`` environment variable
+if you would rather point Claude Code at the package in place than copy it).
+"""
+
+import argparse
+import shutil
+import sys
+
+from pathlib import Path
+
+
+SKILL_NAME = "tangermeme"
+
+
+def _bundled_skill_dir() -> Path:
+	"""Return the path to the Agent Skill bundled inside the package.
+
+	Returns
+	-------
+	skill_dir: pathlib.Path
+		The ``data/`` directory containing the bundled ``SKILL.md`` and
+		``references/``.
+	"""
+
+	return Path(__file__).resolve().parent / "data"
+
+
+def _default_dest() -> Path:
+	"""Return the default install destination in the user's personal skill root.
+
+	Returns
+	-------
+	dest: pathlib.Path
+		``~/.claude/skills/tangermeme``.
+	"""
+
+	return Path.home() / ".claude" / "skills" / SKILL_NAME
+
+
+def install_skill(dest: Path | None = None, force: bool = False) -> Path:
+	"""Copy the bundled tangermeme skill into a Claude Code skills directory.
+
+	The bundled skill directory is copied wholesale to ``dest``. If ``dest``
+	already exists it is left untouched unless ``force`` is set, in which case it
+	is removed and replaced so that an upgrade reflects the installed package
+	version exactly.
+
+	Parameters
+	----------
+	dest: pathlib.Path or None, optional
+		The directory to install the skill into. If None, defaults to
+		``~/.claude/skills/tangermeme``. Default is None.
+
+	force: bool, optional
+		Whether to overwrite an existing installation at ``dest``. Default is
+		False.
+
+	Returns
+	-------
+	dest: pathlib.Path
+		The directory the skill was installed into.
+	"""
+
+	src = _bundled_skill_dir()
+	if not (src / "SKILL.md").is_file():
+		raise FileNotFoundError(
+			"Bundled skill not found at {}. The package may be installed "
+			"without its skill data.".format(src))
+
+	if dest is None:
+		dest = _default_dest()
+
+	if dest.exists():
+		if not force:
+			raise FileExistsError(
+				"{} already exists. Re-run with --force to overwrite.".format(
+					dest))
+		shutil.rmtree(dest)
+
+	dest.parent.mkdir(parents=True, exist_ok=True)
+	shutil.copytree(src, dest,
+		ignore=shutil.ignore_patterns(".ipynb_checkpoints", "__pycache__"))
+	return dest
+
+
+def main(argv: list[str] | None = None) -> int:
+	"""Command-line entry point for ``tangermeme-install-skills``.
+
+	Parameters
+	----------
+	argv: list of str or None, optional
+		Arguments to parse. If None, ``sys.argv`` is used. Default is None.
+
+	Returns
+	-------
+	code: int
+		Process exit code; 0 on success and 1 on a handled error.
+	"""
+
+	parser = argparse.ArgumentParser(
+		prog="tangermeme-install-skills",
+		description="Install the tangermeme Agent Skill for Claude Code.")
+	parser.add_argument("--dest", type=Path, default=None,
+		help="Destination directory (default: ~/.claude/skills/tangermeme).")
+	parser.add_argument("--force", action="store_true",
+		help="Overwrite an existing installation.")
+	parser.add_argument("--print-path", action="store_true",
+		help="Print the bundled skill directory and exit without installing.")
+	args = parser.parse_args(argv)
+
+	if args.print_path:
+		print(_bundled_skill_dir())
+		return 0
+
+	try:
+		dest = install_skill(dest=args.dest, force=args.force)
+	except (FileExistsError, FileNotFoundError) as e:
+		print("error: {}".format(e), file=sys.stderr)
+		return 1
+
+	print("Installed tangermeme skill to {}".format(dest))
+	print("It will be available to Claude Code in your next session.")
+	return 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/tests/test_install_skills.py
+++ b/tests/test_install_skills.py
@@ -1,0 +1,157 @@
+# test_install_skills.py
+# Contact: Jacob Schreiber <jmschreiber91@gmail.com>
+
+import re
+import subprocess
+
+import pytest
+
+from pathlib import Path
+
+from tangermeme._skills import install as install_mod
+from tangermeme._skills.install import _bundled_skill_dir
+from tangermeme._skills.install import _default_dest
+from tangermeme._skills.install import install_skill
+
+
+###
+# Helpers
+
+
+def _link_targets(text):
+	"""Return the basenames of every Markdown link to a .md file in `text`."""
+
+	return [m.split("/")[-1] for m in re.findall(r'\]\(([^)]+\.md)\)', text)]
+
+
+def _seed_fake_skill(root):
+	"""Create a minimal but well-formed skill directory at `root`."""
+
+	(root / "references").mkdir(parents=True)
+	(root / "SKILL.md").write_text("---\nname: x\ndescription: y\n---\n\nbody\n")
+	(root / "references" / "foo.md").write_text("# foo\n")
+	return root
+
+
+###
+# Bundled-skill integrity (run against the data that actually ships)
+
+
+def test_bundled_skill_dir_is_well_formed():
+	data = _bundled_skill_dir()
+	assert data.is_dir()
+	assert (data / "SKILL.md").is_file()
+
+	refs = list((data / "references").glob("*.md"))
+	assert len(refs) > 0
+
+
+def test_skill_frontmatter():
+	text = (_bundled_skill_dir() / "SKILL.md").read_text()
+	assert text.startswith("---\n")
+
+	frontmatter = text.split("---\n", 2)[1]
+	fields = dict(re.findall(r'^(\w+):\s*(.*)$', frontmatter, flags=re.MULTILINE))
+
+	assert fields.get("name") == "tangermeme"
+	# Claude Code caps the description (combined with when_to_use) at 1536 chars.
+	assert 0 < len(fields.get("description", "")) <= 1536
+
+
+def test_internal_links_all_resolve():
+	data = _bundled_skill_dir()
+	refs = data / "references"
+	existing = {p.name for p in refs.glob("*.md")}
+
+	broken = []
+	for f in [data / "SKILL.md", *refs.glob("*.md")]:
+		for target in _link_targets(f.read_text()):
+			if target not in existing:
+				broken.append("{} -> {}".format(f.name, target))
+
+	assert broken == [], "broken internal links: {}".format(broken)
+
+
+###
+# install_skill behavior (always into a temporary destination)
+
+
+def test_install_into_fresh_dest(tmp_path):
+	dest = tmp_path / "tangermeme"
+	result = install_skill(dest=dest)
+
+	assert result == dest
+	assert (dest / "SKILL.md").is_file()
+
+	bundled = {p.name for p in (_bundled_skill_dir() / "references").glob("*.md")}
+	installed = {p.name for p in (dest / "references").glob("*.md")}
+	assert installed == bundled
+
+
+def test_install_existing_dest_raises_without_force(tmp_path):
+	dest = tmp_path / "tangermeme"
+	install_skill(dest=dest)
+
+	with pytest.raises(FileExistsError):
+		install_skill(dest=dest)
+
+
+def test_install_force_replaces_stale_content(tmp_path):
+	dest = tmp_path / "tangermeme"
+	install_skill(dest=dest)
+
+	junk = dest / "references" / "stale.md"
+	junk.write_text("remove me")
+
+	install_skill(dest=dest, force=True)
+
+	assert not junk.exists()
+	assert (dest / "SKILL.md").is_file()
+
+
+def test_install_missing_bundle_raises(tmp_path, monkeypatch):
+	empty = tmp_path / "empty"
+	empty.mkdir()
+	monkeypatch.setattr(install_mod, "_bundled_skill_dir", lambda: empty)
+
+	with pytest.raises(FileNotFoundError):
+		install_skill(dest=tmp_path / "tangermeme")
+
+
+def test_install_excludes_checkpoints_and_pycache(tmp_path, monkeypatch):
+	src = _seed_fake_skill(tmp_path / "src")
+	(src / ".ipynb_checkpoints").mkdir()
+	(src / ".ipynb_checkpoints" / "SKILL-checkpoint.md").write_text("nope")
+	(src / "__pycache__").mkdir()
+	(src / "__pycache__" / "x.pyc").write_text("nope")
+	monkeypatch.setattr(install_mod, "_bundled_skill_dir", lambda: src)
+
+	dest = install_skill(dest=tmp_path / "tangermeme")
+
+	assert not (dest / ".ipynb_checkpoints").exists()
+	assert not (dest / "__pycache__").exists()
+	assert (dest / "references" / "foo.md").is_file()
+
+
+def test_default_dest_is_under_home_and_isolated(tmp_path, monkeypatch):
+	# Patch home so the default-destination path never touches the real ~/.claude.
+	monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+	result = install_skill()
+
+	assert result == _default_dest()
+	assert result == tmp_path / ".claude" / "skills" / "tangermeme"
+	assert (result / "SKILL.md").is_file()
+
+
+###
+# Console-script entry point (opt-in; does not install anything)
+
+
+@pytest.mark.cmd
+def test_console_script_print_path():
+	result = subprocess.run(["tangermeme-install-skills", "--print-path"],
+		capture_output=True, text=True)
+
+	assert result.returncode == 0
+	assert result.stdout.strip().endswith("data")


### PR DESCRIPTION
## Summary

Adds a [Claude Code Agent Skill](https://docs.claude.com/en/docs/claude-code/skills) bundled with the package, plus a `tangermeme-install-skills` console script to install it, and documents both in the README and docs site.

The skill teaches a coding agent how to use tangermeme correctly — the API contracts, the footguns, and the multi-step workflows — so that using tangermeme as a dependency in any project is lower-friction and less error-prone.

## What's included

- **`tangermeme/_skills/`** — a `data/SKILL.md` router plus 14 progressive-disclosure reference files (loaded on demand, so near-zero context cost until used):
  - Attribution (`deep_lift_shap`, `saturation_mutagenesis`/ISM), the `func=` plug-point, model wrapping, marginalize/ablate/spacing, variant effects, seqlet calling, motif annotation, cartesian products, logo plotting, IO/loci loading, sequence design, cross-model comparison, and an end-to-end notebook walkthrough.
  - Content is footgun-focused (e.g. `deep_lift_shap` needs `target=` for multi-task models; `extract_loci` has a variable-length return; `screen`'s `shape` excludes the batch dim) and every signature/claim was verified against the source.
- **`tangermeme/_skills/install.py`** — `tangermeme-install-skills` console script that copies the skill into `~/.claude/skills/tangermeme/` (Claude Code does not scan installed Python packages, so this is opt-in rather than automatic). `--force` to refresh after upgrades; `--print-path` for the `CLAUDE_SKILLS_PATH` zero-copy route.
- **`pyproject.toml`** — the `[project.scripts]` entry; the skill data ships in both wheel and sdist.
- **README + docs** — a "Claude Code Skill" section covering install and brief usage.

## How to use

```bash
pip install tangermeme
tangermeme-install-skills
```

Then ask Claude Code to do tangermeme tasks; the skill is consulted automatically.

## Notes

- No changes to any library code or public API — this is additive (new subpackage + one console script + docs).
- `CLAUDE.md` is intentionally not included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)