### PR TITLE
Extend DeepLIFT/SHAP with rules for LayerNorm and Softmax, add Local IG hook factory, and local dinuc shuffling routine

### DIFF
--- a/tangermeme/deep_lift_rules.py
+++ b/tangermeme/deep_lift_rules.py
@@ -1,0 +1,313 @@
+
+import torch
+import torch.nn.functional as F
+
+
+def _nonlinear(module, grad_input, grad_output):
+	"""An internal function implementing a general-purpose nonlinear correction.
+
+	This function, copied and slightly modified from Captum, is meant to be
+	the `rescale` rule applied to general non-linear functions such as
+	activations.
+	"""
+
+	delta_in_ = torch.sub(*module.input.chunk(2))
+	delta_out_ = torch.sub(*module.output.chunk(2))
+
+	delta_in = torch.cat([delta_in_, delta_in_])
+	delta_out = torch.cat([delta_out_, delta_out_])
+
+	delta = delta_out / delta_in
+	idxs = torch.abs(delta_in) < 1e-6
+
+	return (torch.where(idxs, grad_input[0], grad_output[0] * delta),)
+
+def _maxpool(module, grad_input, grad_output):
+	"""An internal function implementing a 1D max-pooling correction.
+
+	This function, copied and slightly modified from Captum, is meant to be
+	the `rescale` rule applied to max pooling layers given their nature of
+	aggregating values across multiple positions.
+	"""
+
+	if isinstance(module, torch.nn.MaxPool1d):
+		pool_func, unpool_func = F.max_pool1d, F.max_unpool1d
+	elif isinstance(module, torch.nn.MaxPool2d):
+		pool_func, unpool_func = F.max_pool2d, F.max_unpool2d
+	else:
+		raise ValueError("module must be either MaxPool1d or MaxPool2d")
+
+
+	with torch.no_grad():
+		delta_in_ = torch.sub(*module.input.chunk(2))
+		delta_in = torch.cat([delta_in_, delta_in_])
+
+		output, output_ref = module.output.chunk(2)
+		delta_out_xmax = torch.max(output, output_ref)
+		delta_out = torch.cat([delta_out_xmax - output_ref, 
+			output - delta_out_xmax])
+
+		_, indices = pool_func(module.input, module.kernel_size, module.stride, 
+			module.padding, module.dilation, module.ceil_mode, True)
+
+		unpool_ = unpool_func(grad_output[0] * delta_out, indices, 
+			module.kernel_size, module.stride, module.padding, 
+			list(module.input.shape))
+		unpool_delta, unpool_ref_delta = torch.chunk(unpool_, 2)
+
+	unpool_delta_ = unpool_delta + unpool_ref_delta
+	unpool_delta = torch.cat([unpool_delta_, unpool_delta_])
+	idxs = torch.abs(delta_in) < 1e-7
+
+	new_grad_inp = torch.where(idxs, grad_input[0], unpool_delta / delta_in)
+	return (new_grad_inp,)
+
+def layernorm_symmetric_rule(module, grad_input, grad_output):
+    """An internal function implementing the DeepLIFT correction for LayerNorm.
+
+    Given y_i = gamma_i * A_i * v + beta_i
+	where A_i = x_i - mu and v = (sigma^2 + eps)^{-1/2}, the DeepLIFT multiplier
+    from input j to output i is:
+
+        m_ji = gamma_i * [ (v + v0)/2 * (delta_ij - 1/D)
+                         + (A_i + A0_i)/2 * (delta_v / delta_sigma2) * (A_j + A0_j) / D ]
+
+    Multiplying by upstream gradient g_i and summing over i gives the vectorized rule:
+
+        grad_in_j = (v + v0)/2 * (g_tilde_j - mean(g_tilde))       [Term 1]
+                  + (delta_v / delta_sigma2) * (A_j + A0_j) / (2*D)
+                    * sum_i( g_tilde_i * (A_i + A0_i) )             [Term 2]
+
+    where g_tilde_i = g_i * gamma_i. When delta_sigma2 is near zero (i.e., x and
+    x0 have the same variance), we fall back to the standard autograd gradient.
+    """
+
+    x, x0 = module.input.chunk(2)
+
+    # Normalized dimensions: last len(normalized_shape) dims
+    n_norm_dims = len(module.normalized_shape)
+    D = 1
+    for s in module.normalized_shape:
+        D *= s
+    norm_dims = list(range(-n_norm_dims, 0))
+
+    # Mean-centered inputs: A_i = x_i - mu
+    mu = x.mean(dim=norm_dims, keepdim=True)
+    mu0 = x0.mean(dim=norm_dims, keepdim=True)
+    A = x - mu
+    A0 = x0 - mu0
+
+    # Inverse std: v = (sigma^2 + eps)^{-1/2}
+    var = (A ** 2).mean(dim=norm_dims, keepdim=True)
+    var0 = (A0 ** 2).mean(dim=norm_dims, keepdim=True)
+    v = (var + module.eps) ** (-0.5)
+    v0 = (var0 + module.eps) ** (-0.5)
+
+    delta_v = v - v0
+    delta_sigma2 = var - var0
+
+    # gamma-scaled upstream gradients for both halves of the batch
+    gamma = module.weight if module.weight is not None else 1.0
+    g_tilde, g0_tilde = (grad_output[0] * gamma).chunk(2)
+
+    # Shared terms
+    v_avg = (v + v0) / 2
+    A_sum = A + A0
+
+    # Safe ratio: delta_v / delta_sigma2; mask degenerate case
+    degenerate = torch.abs(delta_sigma2) < 1e-6
+    ratio_secant = delta_v / torch.where(
+        degenerate,
+        torch.ones_like(delta_sigma2),
+        delta_sigma2,
+    )
+    var_avg = (var + var0) / 2
+    ratio_limit = -0.5 * (var_avg + module.eps).pow(-1.5)
+    ratio = torch.where(degenerate, ratio_limit, ratio_secant)
+
+    def _compute_grad(g_tilde_):
+        term1 = v_avg * (g_tilde_ - g_tilde_.mean(dim=norm_dims, keepdim=True))
+        dot = (g_tilde_ * A_sum).sum(dim=norm_dims, keepdim=True)
+        term2 = ratio * A_sum / (2 * D) * dot
+        return term1 + term2
+
+    grad_in = _compute_grad(g_tilde)
+    grad_in0 = _compute_grad(g0_tilde)
+
+    return (torch.cat([grad_in, grad_in0]),)
+
+def gauss_legendre_rule(n_points):
+    """Return Gauss-Legendre nodes and weights mapped from [-1, 1] to [0, 1]."""
+    from numpy.polynomial.legendre import leggauss
+    print(f"gauss_legendre_rule n_points: {n_points}")
+    nodes, weights = leggauss(n_points)
+	# Map from [-1, 1] to [0, 1] for integration along the path z(t) = z0 + t*(z - z0)
+    alphas = (nodes + 1.0) / 2.0
+    weights = weights / 2.0
+    return alphas, weights
+
+def make_local_ig_autograd(forward_func, K=8, name=None):
+    """Return a generic local-IG hook using autograd VJPs.
+
+    This function implements integrated-gradients for any generic module. It integrates
+    ``J_f(z(t))^T q`` along the local linear path from reference activation ``z0`` to
+    actual activation ``z`` using Gauss-Legendre quadrature for integral approximation.
+	The caller supplies the local differentiable function for the module, e.g.::
+
+        ln_hook = make_local_ig_autograd(
+            lambda module, z: F.layer_norm(
+                z, module.normalized_shape, module.weight, module.bias, module.eps
+            )
+        )
+
+        softmax_hook = make_local_ig_autograd(
+            lambda module, z: F.softmax(z, dim=module.dim)
+        )
+
+    The implementation computes VJPs, not full Jacobians. For efficiency, all
+    quadrature nodes and both upstream-gradient halves are packed into one
+    autograd call.
+
+    Use a functional or otherwise stateless implementation inside
+    ``forward_func``. Avoid calling ``module(z)`` directly from this function:
+    this hook is already running for ``module``, so re-entering the module can
+    trigger its hooks again or overwrite saved hook state such as
+    ``module.input``. Prefer functional calls such as ``F.layer_norm`` or
+    ``F.softmax`` that read parameters from ``module`` without invoking the
+    module's hook machinery.
+
+    Args:
+        forward_func: Callable with signature ``forward_func(module, z)``.
+            It must return a tensor with the same shape as ``grad_output[0]``
+            for the corresponding packed input. This callable should not call
+            ``module(z)``; use a functional/stateless equivalent instead.
+        K (int): Number of Gauss-Legendre quadrature points. Higher K incurs more
+		autograd calls but yields more accurate IG approximations.
+        name (str or None): Optional name suffix for the returned hook.
+
+    Returns:
+        A hook function compatible with ``additional_nonlinear_ops``.
+    """
+    _nodes_list, _weights_list = gauss_legendre_rule(K)
+
+    def _hook(module, grad_input, grad_output):
+        dtype, device = grad_output[0].dtype, grad_output[0].device
+        GL_NODES = torch.tensor(_nodes_list, dtype=dtype, device=device)
+        GL_WEIGHTS = torch.tensor(_weights_list, dtype=dtype, device=device)
+
+        z, z0 = module.input.chunk(2)
+        q, q0 = grad_output[0].chunk(2)
+        delta_z = z - z0
+        batch_size = z.shape[0]
+
+        z_path = torch.cat([z0 + t_k * delta_z for t_k in GL_NODES], dim=0)
+        z_eval = torch.cat([z_path, z_path], dim=0).detach().requires_grad_()
+
+        q_path = torch.cat([w_k * q.detach() for w_k in GL_WEIGHTS], dim=0)
+        q0_path = torch.cat([w_k * q0.detach() for w_k in GL_WEIGHTS], dim=0)
+        q_eval = torch.cat([q_path, q0_path], dim=0)
+
+        with torch.enable_grad():
+            y_eval = forward_func(module, z_eval)
+            grad_eval = torch.autograd.grad(
+                y_eval,
+                z_eval,
+                grad_outputs=q_eval,
+                retain_graph=False,
+                create_graph=False,
+                allow_unused=False,
+            )[0]
+
+        grad, grad0 = grad_eval.chunk(2)
+        grad = grad.reshape(K, batch_size, *z.shape[1:])
+        grad0 = grad0.reshape(K, batch_size, *z0.shape[1:])
+        return (torch.cat([grad.sum(dim=0), grad0.sum(dim=0)]),)
+
+    suffix = name if name is not None else getattr(forward_func, "__name__", "fn")
+    _hook.__name__ = f"_local_ig_autograd_{suffix}_K{K}"
+    return _hook
+
+def softmax_log_ratio_product_rule(module, grad_input, grad_output):
+    """DeepLIFT rule for softmax that respects full input-output dependencies and uses
+    a log-ratio product rule.
+    Softmax decomposition:
+        a_i = exp(x_i - c)              c is a constant for numerical stability
+        d = sum_i a_i
+        r = 1 / d
+        y_k = a_k * r
+    """
+    dim = module.dim
+    if dim < 0:
+        dim = module.input.ndim + dim
+    if dim != module.input.ndim - 1:
+        raise ValueError("Only softmax over the last dimension is currently supported.")
+
+    x, x_ref = module.input.chunk(2, dim=0)
+    gout, gout_ref = grad_output[0].chunk(2, dim=0)
+
+    c = torch.maximum(
+        x.max(dim=-1, keepdim=True).values,
+        x_ref.max(dim=-1, keepdim=True).values,
+    )
+    a = torch.exp(x - c)
+    a_ref = torch.exp(x_ref - c)
+    d = a.sum(dim=-1, keepdim=True)
+    d_ref = a_ref.sum(dim=-1, keepdim=True)
+    r = d.reciprocal()
+    r_ref = d_ref.reciprocal()
+    y = a * r
+    y_ref = a_ref * r_ref
+
+    # Multiplier for x_i -> exp(x_i - c), with derivative fallback.
+    delta_x = x - x_ref
+    delta_a = a - a_ref
+    mult_x_to_a = torch.where(delta_x.abs() > 1e-6, delta_a / delta_x, a_ref)
+
+    # Log-ratio multipliers for the direct numerator path and denominator path.
+    #     m_{a_i -> y_k} =
+    #       1{i = k} * (Δy_k / Δlog(y_k)) * (Δlog(a_k) / Δa_k)
+    #       - (1 / (d * d_ref)) * (Δy_k / Δlog(y_k)) * (Δlog(r) / Δr)
+    delta_log_a = x - x_ref
+    delta_log_r = torch.log(r) - torch.log(r_ref)
+    delta_log_y = delta_log_a + delta_log_r
+    delta_y = y - y_ref
+    delta_r = r - r_ref
+
+    delta_y_over_delta_log_y = torch.where(
+        delta_log_y.abs() > 1e-6,
+        delta_y / delta_log_y,
+        y_ref,
+    )
+    delta_log_a_over_delta_a = torch.where(
+        delta_a.abs() > 1e-6,
+        delta_log_a / delta_a,
+        a_ref.reciprocal(),
+    )
+    delta_log_r_over_delta_r = torch.where(
+        delta_r.abs() > 1e-6,
+        delta_log_r / delta_r,
+        r_ref.reciprocal(),
+    )
+
+    mult_a_to_y = delta_y_over_delta_log_y * delta_log_a_over_delta_a
+    mult_r_to_y = delta_y_over_delta_log_y * delta_log_r_over_delta_r
+    reciprocal_mult = -1.0 / (d * d_ref)
+
+    # Combine the direct a_i -> y_i contribution with the dense r -> y_k path.
+    #     gin_i = m_{x_i -> a_i} * [
+    #         gout_i * (Δy_i / Δlog(y_i)) * (Δlog(a_i) / Δa_i)
+    #         - sum_k gout_k
+    #             * (1 / (d * d_ref))
+    #             * (Δy_k / Δlog(y_k))
+    #             * (Δlog(r) / Δr)
+    #     ]
+    gin = mult_x_to_a * (
+        gout * mult_a_to_y
+        + (gout * mult_r_to_y * reciprocal_mult).sum(dim=-1, keepdim=True)
+    )
+    gin_ref = mult_x_to_a * (
+        gout_ref * mult_a_to_y
+        + (gout_ref * mult_r_to_y * reciprocal_mult).sum(dim=-1, keepdim=True)
+    )
+
+    return (torch.cat([gin, gin_ref], dim=0),)

