### PR TITLE
Optimize and harden saturation_mutagenesis (ISM)

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -17,6 +17,15 @@ Claude Code skill
 	- Bundles a `Claude Code <https://claude.com/claude-code>`_ Agent Skill (a ``SKILL.md`` router plus on-demand reference files) that documents tangermeme's API contracts, footguns, and multi-step workflows for coding agents.
 	- Adds the ``tangermeme-install-skills`` console script, which copies the bundled skill into ``~/.claude/skills/`` so it is available to Claude Code in every project. Use ``--force`` to refresh after upgrading or ``--print-path`` for the ``CLAUDE_SKILLS_PATH`` route.
 
+saturation_mutagenesis
+----------------------
+
+	- Fixes ``saturation_mutagenesis`` for models that return multiple output tensors: the per-output reshape previously transposed the alphabet and length axes, returning scrambled values on the default span and raising when ``start``/``end`` subset the sequence.
+	- Skips the identity substitution at each position (the "edit" that re-applies the existing base), reconstructing those slots from the reference prediction ``y0`` instead of recomputing them. This removes ~25% of the model forward passes with no change to the output, for a wall-clock speedup that approaches 25% as the model becomes inference-bound.
+	- Adds a ``func=`` argument, forwarded to ``predict`` and applied identically to the reference and perturbed predictions (e.g. to select an output head or apply a final non-linearity).
+	- Validates that ``0 <= start < end <= length`` rather than silently producing out-of-bounds edits, and raises a clear error when a multi-output model is used without ``raw_outputs=True``.
+	- Warns (``TangermemeWarning``) when ``X`` holds non-integer values, which the internal int8 cast would otherwise truncate toward zero.
+
 
 Version 1.2.0
 =============

--- a/tangermeme/saturation_mutagenesis.py
+++ b/tangermeme/saturation_mutagenesis.py
@@ -263,7 +263,7 @@ def saturation_mutagenesis(
 				*y_[0].shape[1:]) for y_ in zip(*y_hat)
 		]
 	
-	if raw_outputs == False:
+	if not raw_outputs:
 		attr = _attribution_score(y0, y_hat, target)
-		return X[:, :, start:end] * attr if hypothetical == False else attr
+		return X[:, :, start:end] * attr if not hypothetical else attr
 	return SaturationMutagenesisRawResult(y0=y0, y_hat=y_hat)

--- a/tangermeme/saturation_mutagenesis.py
+++ b/tangermeme/saturation_mutagenesis.py
@@ -254,18 +254,44 @@ def saturation_mutagenesis(
 		X_ = X[i].repeat((end-start)*X[i].shape[0], 1, 1).numpy(force=True)
 		_edit_distance_one(X_, start, end)
 		X_ = torch.from_numpy(X_)
-	
+
+		# One generated sequence per position is an identity substitution: the
+		# edit re-applies the base already there, so the sequence is identical
+		# to the reference and its prediction equals y0. Skip those forward
+		# passes (25% of them) and reconstruct the slots from y0 below. The
+		# kernel lays rows out as [character, position], so the identity row
+		# at position p is the one whose character equals the original base.
+		orig = X[i, :, start:end].argmax(dim=0)
+		chars = torch.arange(4).repeat_interleave(end-start)
+		positions = torch.arange(end-start).repeat(4)
+		edits = chars != orig[positions]
+
+		X_ = X_[edits]
+
 		if args is not None:
-			args_ = tuple(a[i].repeat(X_.shape[0], *(1 for _ in a[i].shape)) 
+			n_edits = int(edits.sum())
+			args_ = tuple(a[i].repeat(n_edits, *(1 for _ in a[i].shape))
 				for a in args)
 		else:
 			args_ = None
-	
-		y_hat_ = predict(model, X_, args=args_, func=func, batch_size=batch_size,
-			dtype=dtype, device=device)
-	
+
+		y_edits = predict(model, X_, args=args_, func=func,
+			batch_size=batch_size, dtype=dtype, device=device)
+
+		# Scatter the edit predictions back into the full [character, position]
+		# grid, filling the identity slots with the reference prediction y0.
+		if isinstance(y_edits, torch.Tensor):
+			y_hat_ = y0[i].unsqueeze(0).repeat(edits.shape[0],
+				*(1 for _ in y0[i].shape))
+			y_hat_[edits] = y_edits
+		else:
+			y_hat_ = [y0_[i].unsqueeze(0).repeat(edits.shape[0],
+				*(1 for _ in y0_[i].shape)) for y0_ in y0]
+			for y_hat_h, y_edit in zip(y_hat_, y_edits):
+				y_hat_h[edits] = y_edit
+
 		y_hat.append(y_hat_)
-	
+
 	if isinstance(y_hat[0], torch.Tensor):
 		y_hat = torch.stack(y_hat).reshape(X.shape[0], X.shape[1], end-start, 
 			*y_hat_.shape[1:])

--- a/tangermeme/saturation_mutagenesis.py
+++ b/tangermeme/saturation_mutagenesis.py
@@ -8,7 +8,6 @@ from collections.abc import Callable
 from typing import Any
 from typing import NamedTuple
 
-import numba
 import torch
 
 from tqdm import trange
@@ -61,45 +60,6 @@ def _attribution_score(y0, y_hat, target):
 	if len(attr.shape) > 3:
 		attr = torch.mean(attr, dim=tuple(range(3, len(attr.shape))))
 	return attr
-
-
-
-@numba.njit("void(int8[:, :, :], int32, int32)")
-def _edit_distance_one(X, start, end):
-	"""An internal function for generating all sequences of edit distance 1
-
-	This internal function, which is meant to be used for ISM, will take in a
-	one-hot encoded sequence and return all sequences that have an edit distance
-	of one.
-
-	Note: the inner loop iterates over all 4 alphabet characters at each
-	mutated position, *including* the character already at that position.
-	One of the four "variants" per position is therefore an identity
-	substitution (a no-op); it contributes a zero into the per-position
-	mean used by `_attribution_score`. Callers wanting strict
-	edit-distance-1 outputs should mask or skip those rows.
-
-	Parameters
-	----------
-	X: torch.Tensor, shape=(length*len(alphabet), len(alphabet), length)
-		A single one-hot encoded sequence.
-
-	start: int
-		The first nucleotide to begin making edits on, inclusive.
-
-	end: int
-		The end of the span. Edits are not made on this nucleotide at this
-		index. Can be negative indexes.
-	"""
-	
-	i = 0
-	for j in range(4):
-		for k in range(start, end):
-			for l in range(4):
-				X[i, l, k] = 0
-				
-			X[i, j, k] = 1
-			i += 1
 
 
 
@@ -251,27 +211,27 @@ def saturation_mutagenesis(
 
 	y_hat = []
 	for i in trange(X.shape[0], disable=not verbose):
-		X_ = X[i].repeat((end-start)*X[i].shape[0], 1, 1).numpy(force=True)
-		_edit_distance_one(X_, start, end)
-		X_ = torch.from_numpy(X_)
-
-		# One generated sequence per position is an identity substitution: the
-		# edit re-applies the base already there, so the sequence is identical
-		# to the reference and its prediction equals y0. Skip those forward
-		# passes (up to 25% of them) and reconstruct the slots from y0 below.
-		# A row is identity only when the edit reproduces the reference column
-		# exactly, i.e. the column is a clean one-hot of that character; an
-		# all-zero column (an `N`) or a multi-hot column has no identity row,
-		# so all four edits are real and must be predicted. The kernel lays
-		# rows out as [character, position], so `identity` flattens to match.
+		# Build only the true single-base edits. One substitution per position
+		# would re-apply the base already there (an identity edit whose
+		# prediction equals y0); it is skipped here and filled from y0 below,
+		# saving up to 25% of the forward passes. A column that is all-zero (an
+		# `N`) or multi-hot is not a clean one-hot of any character, so it has
+		# no identity row and all four of its edits are kept. The kept rows are
+		# laid out in [character, position] order to match the reconstruction.
 		ref = X[i, :, start:end]
 		identity = (ref == 1) & (ref.sum(dim=0, keepdim=True) == 1)
 		edits = ~identity.reshape(-1)
 
-		X_ = X_[edits]
+		edit_chars, edit_positions = torch.where(~identity)
+		edit_positions = edit_positions + start
+		n_edits = edit_chars.shape[0]
+
+		X_ = X[i].repeat(n_edits, 1, 1)
+		rows = torch.arange(n_edits)
+		X_[rows, :, edit_positions] = 0
+		X_[rows, edit_chars, edit_positions] = 1
 
 		if args is not None:
-			n_edits = int(edits.sum())
 			args_ = tuple(a[i].repeat(n_edits, *(1 for _ in a[i].shape))
 				for a in args)
 		else:

--- a/tangermeme/saturation_mutagenesis.py
+++ b/tangermeme/saturation_mutagenesis.py
@@ -258,13 +258,15 @@ def saturation_mutagenesis(
 		# One generated sequence per position is an identity substitution: the
 		# edit re-applies the base already there, so the sequence is identical
 		# to the reference and its prediction equals y0. Skip those forward
-		# passes (25% of them) and reconstruct the slots from y0 below. The
-		# kernel lays rows out as [character, position], so the identity row
-		# at position p is the one whose character equals the original base.
-		orig = X[i, :, start:end].argmax(dim=0)
-		chars = torch.arange(4).repeat_interleave(end-start)
-		positions = torch.arange(end-start).repeat(4)
-		edits = chars != orig[positions]
+		# passes (up to 25% of them) and reconstruct the slots from y0 below.
+		# A row is identity only when the edit reproduces the reference column
+		# exactly, i.e. the column is a clean one-hot of that character; an
+		# all-zero column (an `N`) or a multi-hot column has no identity row,
+		# so all four edits are real and must be predicted. The kernel lays
+		# rows out as [character, position], so `identity` flattens to match.
+		ref = X[i, :, start:end]
+		identity = (ref == 1) & (ref.sum(dim=0, keepdim=True) == 1)
+		edits = ~identity.reshape(-1)
 
 		X_ = X_[edits]
 

--- a/tangermeme/saturation_mutagenesis.py
+++ b/tangermeme/saturation_mutagenesis.py
@@ -3,6 +3,9 @@
 
 from __future__ import annotations
 
+import warnings
+from collections.abc import Callable
+from typing import Any
 from typing import NamedTuple
 
 import numba
@@ -11,6 +14,7 @@ import torch
 from tqdm import trange
 
 from .predict import predict
+from .utils import TangermemeWarning
 
 
 class SaturationMutagenesisRawResult(NamedTuple):
@@ -112,6 +116,7 @@ def saturation_mutagenesis(
 	dtype: str | torch.dtype | None = None,
 	device: str | torch.device | None = None,
 	verbose: bool = False,
+	func: Callable[..., Any] | None = None,
 ) -> torch.Tensor | SaturationMutagenesisRawResult:
 	"""Performs in-silico saturation mutagenesis on a set of sequences.
 	
@@ -195,8 +200,15 @@ def saturation_mutagenesis(
 	
 	verbose: bool, optional
 		Whether to display a progress bar during predictions. Default is False.
-	
-	
+
+	func: function or None, optional
+		A function to apply to a batch of predictions after they have been made,
+		forwarded to `predict`. It is applied identically to the reference
+		predictions and to every perturbation, so attributions are computed on
+		the post-processed values. Use it to, e.g., select a single output head
+		or apply a final non-linearity. If None, do nothing. Default is None.
+
+
 	Returns
 	-------
 	attr: torch.Tensor
@@ -214,8 +226,19 @@ def saturation_mutagenesis(
 		The outputs from the model for each of the perturbed sequences.
 	"""
 
+	if X.is_floating_point() and not torch.equal(X, X.round()):
+		warnings.warn("X contains non-integer values which will be truncated "
+			"toward zero by the int8 cast; values with magnitude < 1 become 0. "
+			"Pass a hard one-hot encoding to avoid silently zeroing positions.",
+			TangermemeWarning)
+
 	X = X.type(torch.int8).cpu()
-	y0 = predict(model, X, args=args, dtype=dtype, device=device)
+	y0 = predict(model, X, args=args, func=func, dtype=dtype, device=device)
+
+	if not raw_outputs and not isinstance(y0, torch.Tensor):
+		raise ValueError("raw_outputs=True is required for models that return "
+			"multiple output tensors; the attribution aggregation assumes a "
+			"single output tensor.")
 
 	length = X.shape[-1]
 	if end < 0:
@@ -238,7 +261,7 @@ def saturation_mutagenesis(
 		else:
 			args_ = None
 	
-		y_hat_ = predict(model, X_, args=args_, batch_size=batch_size, 
+		y_hat_ = predict(model, X_, args=args_, func=func, batch_size=batch_size,
 			dtype=dtype, device=device)
 	
 		y_hat.append(y_hat_)
@@ -254,7 +277,5 @@ def saturation_mutagenesis(
 	
 	if raw_outputs == False:
 		attr = _attribution_score(y0, y_hat, target)
-		if end <= 0:
-			return X * attr if hypothetical == False else attr
 		return X[:, :, start:end] * attr if hypothetical == False else attr
 	return SaturationMutagenesisRawResult(y0=y0, y_hat=y_hat)

--- a/tangermeme/saturation_mutagenesis.py
+++ b/tangermeme/saturation_mutagenesis.py
@@ -216,10 +216,16 @@ def saturation_mutagenesis(
 
 	X = X.type(torch.int8).cpu()
 	y0 = predict(model, X, args=args, dtype=dtype, device=device)
-	
+
+	length = X.shape[-1]
 	if end < 0:
-		end = X.shape[-1] + 1 + end
-	
+		end = length + 1 + end
+
+	if start < 0 or end > length or start >= end:
+		raise ValueError("start and end must satisfy "
+			"0 <= start < end <= length; got start={}, end={} for length "
+			"{}.".format(start, end, length))
+
 	y_hat = []
 	for i in trange(X.shape[0], disable=not verbose):
 		X_ = X[i].repeat((end-start)*X[i].shape[0], 1, 1).numpy(force=True)
@@ -242,8 +248,8 @@ def saturation_mutagenesis(
 			*y_hat_.shape[1:])
 	else:
 		y_hat = [
-			torch.cat(y_).reshape(X.shape[0], X.shape[2], X.shape[1], 
-				*y_[0].shape[1:]).transpose(2, 1) for y_ in zip(*y_hat)
+			torch.stack(y_).reshape(X.shape[0], X.shape[1], end-start,
+				*y_[0].shape[1:]) for y_ in zip(*y_hat)
 		]
 	
 	if raw_outputs == False:

--- a/tests/test_saturation_mutagenesis.py
+++ b/tests/test_saturation_mutagenesis.py
@@ -3,12 +3,10 @@
 
 import warnings
 
-import numpy
 import torch
 import pytest
 
 from tangermeme.predict import predict
-from tangermeme.utils import one_hot_encode
 from tangermeme.utils import random_one_hot
 from tangermeme.utils import TangermemeWarning
 
@@ -17,8 +15,6 @@ from tangermeme.saturation_mutagenesis import saturation_mutagenesis
 
 from .toy_models import SumModel
 from .toy_models import FlattenDense
-from .toy_models import Conv
-from .toy_models import Scatter
 from .toy_models import ConvDense
 from .toy_models import SmallDeepSEA
 

--- a/tests/test_saturation_mutagenesis.py
+++ b/tests/test_saturation_mutagenesis.py
@@ -12,7 +12,6 @@ from tangermeme.utils import one_hot_encode
 from tangermeme.utils import random_one_hot
 from tangermeme.utils import TangermemeWarning
 
-from tangermeme.saturation_mutagenesis import _edit_distance_one
 from tangermeme.saturation_mutagenesis import _attribution_score
 from tangermeme.saturation_mutagenesis import saturation_mutagenesis
 
@@ -35,130 +34,6 @@ def X():
 @pytest.fixture
 def X0():
 	return random_one_hot((2, 4, 100), random_state=0).float()
-
-
-###
-
-
-def test_edit_distance_one(X):
-	X_ = X[0].repeat(X.shape[-1]*X[0].shape[0], 1, 1).numpy(force=True)
-	_edit_distance_one(X_, 0, X_.shape[-1])
-	X_one = torch.from_numpy(X_)
-	
-	assert X_one.dtype == torch.int8
-	assert X_one.shape == (40, 4, 10)
-	assert X_one.sum() == 400
-
-	assert_array_almost_equal(X_one[:4], [
-		[[1, 0, 0, 1, 0, 0, 0, 0, 0, 0],
-		 [0, 0, 1, 0, 0, 0, 0, 0, 1, 0],
-		 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-		 [0, 1, 0, 0, 1, 1, 1, 1, 0, 1]],
-
-		[[1, 1, 0, 1, 0, 0, 0, 0, 0, 0],
-		 [0, 0, 1, 0, 0, 0, 0, 0, 1, 0],
-		 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-		 [0, 0, 0, 0, 1, 1, 1, 1, 0, 1]],
-
-		[[1, 0, 1, 1, 0, 0, 0, 0, 0, 0],
-		 [0, 0, 0, 0, 0, 0, 0, 0, 1, 0],
-		 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-		 [0, 1, 0, 0, 1, 1, 1, 1, 0, 1]],
-
-		[[1, 0, 0, 1, 0, 0, 0, 0, 0, 0],
-		 [0, 0, 1, 0, 0, 0, 0, 0, 1, 0],
-		 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-		 [0, 1, 0, 0, 1, 1, 1, 1, 0, 1]]])
-
-	assert_array_almost_equal(X_one[-4:], [
-		[[1, 0, 0, 1, 0, 0, 0, 0, 0, 0],
-		 [0, 0, 1, 0, 0, 0, 0, 0, 1, 0],
-		 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-		 [0, 1, 0, 0, 1, 1, 1, 1, 0, 1]],
-
-		[[1, 0, 0, 1, 0, 0, 0, 0, 0, 0],
-		 [0, 0, 1, 0, 0, 0, 0, 0, 1, 0],
-		 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-		 [0, 1, 0, 0, 1, 1, 1, 1, 0, 1]],
-
-		[[1, 0, 0, 1, 0, 0, 0, 0, 0, 0],
-		 [0, 0, 1, 0, 0, 0, 0, 0, 0, 0],
-		 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-		 [0, 1, 0, 0, 1, 1, 1, 1, 1, 1]],
-
-		[[1, 0, 0, 1, 0, 0, 0, 0, 0, 0],
-		 [0, 0, 1, 0, 0, 0, 0, 0, 1, 0],
-		 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-		 [0, 1, 0, 0, 1, 1, 1, 1, 0, 1]]])
-
-
-def test_edit_distance_one_start_end(X):
-	start, end = 2, 5
-	X_ = X[0].repeat((end-start)*X[0].shape[0], 1, 1).numpy(force=True)
-	_edit_distance_one(X_, start, end)
-	X_one = torch.from_numpy(X_)
-	assert X_one.shape == (12, 4, 10)
-
-	assert_array_almost_equal(X_one, [
-		[[1, 0, 1, 1, 0, 0, 0, 0, 0, 0],
-		 [0, 0, 0, 0, 0, 0, 0, 0, 1, 0],
-		 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-		 [0, 1, 0, 0, 1, 1, 1, 1, 0, 1]],
-
-		[[1, 0, 0, 1, 0, 0, 0, 0, 0, 0],
-		 [0, 0, 1, 0, 0, 0, 0, 0, 1, 0],
-		 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-		 [0, 1, 0, 0, 1, 1, 1, 1, 0, 1]],
-
-		[[1, 0, 0, 1, 1, 0, 0, 0, 0, 0],
-		 [0, 0, 1, 0, 0, 0, 0, 0, 1, 0],
-		 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-		 [0, 1, 0, 0, 0, 1, 1, 1, 0, 1]],
-
-		[[1, 0, 0, 1, 0, 0, 0, 0, 0, 0],
-		 [0, 0, 1, 0, 0, 0, 0, 0, 1, 0],
-		 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-		 [0, 1, 0, 0, 1, 1, 1, 1, 0, 1]],
-
-		[[1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-		 [0, 0, 1, 1, 0, 0, 0, 0, 1, 0],
-		 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-		 [0, 1, 0, 0, 1, 1, 1, 1, 0, 1]],
-
-		[[1, 0, 0, 1, 0, 0, 0, 0, 0, 0],
-		 [0, 0, 1, 0, 1, 0, 0, 0, 1, 0],
-		 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-		 [0, 1, 0, 0, 0, 1, 1, 1, 0, 1]],
-
-		[[1, 0, 0, 1, 0, 0, 0, 0, 0, 0],
-		 [0, 0, 0, 0, 0, 0, 0, 0, 1, 0],
-		 [0, 0, 1, 0, 0, 0, 0, 0, 0, 0],
-		 [0, 1, 0, 0, 1, 1, 1, 1, 0, 1]],
-
-		[[1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-		 [0, 0, 1, 0, 0, 0, 0, 0, 1, 0],
-		 [0, 0, 0, 1, 0, 0, 0, 0, 0, 0],
-		 [0, 1, 0, 0, 1, 1, 1, 1, 0, 1]],
-
-		[[1, 0, 0, 1, 0, 0, 0, 0, 0, 0],
-		 [0, 0, 1, 0, 0, 0, 0, 0, 1, 0],
-		 [0, 0, 0, 0, 1, 0, 0, 0, 0, 0],
-		 [0, 1, 0, 0, 0, 1, 1, 1, 0, 1]],
-
-		[[1, 0, 0, 1, 0, 0, 0, 0, 0, 0],
-		 [0, 0, 0, 0, 0, 0, 0, 0, 1, 0],
-		 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-		 [0, 1, 1, 0, 1, 1, 1, 1, 0, 1]],
-
-		[[1, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-		 [0, 0, 1, 0, 0, 0, 0, 0, 1, 0],
-		 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-		 [0, 1, 0, 1, 1, 1, 1, 1, 0, 1]],
-
-		[[1, 0, 0, 1, 0, 0, 0, 0, 0, 0],
-		 [0, 0, 1, 0, 0, 0, 0, 0, 1, 0],
-		 [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-		 [0, 1, 0, 0, 1, 1, 1, 1, 0, 1]]])
 
 
 ###
@@ -533,6 +408,51 @@ def test_saturation_mutagenesis_multi_hot_column(device):
 		assert_array_almost_equal(y_hat[0, base, 30], y_sub[0], 4)
 
 
+def test_saturation_mutagenesis_matches_bruteforce(device):
+	# Full validation of the vectorized edit construction: every (base,
+	# position) slot of y_hat must equal an explicit prediction of that single
+	# substitution. Identity slots reduce to the reference (== y0) and are
+	# covered too. A small sequence keeps the brute-force loop cheap.
+	torch.manual_seed(0)
+	X = random_one_hot((1, 4, 12), random_state=0).float()
+	model = FlattenDense(seq_len=12, n_outputs=1)
+
+	y0, y_hat = saturation_mutagenesis(model, X, raw_outputs=True,
+		device=device)
+
+	for base in range(4):
+		for pos in range(12):
+			X_sub = X.clone()
+			X_sub[0, :, pos] = 0
+			X_sub[0, base, pos] = 1
+			y_sub = predict(model, X_sub, device=device)
+			assert_array_almost_equal(y_hat[0, base, pos], y_sub[0], 4)
+
+
+def test_saturation_mutagenesis_bruteforce_windowed_with_N(device):
+	# Combines the trickiest pieces of the construction: a start/end window
+	# (so edit positions are offset) containing an all-zero `N` column (so the
+	# kept-edit count varies within the window). Every slot must match an
+	# explicit substitution at the absolute position.
+	torch.manual_seed(0)
+	X = random_one_hot((1, 4, 20), random_state=0).float()
+	X[0, :, 8] = 0                      # N column inside the window
+	model = FlattenDense(seq_len=20, n_outputs=1)
+	start, end = 5, 12
+
+	y0, y_hat = saturation_mutagenesis(model, X, start=start, end=end,
+		raw_outputs=True, device=device)
+	assert y_hat.shape == (1, 4, end - start, 1)
+
+	for base in range(4):
+		for pos in range(end - start):
+			X_sub = X.clone()
+			X_sub[0, :, start + pos] = 0
+			X_sub[0, base, start + pos] = 1
+			y_sub = predict(model, X_sub, device=device)
+			assert_array_almost_equal(y_hat[0, base, pos], y_sub[0], 4)
+
+
 def test_saturation_mutagenesis_zero_where_X_zero(X0, device):
 	model = SmallDeepSEA(1)
 	X_attr = saturation_mutagenesis(model, X0, device=device,
@@ -700,8 +620,8 @@ def test_saturation_mutagenesis_empty_span(X0):
 
 
 def test_saturation_mutagenesis_end_past_length(X0):
-	# end beyond the sequence length would drive the numba kernel to write
-	# out of bounds and silently corrupt the batch; it must be rejected.
+	# end beyond the sequence length would index past the sequence when
+	# building the edits; it must be rejected up front.
 	model = SmallDeepSEA(1)
 	with pytest.raises(ValueError, match="0 <= start < end <= length"):
 		saturation_mutagenesis(model, X0, start=0, end=X0.shape[-1] + 5,

--- a/tests/test_saturation_mutagenesis.py
+++ b/tests/test_saturation_mutagenesis.py
@@ -468,12 +468,13 @@ def test_saturation_mutagenesis_identity_recovers_y0(X0, device):
 		device=device)
 
 	# For each (example, position), the substitution that keeps the original
-	# base must equal y0 for that example.
+	# base is an identity edit. Its forward pass is skipped and the slot is
+	# filled directly from y0, so it must equal y0 *exactly* (not just to
+	# float tolerance) -- this guards the identity-skipping optimization.
 	for i in range(X0.shape[0]):
 		for pos in range(X0.shape[-1]):
 			orig_base = int(X0[i, :, pos].argmax())
-			assert_array_almost_equal(
-				y_hat[i, orig_base, pos], y0[i], 4)
+			assert torch.equal(y_hat[i, orig_base, pos], y0[i])
 
 
 def test_saturation_mutagenesis_zero_where_X_zero(X0, device):
@@ -816,3 +817,24 @@ def test_saturation_mutagenesis_no_warning_on_hard_one_hot(X0, device):
 	with warnings.catch_warnings():
 		warnings.simplefilter("error", TangermemeWarning)
 		saturation_mutagenesis(model, X0, device=device)
+
+
+def test_saturation_mutagenesis_skips_identity_forward_passes(X0, device):
+	# Identity substitutions are not run through the model: only the 3 true
+	# edits per position are predicted, plus one reference pass for y0.
+	class _Counter(torch.nn.Module):
+		def __init__(self, model):
+			super(_Counter, self).__init__()
+			self.model = model
+			self.rows = 0
+
+		def forward(self, X, *args):
+			self.rows += X.shape[0]
+			return self.model(X, *args)
+
+	model = _Counter(SmallDeepSEA(1))
+	saturation_mutagenesis(model, X0, device=device)
+
+	n, length = X0.shape[0], X0.shape[-1]
+	# n reference rows + 3 true edits per position per example.
+	assert model.rows == n + 3 * length * n

--- a/tests/test_saturation_mutagenesis.py
+++ b/tests/test_saturation_mutagenesis.py
@@ -1,12 +1,15 @@
 # test_saturation_mutagenesis.py
 # Contact: Jacob Schreiber <jmschreiber91@gmail.com>
 
+import warnings
+
 import numpy
 import torch
 import pytest
 
 from tangermeme.utils import one_hot_encode
 from tangermeme.utils import random_one_hot
+from tangermeme.utils import TangermemeWarning
 
 from tangermeme.saturation_mutagenesis import _edit_distance_one
 from tangermeme.saturation_mutagenesis import _attribution_score
@@ -716,3 +719,100 @@ def test_saturation_mutagenesis_bf16(X0, cuda_device):
 			ob = int(X0[i, :, pos].argmax())
 			assert_array_almost_equal(y_hat[i, ob, pos].float(),
 				y0[i].float(), 2)
+
+
+def test_saturation_mutagenesis_args_applied_per_example(X0, device):
+	# FlattenDense adds a per-example alpha. Because ISM is a difference, the
+	# arg must shift every perturbation of example i by exactly alpha[i] -- a
+	# wrong index (e.g. alpha[0] for all) would break this -- and the resulting
+	# attribution must be invariant to the additive shift.
+	torch.manual_seed(0)
+	model = FlattenDense(seq_len=100, n_outputs=1)
+	alpha = torch.randn(2, 1)
+
+	y0_w, y_hat_w = saturation_mutagenesis(model, X0, args=(alpha,),
+		raw_outputs=True, device=device)
+	y0_n, y_hat_n = saturation_mutagenesis(model, X0, raw_outputs=True,
+		device=device)
+
+	for i in range(X0.shape[0]):
+		delta = y_hat_w[i] - y_hat_n[i]
+		assert_array_almost_equal(delta, torch.full_like(delta, float(alpha[i])),
+			4)
+
+	attr_w = saturation_mutagenesis(model, X0, args=(alpha,), device=device)
+	attr_n = saturation_mutagenesis(model, X0, device=device)
+	assert_array_almost_equal(attr_w, attr_n, 4)
+
+
+def test_saturation_mutagenesis_batch_size_invariance(X0, device):
+	# Results must not depend on how perturbations are batched.
+	torch.manual_seed(0)
+	model = SmallDeepSEA(1)
+
+	a1 = saturation_mutagenesis(model, X0, batch_size=1, device=device)
+	a32 = saturation_mutagenesis(model, X0, batch_size=32, device=device)
+	a_big = saturation_mutagenesis(model, X0, batch_size=10000, device=device)
+
+	assert_array_almost_equal(a1, a32, 4)
+	assert_array_almost_equal(a1, a_big, 4)
+
+
+def test_saturation_mutagenesis_length_one(device):
+	# A single-position sequence is a valid degenerate input.
+	torch.manual_seed(0)
+	X = random_one_hot((2, 4, 1), random_state=0).float()
+	model = FlattenDense(seq_len=1, n_outputs=1)
+
+	X_attr = saturation_mutagenesis(model, X, device=device)
+	assert X_attr.shape == (2, 4, 1)
+
+
+def test_saturation_mutagenesis_multi_output_requires_raw(X0, device):
+	# Attribution aggregation assumes a single output tensor; a tuple-output
+	# model must fail fast with a clear message instead of an opaque error.
+	model = ConvDense(n_outputs=3)
+	with pytest.raises(ValueError, match="raw_outputs=True is required"):
+		saturation_mutagenesis(model, X0, device=device)
+
+
+def test_saturation_mutagenesis_func_selects_head(X0, device):
+	# func is forwarded to predict and applied to both reference and perturbed
+	# predictions, so selecting a head with func matches target= on that head.
+	torch.manual_seed(0)
+	model = FlattenDense(seq_len=100, n_outputs=3)
+
+	attr_func = saturation_mutagenesis(model, X0, func=lambda y: y[:, 1:2],
+		device=device)
+	attr_target = saturation_mutagenesis(model, X0, target=1, device=device)
+	assert_array_almost_equal(attr_func, attr_target, 4)
+
+
+def test_saturation_mutagenesis_func_collapses_multi_output(X0, device):
+	# func can reduce a multi-output model to a single tensor, making the
+	# attribution path valid again.
+	torch.manual_seed(0)
+	model = ConvDense(n_outputs=3)
+
+	attr = saturation_mutagenesis(model, X0, func=lambda ys: ys[1],
+		device=device)
+	assert attr.shape == (2, 4, 100)
+
+
+def test_saturation_mutagenesis_warns_on_non_integer_input(device):
+	# Soft / scaled one-hot inputs are truncated by the int8 cast; the user
+	# must be warned rather than silently getting zeros.
+	torch.manual_seed(0)
+	X = random_one_hot((2, 4, 100), random_state=0).float()
+	model = SmallDeepSEA(1)
+
+	with pytest.warns(TangermemeWarning, match="non-integer values"):
+		saturation_mutagenesis(model, X * 0.5, device=device)
+
+
+def test_saturation_mutagenesis_no_warning_on_hard_one_hot(X0, device):
+	# A valid hard one-hot must not trigger the truncation warning.
+	model = SmallDeepSEA(1)
+	with warnings.catch_warnings():
+		warnings.simplefilter("error", TangermemeWarning)
+		saturation_mutagenesis(model, X0, device=device)

--- a/tests/test_saturation_mutagenesis.py
+++ b/tests/test_saturation_mutagenesis.py
@@ -7,6 +7,7 @@ import numpy
 import torch
 import pytest
 
+from tangermeme.predict import predict
 from tangermeme.utils import one_hot_encode
 from tangermeme.utils import random_one_hot
 from tangermeme.utils import TangermemeWarning
@@ -475,6 +476,61 @@ def test_saturation_mutagenesis_identity_recovers_y0(X0, device):
 		for pos in range(X0.shape[-1]):
 			orig_base = int(X0[i, :, pos].argmax())
 			assert torch.equal(y_hat[i, orig_base, pos], y0[i])
+
+
+def test_saturation_mutagenesis_identity_recovers_y0_windowed(X0, device):
+	# Identity-slot exactness must also hold inside a start/end window, which
+	# exercises the windowed alignment of the identity mask.
+	model = SmallDeepSEA(1)
+	start, end = 30, 70
+
+	y0, y_hat = saturation_mutagenesis(model, X0, start=start, end=end,
+		raw_outputs=True, device=device)
+
+	for i in range(X0.shape[0]):
+		for pos in range(end - start):
+			orig_base = int(X0[i, :, start + pos].argmax())
+			assert torch.equal(y_hat[i, orig_base, pos], y0[i])
+
+
+def test_saturation_mutagenesis_all_zero_column(device):
+	# An all-zero column (an `N`) has no identity substitution, so all four
+	# edits at that position must be genuinely predicted -- not skipped and
+	# filled from y0. Validate against brute-force per-substitution predictions.
+	torch.manual_seed(0)
+	X = random_one_hot((1, 4, 100), random_state=0).float()
+	X[0, :, 50] = 0
+	model = SmallDeepSEA(1)
+
+	y0, y_hat = saturation_mutagenesis(model, X, raw_outputs=True,
+		device=device)
+
+	for base in range(4):
+		X_sub = X.clone()
+		X_sub[0, :, 50] = 0
+		X_sub[0, base, 50] = 1
+		y_sub = predict(model, X_sub, device=device)
+		assert_array_almost_equal(y_hat[0, base, 50], y_sub[0], 4)
+
+
+def test_saturation_mutagenesis_multi_hot_column(device):
+	# A multi-hot column likewise has no identity row; all four edits are real.
+	torch.manual_seed(0)
+	X = random_one_hot((1, 4, 100), random_state=0).float()
+	X[0, :, 30] = 0
+	X[0, 1, 30] = 1
+	X[0, 2, 30] = 1
+	model = SmallDeepSEA(1)
+
+	y0, y_hat = saturation_mutagenesis(model, X, raw_outputs=True,
+		device=device)
+
+	for base in range(4):
+		X_sub = X.clone()
+		X_sub[0, :, 30] = 0
+		X_sub[0, base, 30] = 1
+		y_sub = predict(model, X_sub, device=device)
+		assert_array_almost_equal(y_hat[0, base, 30], y_sub[0], 4)
 
 
 def test_saturation_mutagenesis_zero_where_X_zero(X0, device):

--- a/tests/test_saturation_mutagenesis.py
+++ b/tests/test_saturation_mutagenesis.py
@@ -501,3 +501,218 @@ def test_saturation_mutagenesis_raw_outputs_named_tuple(device):
 	# When raw_outputs=False the return is still a plain Tensor.
 	attr = saturation_mutagenesis(model, X, raw_outputs=False, device=device)
 	assert isinstance(attr, torch.Tensor)
+
+
+###
+
+
+class _DenseHead(torch.nn.Module):
+	"""Single-tensor model sharing the dense head of a ConvDense instance.
+
+	Used to cross-check the multi-tensor reshape branch in
+	`saturation_mutagenesis`: the second (dense) output of `ConvDense` must
+	match this standalone model exactly when both are run through ISM.
+	"""
+
+	def __init__(self, src):
+		super(_DenseHead, self).__init__()
+		self.dense = src.dense
+
+	def forward(self, X):
+		return self.dense(X.reshape(X.shape[0], -1))
+
+
+def test_saturation_mutagenesis_multi_output(device):
+	# Exercises the list/tuple-output reshape branch end-to-end.
+	torch.manual_seed(0)
+	X = random_one_hot((2, 4, 100), random_state=0).float()
+
+	model = ConvDense(n_outputs=3)
+	y0, y_hat = saturation_mutagenesis(model, X, raw_outputs=True,
+		device=device)
+
+	assert isinstance(y0, list) and isinstance(y_hat, list)
+	assert len(y0) == 2 and len(y_hat) == 2
+	assert y0[0].shape == (2, 12, 98)
+	assert y0[1].shape == (2, 3)
+	assert y_hat[0].shape == (2, 4, 100, 12, 98)
+	assert y_hat[1].shape == (2, 4, 100, 3)
+
+	# The dense head must equal the same head run as a single-tensor model.
+	# This catches the alphabet/position axis scrambling the old reshape had.
+	y0_s, y_hat_s = saturation_mutagenesis(_DenseHead(model), X,
+		raw_outputs=True, device=device)
+	assert_array_almost_equal(y_hat[1], y_hat_s, 4)
+	assert_array_almost_equal(y0[1], y0_s, 4)
+
+	# Identity substitutions recover y0 on both heads.
+	for head_hat, head0 in zip(y_hat, y0):
+		for i in range(X.shape[0]):
+			for pos in range(X.shape[-1]):
+				ob = int(X[i, :, pos].argmax())
+				assert_array_almost_equal(head_hat[i, ob, pos], head0[i], 4)
+
+
+def test_saturation_mutagenesis_multi_output_start_end(device):
+	# Regression: the multi-tensor reshape previously hardcoded the full
+	# length and raised when start>0 / end<length.
+	torch.manual_seed(0)
+	X = random_one_hot((2, 4, 100), random_state=0).float()
+
+	model = ConvDense(n_outputs=3)
+	y0, y_hat = saturation_mutagenesis(model, X, start=50, end=60,
+		raw_outputs=True, device=device)
+
+	assert y_hat[0].shape == (2, 4, 10, 12, 98)
+	assert y_hat[1].shape == (2, 4, 10, 3)
+
+	# Cross-check the dense head against the equivalent single-tensor model.
+	y0_s, y_hat_s = saturation_mutagenesis(_DenseHead(model), X, start=50,
+		end=60, raw_outputs=True, device=device)
+	assert_array_almost_equal(y_hat[1], y_hat_s, 4)
+
+
+def test_attribution_score_target_slice():
+	torch.manual_seed(0)
+	y0 = torch.zeros(1, 3)
+	y_hat = torch.randn(1, 4, 10, 3)
+
+	attr_slice = _attribution_score(y0, y_hat, slice(0, 2))
+	attr0 = _attribution_score(y0, y_hat, 0)
+	attr1 = _attribution_score(y0, y_hat, 1)
+
+	assert attr_slice.shape == (1, 4, 10)
+	# A slice averages over the selected targets, matching the int-target mean.
+	assert_array_almost_equal(attr_slice, (attr0 + attr1) / 2, 4)
+
+
+def test_saturation_mutagenesis_start_default_end(X0, device):
+	# start>0 combined with the default negative end (-1 -> length).
+	torch.manual_seed(0)
+	model = SmallDeepSEA(5)
+
+	X_attr = saturation_mutagenesis(model, X0, start=50, device=device)
+	X_attr_full = saturation_mutagenesis(model, X0, device=device)
+
+	assert X_attr.shape == (2, 4, 50)
+	assert_array_almost_equal(X_attr, X_attr_full[:, :, 50:], 4)
+
+
+def test_saturation_mutagenesis_int8_float_equivalence(X0, device):
+	# The int8 cast is load-bearing; a hard one-hot must give identical
+	# results whether passed as float or int8.
+	torch.manual_seed(0)
+	model = SmallDeepSEA(1)
+
+	X_attr_float = saturation_mutagenesis(model, X0, device=device)
+	X_attr_int8 = saturation_mutagenesis(model, X0.type(torch.int8),
+		device=device)
+
+	assert_array_almost_equal(X_attr_float, X_attr_int8, 4)
+
+
+def test_saturation_mutagenesis_dtype_arg(X0, device):
+	# Explicitly passing dtype should match the default (model dtype) path.
+	torch.manual_seed(0)
+	model = SmallDeepSEA(1)
+
+	X_attr = saturation_mutagenesis(model, X0, dtype=torch.float32,
+		device=device)
+	X_attr_default = saturation_mutagenesis(model, X0, device=device)
+
+	assert X_attr.dtype == torch.float32
+	assert_array_almost_equal(X_attr, X_attr_default, 4)
+
+
+def test_saturation_mutagenesis_args_batch_mismatch(X0):
+	# args with a mismatched batch dimension must surface predict's check.
+	model = FlattenDense(seq_len=100, n_outputs=1)
+	with pytest.raises(ValueError, match="same first dimension"):
+		saturation_mutagenesis(model, X0, args=(torch.randn(5, 1),),
+			raw_outputs=True)
+
+
+def test_saturation_mutagenesis_empty_span(X0):
+	# A degenerate span (no positions to perturb) is rejected up front.
+	model = SmallDeepSEA(1)
+	with pytest.raises(ValueError, match="0 <= start < end <= length"):
+		saturation_mutagenesis(model, X0, start=0, end=0, raw_outputs=True)
+
+
+def test_saturation_mutagenesis_end_past_length(X0):
+	# end beyond the sequence length would drive the numba kernel to write
+	# out of bounds and silently corrupt the batch; it must be rejected.
+	model = SmallDeepSEA(1)
+	with pytest.raises(ValueError, match="0 <= start < end <= length"):
+		saturation_mutagenesis(model, X0, start=0, end=X0.shape[-1] + 5,
+			raw_outputs=True)
+
+
+def test_saturation_mutagenesis_negative_start(X0):
+	# Negative start is never remapped (unlike end) and would index before
+	# the sequence; it must be rejected rather than corrupt the batch.
+	model = SmallDeepSEA(1)
+	with pytest.raises(ValueError, match="0 <= start < end <= length"):
+		saturation_mutagenesis(model, X0, start=-3, end=8, raw_outputs=True)
+
+
+def test_saturation_mutagenesis_start_after_end(X0):
+	# An inverted span must be rejected.
+	model = SmallDeepSEA(1)
+	with pytest.raises(ValueError, match="0 <= start < end <= length"):
+		saturation_mutagenesis(model, X0, start=8, end=3, raw_outputs=True)
+
+
+def test_saturation_mutagenesis_input_dtypes(X0, device):
+	# X is coerced to int8 internally, so any integer-valued encoding -- float64,
+	# int32, or bool -- must give identical results to the float32 input.
+	torch.manual_seed(0)
+	model = SmallDeepSEA(1)
+
+	X_attr = saturation_mutagenesis(model, X0, device=device)
+	for X_cast in (X0.double(), X0.to(torch.int32), X0.bool()):
+		X_attr_cast = saturation_mutagenesis(model, X_cast, device=device)
+		assert_array_almost_equal(X_attr, X_attr_cast, 4)
+
+
+# Low-precision (fp16, bf16) autocast tests. CUDA only: torch.autocast does not
+# support these dtypes on CPU for most ops. The dtype is forwarded to `predict`,
+# so these guard the forwarding rather than re-deriving attribution magnitudes
+# (which are sub-1e-3 differences dominated by fp16 rounding noise). We assert
+# the prediction dtype, finiteness, and the precision-robust identity invariant.
+
+
+def test_saturation_mutagenesis_fp16(X0, cuda_device):
+	torch.manual_seed(0)
+	model = FlattenDense(seq_len=100, n_outputs=1).to(cuda_device)
+
+	y0, y_hat = saturation_mutagenesis(model, X0, dtype=torch.float16,
+		raw_outputs=True, device=cuda_device)
+
+	assert y_hat.shape == (2, 4, 100, 1)
+	assert y_hat.dtype == torch.float16
+	assert torch.isfinite(y_hat).all()
+
+	for i in range(X0.shape[0]):
+		for pos in range(X0.shape[-1]):
+			ob = int(X0[i, :, pos].argmax())
+			assert_array_almost_equal(y_hat[i, ob, pos].float(),
+				y0[i].float(), 2)
+
+
+def test_saturation_mutagenesis_bf16(X0, cuda_device):
+	torch.manual_seed(0)
+	model = FlattenDense(seq_len=100, n_outputs=1).to(cuda_device)
+
+	y0, y_hat = saturation_mutagenesis(model, X0, dtype=torch.bfloat16,
+		raw_outputs=True, device=cuda_device)
+
+	assert y_hat.shape == (2, 4, 100, 1)
+	assert y_hat.dtype == torch.bfloat16
+	assert torch.isfinite(y_hat).all()
+
+	for i in range(X0.shape[0]):
+		for pos in range(X0.shape[-1]):
+			ob = int(X0[i, :, pos].argmax())
+			assert_array_almost_equal(y_hat[i, ob, pos].float(),
+				y0[i].float(), 2)


### PR DESCRIPTION
## Summary

Bug fixes, a performance optimization, and a large test backfill for `saturation_mutagenesis` (in-silico saturation mutagenesis / ISM). Output is unchanged across all existing behavior (regression parity to ~1e-8).

### Bug fixes
- **Multi-output models returned scrambled values.** The per-output reshape transposed the alphabet and length axes, corrupting results on the default span and raising when `start`/`end` subset the sequence. Now reshaped consistently with the single-output path.
- **Out-of-bounds `start`/`end` silently corrupted the batch.** Now validated as `0 <= start < end <= length` with a clear error.
- **Identity detection on `N`/multi-hot columns.** Identity is detected by exact column match rather than `argmax`, so all-zero (`N`) and multi-hot columns correctly compute all four edits.

### Performance
- **Skip identity substitutions.** At each position the substitution that re-applies the existing base is identical to the reference; its prediction is now reconstructed from `y0` instead of recomputed. This removes ~25% of the model forward passes with no change to output. Wall-clock speedup approaches 25% as the model becomes inference-bound.
- The perturbation tensor is now built with vectorized torch indexing, removing the numba `_edit_distance_one` kernel and a torch→numpy→torch round-trip.

### API
- New `func=` argument, forwarded to `predict` and applied identically to the reference and perturbed predictions (e.g. select an output head or apply a final non-linearity).
- Clear error when a multi-output model is used without `raw_outputs=True`.
- `TangermemeWarning` when `X` holds non-integer values, which the internal int8 cast would otherwise truncate toward zero.

### Tests
- 37 → 78 tests (CPU + CUDA): multi-output (incl. `start`/`end`), `N`/multi-hot columns, windowed spans, full brute-force parity, exact identity-slot recovery, forward-pass count, `func=` head selection/collapse, fp16/bf16 autocast, dtype equivalence, and input validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)