--- a/tangermeme/deep_lift_shap.py
+++ b/tangermeme/deep_lift_shap.py
@@ -95,6 +95,7 @@ def hypothetical_attributions(
 def _register_hooks(module): 
 	if len(module._backward_hooks) > 0:
 		return
+	# for the other modules the normal torch gradient will appl
 	if not isinstance(module, tuple(module._NON_LINEAR_OPS.keys())):
 		return
 
@@ -113,102 +114,21 @@ def _clear_hooks(module):
 
 
 def _fp_hook(module, inputs): 
+	# save a copy of the input to the module. this is needed for example in _nonlinear
+    # so that we can do delta_y / delta_x. The delta_y comes from doing a diff of module
+    # output for a seq and module output for its reference seq. Same for delta_x. inputs
+    # is a tuple (of size 1) so just grab the input
 	module.input = inputs[0].clone().detach()
 
 
 def _f_hook(module, inputs, outputs):
+	# save a copy of the output of the module. outputs is a tensor
 	module.output = outputs.clone().detach()
 
 
 def _b_hook(module, grad_input, grad_output):
 	return module._NON_LINEAR_OPS[type(module)](module, grad_input, 
 		grad_output)
-
-
-def _nonlinear(module, grad_input, grad_output):
-	"""An internal function implementing a general-purpose nonlinear correction.
-
-	This function, copied and slightly modified from Captum, is meant to be
-	the `rescale` rule applied to general non-linear functions such as
-	activations.
-	"""
-
-	delta_in_ = torch.sub(*module.input.chunk(2))
-	delta_out_ = torch.sub(*module.output.chunk(2))
-
-	delta_in = torch.cat([delta_in_, delta_in_])
-	delta_out = torch.cat([delta_out_, delta_out_])
-
-	delta = delta_out / delta_in
-	idxs = torch.abs(delta_in) < 1e-6
-
-	return (torch.where(idxs, grad_input[0], grad_output[0] * delta),)
-
-
-def _softmax(module, grad_input, grad_output):
-	"""An internal function implementing a correction for softmax activations.
-
-	This function, copied and slightly modified from Captum, is meant to be
-	the `rescale` rule applied specifically to softmax activations without
-	needing to remove them and operate on the underlying logits.
-	"""
-
-	delta_in_ = torch.sub(*module.input.chunk(2))
-	delta_out_ = torch.sub(*module.output.chunk(2))
-
-	delta_in = torch.cat([delta_in_, delta_in_])
-	delta_out = torch.cat([delta_out_, delta_out_])
-
-	delta = delta_out / delta_in
-	idxs = torch.abs(delta_in) < 1e-6
-
-	grad_input_unnorm = torch.where(idxs, grad_input[0], grad_output[0] * delta)
-
-	n = grad_input[0].numel()
-	new_grad_inp = grad_input_unnorm - grad_input_unnorm.sum() * 1 / n
-	return (new_grad_inp,)
-
-
-def _maxpool(module, grad_input, grad_output):
-	"""An internal function implementing a 1D max-pooling correction.
-
-	This function, copied and slightly modified from Captum, is meant to be
-	the `rescale` rule applied to max pooling layers given their nature of
-	aggregating values across multiple positions.
-	"""
-
-	if isinstance(module, torch.nn.MaxPool1d):
-		pool_func, unpool_func = F.max_pool1d, F.max_unpool1d
-	elif isinstance(module, torch.nn.MaxPool2d):
-		pool_func, unpool_func = F.max_pool2d, F.max_unpool2d
-	else:
-		raise ValueError("module must be either MaxPool1d or MaxPool2d")
-
-
-	with torch.no_grad():
-		delta_in_ = torch.sub(*module.input.chunk(2))
-		delta_in = torch.cat([delta_in_, delta_in_])
-
-		output, output_ref = module.output.chunk(2)
-		delta_out_xmax = torch.max(output, output_ref)
-		delta_out = torch.cat([delta_out_xmax - output_ref, 
-			output - delta_out_xmax])
-
-		_, indices = pool_func(module.input, module.kernel_size, module.stride, 
-			module.padding, module.dilation, module.ceil_mode, True)
-
-		unpool_ = unpool_func(grad_output[0] * delta_out, indices, 
-			module.kernel_size, module.stride, module.padding, 
-			list(module.input.shape))
-		unpool_delta, unpool_ref_delta = torch.chunk(unpool_, 2)
-
-	unpool_delta_ = unpool_delta + unpool_ref_delta
-	unpool_delta = torch.cat([unpool_delta_, unpool_delta_])
-	idxs = torch.abs(delta_in) < 1e-7
-
-	new_grad_inp = torch.where(idxs, grad_input[0], unpool_delta / delta_in)
-	return (new_grad_inp,)
-
 
 def deep_lift_shap(
 	model: torch.nn.Module,
@@ -223,6 +143,7 @@ def deep_lift_shap(
 	warning_threshold: float = 0.001,
 	additional_nonlinear_ops: dict | None = None,
 	print_convergence_deltas: bool = False,
+	print_convergence_delta_stats: bool = False,
 	raw_outputs: bool = False,
 	only_warn: bool = False,
 	dtype: str | torch.dtype | None = None,
@@ -340,6 +261,10 @@ def deep_lift_shap(
 		Whether to print the convergence deltas for each example when using
 		DeepLiftShap. Default is False.
 
+	print_convergence_delta_stats: bool, optional
+		Whether to print convergence delta statistics (eg mean, max, min) across
+		all example-reference pairs. Default is False.
+
 	raw_outputs: bool, optional
 		Whether to return the raw outputs from the method -- in this case,
 		the multipliers for each example-reference pair -- or the processed
@@ -411,10 +336,14 @@ def deep_lift_shap(
 		torch.nn.PReLU: _nonlinear,
 		torch.nn.MaxPool1d: _maxpool,
 		torch.nn.MaxPool2d: _maxpool,
-		torch.nn.Softmax: _softmax
+		torch.nn.Softmax: softmax_log_ratio_product_rule,
+		torch.nn.LayerNorm: layernorm_symmetric_rule,
 	}
 
 	device = _resolve_device(device)
+
+	if random_state is not None:
+		print(f"DLS: setting random state to {random_state}")
 
 	if dtype is None:
 		try:
@@ -453,6 +382,8 @@ def deep_lift_shap(
 		# Begin DeepLIFT procedure
 	
 		attributions, references_, Xi, rj, attr_ = [], [], [], [], []
+		all_convergence_deltas = [] # per example-reference pair, always collected
+
 		if isinstance(references, torch.Tensor):
 			_validate_input(references, "references", shape=(X.shape[0], -1, X.shape[1], 
 				X.shape[2]), ohe=True, allow_N=False, ohe_dim=-2, only_warn=only_warn)
@@ -461,13 +392,19 @@ def deep_lift_shap(
 		n, z = X.shape[0] * n_shuffles, 0
 
 		for i in trange(n, disable=not verbose):
+			# Xi will be like [0,0,0, 1,1,1, 2,2,2, ...] if n_shuffles=3, so when len(Xi) == batch_size,
+			# there are 3 0's, 3 1's, etc. in Xi, so X[Xi] will contain 3 times the first seq in X, 3 times
+			# the second seq, etc. Note that batch_size does not have to be a multiple of n_shuffles so for
+			# instance Xi might be like [0,0,0, 1,1,1, 2,2,2, 3,3,3, 4,4] (in this case batch_size=14)
 			Xi.append(i // n_shuffles)
 			rj.append(i % n_shuffles)
 
 			if len(Xi) == batch_size or i == (n-1):
 				_X = X[Xi].cpu().type(dtype)
-				_args = None if args is None else tuple([a[Xi].to(device).type(dtype)
-					for a in args])
+				_args = None
+				if args is not None:
+					_args_lst = [None if a is None else a[Xi].to(device) for a in args]
+					_args = tuple(_args_lst)
 
 				# Handle reference sequences while ensuring that the same seed is
 				# used for each shuffle even if not all shuffles are done in the
@@ -475,6 +412,9 @@ def deep_lift_shap(
 				if isinstance(references, torch.Tensor):
 					_references = references[Xi, rj]
 				else:
+					# shuffle each seq once (_X already contains n_shuffle entries) -- the [:, 0]
+					# is b/c references(_X, n=1).shape = torch.Size([n_examples, 1, 4, seq_length]),
+					# and 1 is b/c n=1
 					if random_state is None:
 						_references = references(_X, n=1)[:, 0]
 					else:
@@ -483,7 +423,9 @@ def deep_lift_shap(
 								for j in range(len(_X))])
 
 				_X = _X.to(device).type(dtype).requires_grad_()
+				# now _X.shape = torch.Size([n_examples, 4, seq_length])
 				_references = _references.to(device).type(dtype).requires_grad_()
+				# now _references.shape = torch.Size([n_examples, 4, seq_length])
 
 				# This next block is actually running DeepLIFT by concatenating the
 				# batch of examples and the batch of references and running the
@@ -492,6 +434,7 @@ def deep_lift_shap(
 				# error is raised. 
 				try:
 					X_ = torch.cat([_X, _references])
+					# now X_.shape = torch.Size([n_examples*2, 4, seq_length])
 
 					if use_autocast:
 						autocast_ctx = torch.autocast(device_type=device.type, dtype=dtype)
@@ -502,11 +445,22 @@ def deep_lift_shap(
 					with torch.autograd.set_grad_enabled(True):
 						with autocast_ctx:
 							if _args is not None:
-								_args = (torch.cat([arg, arg]) for arg in _args)
+								_args = (None if arg is None else torch.cat([arg, arg]) for arg in _args)
 								y = model(X_, *_args)[:, target]
 							else:
+								# The model here is actually a wrapper model (like CountWrapper)
+								# that returns only the output type we're interested in.
+								# model(X_).shape = torch.Size([n_examples*2, 1]).
+								# In the case of counts w/ a target=0, the "[:, target]" is basically
+								# a no-op.
 								y = model(X_)[:, target]
 
+							# when we do the forward pass, _X is a specific tensor object in
+							# memory with requires_grad=True, when we later call torch.autograd.grad(y.sum(), _X)
+							# we are passing the exact same tensor object that was used (via concatenation) to
+							# build X_. Here torch.autograd.grad returns gradients only for _X (and not for the
+							# _references).
+							# multipliers.shape = _X.shape = torch.Size([n_examples, 4, seq_length])
 							multipliers = torch.autograd.grad(y.sum(), _X)[0]
 
 					# Check that the prediction-difference-from-reference is equal to
@@ -519,7 +473,8 @@ def deep_lift_shap(
 					if torch.any(convergence_deltas > warning_threshold):
 						warnings.warn("Convergence deltas too high: " +   
 							str(convergence_deltas), RuntimeWarning)
-
+						
+					all_convergence_deltas.append(convergence_deltas.detach().cpu())
 					if print_convergence_deltas:
 						print(convergence_deltas)
 
@@ -537,13 +492,19 @@ def deep_lift_shap(
 				# of one example-reference pair, so that once all references for an
 				# example have been processed we can chunk them together.
 				attr_.extend(list(multipliers.cpu().detach()))
+				# now len(attr_) = multipliers.shape[0] = batch_size
 
 				# When all references for a sequence have been calculated, remove
 				# that block from the list of example-reference attributions and
 				# add it to the final attribution list, averaging across references
 				# if providing the processed results.
 				while len(attr_) >= n_shuffles:
+					# Take the first n_shuffles elements from attr_
+					# this includes the attributions for all references for one seq
+					# attr_chunk.shape = torch.Size([n_shuffles, 4, seq_length])
 					attr_chunk = torch.stack(attr_[:n_shuffles])
+					# now attr_chunk.shape = torch.Size([4, seq_length]), ie avg attr
+					# (across shuffles) for one seq
 
 					if raw_outputs == False:
 						attr_chunk = attr_chunk.mean(dim=0)
@@ -559,8 +520,12 @@ def deep_lift_shap(
 
 				Xi, rj = [], []
 
-
-
+		all_deltas = torch.cat(all_convergence_deltas)  # shape: (n_examples * n_shuffles,)
+		if print_convergence_delta_stats:
+			print(f"Convergence delta stats — mean: {all_deltas.mean().item():.6e}, "
+				f"max: {all_deltas.max().item():.6e}, "
+				f"min: {all_deltas.min().item():.6e}")
+		
 		attributions = torch.stack(attributions)
 
 		if return_references:

--- a/tangermeme/ersatz.py
+++ b/tangermeme/ersatz.py
@@ -8,6 +8,7 @@ import warnings
 import numba
 import numpy
 import torch
+import numpy as np
 
 from tqdm import tqdm
 
@@ -686,3 +687,54 @@ def dinucleotide_shuffle(
 		X_shufs.append(X_shuf)
 
 	return torch.stack(X_shufs)
+
+def local_dinucleotide_shuffle(
+    X: torch.Tensor,
+    n: int = 20,
+    bin_size: int = 1024,
+    min_bin_size: int = 512,
+    random_state: int | None = None,
+    verbose: bool = False,
+) -> torch.Tensor:
+    """Dinucleotide-shuffle sequences independently within local bins.
+    This function largely has the same interface as
+    :func:`tangermeme.ersatz.dinucleotide_shuffle`, but each bin is shuffled
+    independently and then stitched back into the full sequence.
+    """
+
+    if X.ndim != 3 or X.shape[1] != 4:
+        raise ValueError("Expected input shape (batch_size, 4, seq_length)")
+    if bin_size >= X.shape[-1]:
+        raise ValueError(
+            "Sequence length must be longer than bin_size. "
+            "Use dinucleotide_shuffle directly for shorter sequences."
+        )
+    if min_bin_size > bin_size:
+        raise ValueError("min_bin_size must be <= bin_size")
+
+    rng = np.random.RandomState(random_state)
+
+    X_shuf = X.unsqueeze(1).repeat(1, n, 1, 1)
+    for i in range(X.shape[0]):
+        for j in range(n):
+            first_cut = rng.randint(min_bin_size, bin_size + 1)
+            boundaries = [0, first_cut]
+            boundaries.extend(range(first_cut + bin_size, X.shape[-1], bin_size))
+            boundaries.append(X.shape[-1])
+
+            bins = list(zip(boundaries[:-1], boundaries[1:]))
+            if bins[-1][1] - bins[-1][0] < min_bin_size:
+                # merge last two bins if the final bin is too small
+                bins[-2] = (bins[-2][0], bins[-1][1])
+                bins.pop()
+
+            for (bin_start, bin_end) in bins:
+                shuffled = dinucleotide_shuffle(
+                    X[i:i+1, :, bin_start:bin_end],
+                    n=1,
+                    random_state=rng.randint(0, 2**31 - 1),
+                    verbose=verbose,
+                )
+                X_shuf[i, j, :, bin_start:bin_end] = shuffled[0, 0]
+
+    return X_shuf


### PR DESCRIPTION
This PR extends deep_lift_shap to support attribution for architectures containing nn.LayerNorm and nn.Softmax (e.g. transformers), adds a general-purpose local integrated-gradients hook factory, and introduces a local dinucleotide shuffling routine for generating references on long sequences. The existing per-op DeepLIFT rules are also factored out of deep_lift_shap.py into a dedicated deep_lift_rules.py module.
