### PR TITLE
FIX three silent-failure paths and correct the bundled skill

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -6,6 +6,31 @@ Release History
 ===============
 
 
+Version 1.4.1
+=============
+
+Claude Code skill
+-----------------
+
+	- Corrects the bundled Agent Skill against the library. Claims that did not match the implementation are fixed: ``predict`` returns the model's parameter dtype rather than always float32; the int8 sequences from ``extract_loci`` should be left as int8 because every entry point except ``pisa`` upcasts each batch; ``recursive_seqlets``' ``additional_flanks`` re-sums the reported attribution rather than only padding the coordinates; ``product.apply_pairwise``/``apply_product`` take ``func`` as a required first positional argument and so do not satisfy the ``func=`` contract themselves; ``apply_pairwise`` zips the elements of ``args`` with each other and crosses that list with every example; ``ablate_annotations``' second output axis is always one; ``plot_logo`` reads the annotation label from the first column positionally and filters the plotted window strictly; the DeepLIFT/SHAP hooks cover twenty stock non-linearities rather than five; ``pairwise_annotations`` sorts away input row order under the default ``unique=True``; and the deletion-width guard and the ``max_iter``/``tol`` stop conditions differ per function. Also documents ``saturation_mutagenesis``' own ``func=`` post-processing hook and its int8 truncation warning, and fixes three examples that could not run.
+	- If you installed the skill with ``tangermeme-install-skills``, re-run it with ``--force`` to pick up the corrections.
+
+annotate
+--------
+
+	- ``pairwise_annotations_spacing`` now raises a ``ValueError`` when two annotations within the same example overlap. The distance between a pair is the gap between the end of the left annotation and the start of the right one, which is negative for overlapping spans; the only guard was on the upper bound, so a negative distance would index from the far end of the distance axis and be recorded as ``max_distance + d``, indistinguishable from a genuine long-range pair. Abutting annotations (a distance of exactly zero) are unaffected.
+
+design
+------
+
+	- ``greedy_substitution`` and ``beam_substitution`` now raise a ``ValueError`` when ``X`` has a batch size other than one. Both design a single sequence at a time, but the batch dimension was never checked and a larger batch produced more rows than the numba substitution kernel had indices for, reading out of bounds and crashing the interpreter rather than raising.
+
+variant_effect
+--------------
+
+	- ``substitution_effect`` now raises a ``ValueError`` when two rows of ``substitutions`` target the same ``(example_idx, position)``. The substitutions are applied with two vectorized assignments over an example-shaped tensor, so colliding rows each set their own alphabet index to one and the model was handed a multi-hot column with no error. The same position in different examples is still valid.
+
+
 Version 1.4.0
 =============
 

--- a/tangermeme/__init__.py
+++ b/tangermeme/__init__.py
@@ -1,4 +1,4 @@
 # tangermeme: biological sequence analysis for the modern age
 # Author: Jacob Schreiber
 
-__version__ = '1.4.0'
+__version__ = '1.4.1'

--- a/tangermeme/_skills/data/SKILL.md
+++ b/tangermeme/_skills/data/SKILL.md
@@ -20,8 +20,9 @@ reproducibility traps).
 ## Two cross-cutting concepts (read these first if unsure)
 
 - **[The `func=` plug-point](references/func-pattern.md)** — `ablate`,
-  `marginalize`, `space`, `variant_effect.*`, and `product.*` all accept
-  `func(model, X, args=, **kwargs)`. Swapping `predict` for
+  `marginalize`, `space`, `variant_effect.*`, and `product.*` (where it is the
+  first positional argument) all accept `func(model, X, args=, **kwargs)`.
+  Swapping `predict` for
   `deep_lift_shap` turns a "predictions before/after" experiment into an
   "attributions before/after" one. Covers the `additional_func_kwargs` collision
   trap. **This is what makes the library compose.**
@@ -57,8 +58,10 @@ reproducibility traps).
 These are well-covered by the official tutorials and are mostly single-call ops —
 no dedicated reference file, but here is where to look:
 
-- `tangermeme.predict.predict` — batched, memory-efficient inference; always
-  returns float32; multi-output models return a list. Satisfies the `func=` contract.
+- `tangermeme.predict.predict` — batched, memory-efficient inference. Returns the
+  model's parameter dtype (override with `dtype=`) and upcasts each batch from `X`,
+  so int8 sequences go straight in; multi-output models return a list. Satisfies the
+  `func=` contract.
 - `tangermeme.ersatz` — atomic sequence ops: `insert`, `substitute`,
   `multisubstitute`, `delete`, `shuffle`, `dinucleotide_shuffle` (most motif-add
   ops *substitute*, preserving length; `start`/`end` confine shuffles to a region).
@@ -66,7 +69,8 @@ no dedicated reference file, but here is where to look:
   `random_one_hot`, `reverse_complement` (single sequence), `pwm_consensus`,
   `set_seed`, `gc_content`, etc.
 - `tangermeme.pisa.pisa` — per-position (PISA) attribution reusing the DLS hooks.
-  Footgun: some paths return tensors on the **input device**, not CPU.
+  Footguns: some paths return tensors on the **input device**, not CPU; and it does
+  **not** upcast `X`, so pass float — it is the one entry point int8 fails on.
 - `tangermeme.kmers` — k-mer counts, batched k-mers, gapped k-mers.
 
 (Motif *scanning* — FIMO/TOMTOM — is not in tangermeme; it lives in the external

--- a/tangermeme/_skills/data/references/annotate.md
+++ b/tangermeme/_skills/data/references/annotate.md
@@ -69,8 +69,14 @@ co = pairwise_annotations(df_example_motif, shape=n_motifs)   # (n_motifs, n_mot
 
 - Default `symmetric=True`: entry counts pairs in both orders (sum = 2×pairs −
   diagonal; take a triangle for the pair count). `symmetric=False` gives an
-  **ordered** matrix (row = motif earlier in the sequence, col = later) — input row
-  order is then meaningful.
+  **ordered** matrix (row = the motif that came first) — input row order is then
+  meaningful.
+- **`unique=True` (the default) breaks that ordering.** It collapses repeated motifs
+  within an example — 3 KLF4 hits give one KLF4–KLF4 pair, not many — by sorting
+  them, which also discards the input row order. So with the default, `symmetric=False`
+  orders by *annotation index*, not by position. Pass `unique=False` for a genuinely
+  sequence-ordered matrix, at the cost of counting repeats.
+- Default `dtype` is `torch.int64` here, unlike `count_annotations`.
 
 ## pairwise_annotations_spacing — co-occurrence by distance
 
@@ -80,11 +86,19 @@ from tangermeme.annotate import pairwise_annotations_spacing
 sp = pairwise_annotations_spacing(df4, max_distance=100)   # (n_motifs, n_motifs, max_distance)
 ```
 
-- Input is the `(n, 4)` form `(example_idx, annotation_idx, start, end)`. **Sort by
-  `example_idx` then `start`**, and pass it as a **single DataFrame** so the motif
-  index stays aligned with its coordinates after sorting.
-- Distance is **absolute** (end-of-left to start-of-right), capped at `max_distance`
-  (default 100 — raise for long-range). Memory grows as `n_motifs² × max_distance`.
+- Input is the `(n, 4)` form `(example_idx, annotation_idx, start, end)`. Row order
+  doesn't matter — the function groups by `example_idx` and reads pair direction off
+  `start` — but pass it as a **single DataFrame** so each motif index stays glued to
+  its own coordinates; sorting the columns separately scrambles the pairing.
+- Distance is `start_of_right − end_of_left`, capped at `max_distance` (default
+  100 — raise for long-range). Memory grows as `n_motifs² × max_distance`.
+- **Annotations that overlap within an example raise a `ValueError`** — the gap
+  would be negative and there is no meaningful bin for it. Abutting spans
+  (`end0 == start1`, distance 0) are fine. Drop or merge overlaps first: FIMO hits
+  from a redundant motif DB routinely overlap, and so do `recursive_seqlets` spans
+  once you set `additional_flanks` (the un-flanked cores are disjoint).
+- **Default `dtype` is `uint8`** — the same 255 saturation as `count_annotations`.
+  Pass `dtype=torch.int32` for anything but small runs.
 
 ## The discovery pipeline
 

--- a/tangermeme/_skills/data/references/comparing-models.md
+++ b/tangermeme/_skills/data/references/comparing-models.md
@@ -82,6 +82,12 @@ models = {name: torch.load(p, weights_only=False) for name, p in paths.items()}
 # all on CPU; each call below moves one over and back
 ```
 
+This is the *across-models* half of memory management. The *within-call* half —
+lowering `batch_size` (which counts example×reference pairs) or `n_shuffles` when a
+single `deep_lift_shap` call OOMs — is in
+[deep_lift_shap.md](deep_lift_shap.md), under "`batch_size` counts example-reference
+pairs".
+
 ## Concordance / ensembling (generic — brief)
 
 Once predictions are harmonized, the comparison itself is ordinary analysis:

--- a/tangermeme/_skills/data/references/deep_lift_shap.md
+++ b/tangermeme/_skills/data/references/deep_lift_shap.md
@@ -102,7 +102,12 @@ from tangermeme.deep_lift_shap import _nonlinear
 X_attr = deep_lift_shap(model, X, additional_nonlinear_ops={MyActivation: _nonlinear})
 ```
 
-The built-in hooks cover ReLU/sigmoid/tanh/softmax/maxpool. The catch:
+The built-in hooks already cover essentially every stock `torch.nn` elementwise
+activation — the ReLU family (`ReLU`, `ReLU6`, `LeakyReLU`, `RReLU`, `PReLU`),
+`GELU`/`SiLU`/`Mish`/`ELU`/`CELU`/`SELU`, `Sigmoid`/`LogSigmoid`/`Tanh`,
+`Softplus`/`Softshrink`, `GLU` — plus `Softmax` and `MaxPool1d`/`MaxPool2d`
+(`pisa` registers the same set). Check that list before assuming you need
+`additional_nonlinear_ops`; it is for **custom** modules. The catch:
 `_nonlinear` divides `delta_out / delta_in`, so it **must be registered on a layer
 with equal input and output shape**. If your op also reduces (e.g. a profile head
 that does `logits * softmax(logits)` then `.sum()`), split it: put the elementwise,
@@ -128,11 +133,8 @@ hook), switch to ISM — see [saturation_mutagenesis.md](saturation_mutagenesis.
   Use these to build motif patterns / contribution-weight matrices (CWMs)
   downstream — **not** as the seqlet-caller input.
 
-Seqlet calling (`tangermeme.seqlet.recursive_seqlets` / `tfmodisco_seqlets`)
-consumes **projected** attributions summed to one value per position — i.e. the
-default (`hypothetical=False`) output collapsed over the channel axis,
-`X_attr.sum(dim=1)`, shape `(n, length)`. Feeding hypothetical attributions to the
-seqlet callers is a common mistake.
+The seqlet callers take the projected output collapsed over the channel axis
+(`X_attr.sum(dim=1)`) — see [seqlets.md](seqlets.md).
 
 ## Return type
 

--- a/tangermeme/_skills/data/references/design.md
+++ b/tangermeme/_skills/data/references/design.md
@@ -22,8 +22,8 @@ X_bar = screen(model, shape=(4, 2114), y=y_bar, batch_size=1000, n_best=1, rando
   the batch dimension**. `batch_size` is how many candidates are drawn and screened
   per iteration (it is *not* forwarded to `predict`'s own batch_size).
 - Generates candidates (default `func=random_one_hot`), scores each against `y` with
-  `loss`, keeps the top `n_best`. Loops until `loss < tol` (set a positive
-  `max_iter` as a safety cap). Simplest baseline; seed/sanity-check before greedy.
+  `loss`, keeps the top `n_best`, and loops until the stop condition below fires.
+  Simplest baseline; seed/sanity-check before greedy.
 
 ## greedy_substitution — build toward a goal with a motif library
 
@@ -35,12 +35,12 @@ X_bar = greedy_substitution(model, X, y=y_bar, motifs=motif_list,
 ```
 
 - Each round, tries substituting every motif at candidate positions and keeps the
-  single edit that most reduces `loss`; repeats until `loss < tol` or `max_iter`
-  motifs have been placed.
-- **`max_iter` defaults to `-1`, which is a silent no-op** — the loop is
-  `iteration < max_iter`, so a non-positive value runs zero iterations and returns
-  `X` unchanged. The greedy functions require a **positive `max_iter`**.
-- **`X` must have batch size 1** — it designs one sequence at a time.
+  single edit that most reduces `loss`; repeats until a stop condition fires.
+- **Always pass a positive `max_iter`** — the `-1` default is a silent no-op *here
+  specifically*. See the stop-conditions section below.
+- **`X` must have batch size 1** — it designs one sequence at a time and raises a
+  `ValueError` otherwise. Loop over examples, passing `X[i:i+1]` to each call. Same
+  for `beam_substitution`.
 - `reverse_complement=True` also considers each motif's reverse complement.
 - `input_mask` restricts which positions may be edited (e.g. the middle 200 bp →
   ~10× speedup); `output_mask` restricts which outputs the loss is computed over.
@@ -75,17 +75,17 @@ X_bar = beam_substitution(model, X, y=y_bar, motifs=motif_list,
   de-duplicated so it does not collapse onto one sequence.
 - `n_best` returns that many sequences (≤ `beam_size`), ranked low→high loss,
   shape `(n_best, len(alphabet), length)`.
-- **`max_iter` differs from the greedy functions:** here `-1` means *no limit*
-  (like `screen`), with `tol` as the stop — not the greedy no-op. Cost scales
-  ~linearly with `beam_size`. `input_mask`/`output_mask`/`reverse_complement`/
-  `args`/`loss` behave exactly as in `greedy_substitution`.
+- **`max_iter=-1` means *no limit* here**, not the `greedy_substitution` no-op — see
+  the stop-conditions section below. Cost scales ~linearly with `beam_size`.
+  `input_mask`/`output_mask`/`reverse_complement`/`args`/`loss` and the batch-size-1
+  requirement behave exactly as in `greedy_substitution`.
 
 ## greedy_marginalize — build a construct against backgrounds
 
 ```python
 from tangermeme.design import greedy_marginalize
 construct = greedy_marginalize(model, X_backgrounds, y=y_delta, motifs=motif_list,
-                               max_iter=5)   # positive max_iter required (see above)
+                               max_iter=5)   # -1 here means unlimited, not a no-op
 ```
 
 Semantics differ from `greedy_substitution` in three ways that are easy to miss:
@@ -95,6 +95,38 @@ Semantics differ from `greedy_substitution` in three ways that are easy to miss:
 - it returns a **variable-width one-hot construct** (e.g. `(4, 51)`), not a full
   sequence — decode with `characters(construct, allow_N=True)`; it contains `N`
   where overlapping motifs cancel. `max_spacing` (default 12) bounds the search.
+
+## Stop conditions: `max_iter` and `tol` differ per function (footgun)
+
+Both behave differently depending on which function you called:
+
+| function | `max_iter=-1` (the default) | `tol` compares |
+|---|---|---|
+| `screen` | no limit | **absolute loss** of the `n_best`-th best candidate |
+| `greedy_substitution` | **runs zero iterations, returns `X` unchanged** | per-round improvement |
+| `beam_substitution` | no limit | per-round improvement |
+| `greedy_marginalize` | no limit | per-round improvement |
+
+Two things to take from that table:
+
+- **`greedy_substitution` is the odd one out on `max_iter`.** Its loop is
+  `while iteration < max_iter`, so the `-1` default never enters the body and you get
+  your input back with no error and no warning. The other three test
+  `iteration == max_iter`, which `-1` never matches, so they run until `tol` stops
+  them. Always pass a positive `max_iter` to `greedy_substitution`.
+- **`tol` is an improvement floor everywhere except `screen`.** The three
+  motif-placing functions stop on `improvement <= tol`, where improvement is
+  `loss_previous_round - loss_this_round` — *not* a threshold on the loss itself.
+  Setting `tol` to a loss value you want to reach therefore ends the run almost
+  immediately, because the first round's improvement is already below it, and the
+  returned sequence can sit orders of magnitude above `tol`. Treat it as "stop when a
+  round stops buying me much", and control the endpoint with `max_iter` plus the
+  per-round loss from `verbose=True`.
+
+`screen` is the mirror image: its `tol` really is a loss target, but it triggers on
+the `n_best`-th best candidate, so with `n_best > 1` the current best may have been
+under `tol` for many iterations before the loop exits. With `max_iter=-1` and a `tol`
+it never reaches, `screen` loops forever — give it one or the other.
 
 ## The loss / target contract (footgun)
 

--- a/tangermeme/_skills/data/references/func-pattern.md
+++ b/tangermeme/_skills/data/references/func-pattern.md
@@ -29,12 +29,25 @@ product.apply_pairwise(func, model, X, ...)   # func is FIRST positional here
 product.apply_product(func, model, X, ...)
 ```
 
-The default `func` is `predict` everywhere above.
+`func` defaults to `predict` on `ablate`, `marginalize`, `space` and the three
+`variant_effect` functions. On `product.apply_pairwise` / `apply_product` it is a
+**required first positional argument** with no default — and because of that
+position they do **not** themselves satisfy the contract; see
+[product.md](product.md).
 
-**Exception — `design.screen` also has a `func=`, but a different contract.** There
-it is a *sequence generator* `func(shape_tuple, random_state=, **kwargs)` (default
-`random_one_hot`) that produces candidates, **not** the `func(model, X)` predictor
-contract above. Don't pass `predict`/`deep_lift_shap` to `screen`'s `func`.
+**Elsewhere in the library `func=` is a different contract entirely.** None of these
+take the `func(model, X)` predictor contract above:
+
+- `design.screen(func=random_one_hot)` — a *sequence generator*
+  `func(shape_tuple, random_state=, **kwargs)` that produces candidates. Don't pass
+  `predict`/`deep_lift_shap` here.
+- `predict(func=None)` and `saturation_mutagenesis(func=None)` — a *post-processing*
+  hook applied to each batch of predictions, e.g. to pick a head or apply a final
+  non-linearity. In `saturation_mutagenesis` it is applied identically to the
+  reference and to every perturbation, so attributions are computed on the
+  post-processed values.
+- `plot.plot_attributions(models, X, func=deep_lift_shap)` — the *attribution*
+  function to run before plotting.
 
 ## The key idea: the return type follows `func`
 
@@ -82,6 +95,10 @@ Rule of thumb: if a name could plausibly belong to either layer, put it in
 `args=(tensor, ...)` carries extra model inputs through the whole stack; the i-th
 example is paired with the i-th row of each arg. It flows from the outer function
 into `func` into `model(X, *args)`.
+
+`product.apply_pairwise` / `apply_product` are the exception: there `args` defines
+the axes to sweep over rather than per-example inputs, so its rows are *not* aligned
+to `X` (see [product.md](product.md)).
 
 ## Related references
 

--- a/tangermeme/_skills/data/references/io-loci.md
+++ b/tangermeme/_skills/data/references/io-loci.md
@@ -33,12 +33,17 @@ extract_loci(
 The result is a list assembled in this fixed order, and a **bare object** (not a
 list) is returned when only one element is present:
 
-1. `X` — one-hot sequences `(n, len(alphabet), in_window)`, dtype **int8** (memory;
-   call `.float()` before most models) — **always present**
+1. `X` — one-hot sequences `(n, len(alphabet), in_window)`, dtype **int8** —
+   **always present**
 2. `y` — output signals `(n, n_signals, out_window)` (single signal still gets a
    signal axis; order = file order) — only if `signals` is given
 3. `X_in` — input signals — only if `in_signals` is given
 4. `mask` — kept-locus boolean tensor — only if `return_mask=True`
+
+**Leave `X` as int8.** `predict`, `deep_lift_shap` and `saturation_mutagenesis`
+upcast each batch to the model's dtype, so the int8 blob is the whole memory win.
+Only `.float()` it for `pisa`, which doesn't upcast, or when you call `model(X)`
+yourself.
 
 So unpack to match exactly what you requested:
 

--- a/tangermeme/_skills/data/references/motif-effects.md
+++ b/tangermeme/_skills/data/references/motif-effects.md
@@ -27,8 +27,10 @@ background can produce a "mirage" effect driven entirely by the GC change, not t
 motif. In order of preference:
 
 1. Real inactive regions matched on GC/dinucleotide content (best).
-2. `random_one_hot(..., probs=...)` with genomic base frequencies (e.g. hg38 chr1
-   ≈ `[0.291, 0.209, 0.209, 0.292]`), or `dinucleotide_shuffle` of real sequences.
+2. `random_one_hot(..., probs=...)` with genomic base frequencies (e.g. hg38
+   ≈ `[0.291, 0.209, 0.209, 0.291]`), or `dinucleotide_shuffle` of real sequences.
+   `probs` must sum to exactly 1 — numpy raises otherwise, so don't round the
+   frequencies independently.
 3. Uniform random — prototyping only.
 
 Returns diminish past ~100 backgrounds.
@@ -52,8 +54,9 @@ y_before, y_after = ablate(model, X, start=990, end=1010, n=20, random_state=0)
 ```python
 from tangermeme.space import space
 
-y_before, y_afters = space(model, X, motifs=["GATA", "TAL1"],
-                           spacing=[5, 10, 20, 40])   # SpaceResult
+# motifs are SEQUENCES, not TF names; spacing is nested even for one gap
+y_before, y_afters = space(model, X, motifs=["AGATAA", "CAGCTG"],
+                           spacing=[[5], [10], [20], [40]])   # SpaceResult
 ```
 
 Returns `SpaceResult(y_before, y_afters)` where `y_afters` covers each spacing —
@@ -62,7 +65,8 @@ use it to find cooperative/competitive distance preferences (output axis is
 
 - **`spacing` shape is `(n_spacings, n_motifs-1)`** — entry `[i, j]` is the gap in
   experiment `i` between motif `j` and `j+1`. Even a single two-motif experiment
-  needs the nested form `[[10]]`. Sweep one gap with `torch.arange(50)[:, None]`.
+  needs the nested form `[[10]]`; a flat list raises `ValueError: spacing has shape
+  ... but must have shape (-1, 1)`. Sweep one gap with `torch.arange(50)[:, None]`.
 - Characters **inside the gaps are left as background** (not overwritten).
 
 ## Multi-task and multi-input models
@@ -84,10 +88,19 @@ positionally (`y_before, y_after = ...`) or by attribute (`r.y_before`), and
 `marginalize_annotations(model, X, X0, annotations)` (X0 = backgrounds) and
 `ablate_annotations(model, X, annotations)` apply the effect to each annotated
 region individually and return `PerturbationAnnotationsResult(y_befores, y_afters)`.
-`annotations` is a `(n_annotations, 3)` tensor `(example_idx, start, end)`. The
-output carries **extra leading axes** — e.g. `ablate_annotations` gives
-`(n_annotations, n_examples, n_shuffles, ...)` — so index carefully before taking
-deltas. See [annotate.md](annotate.md) for building the annotation tensor.
+`annotations` is a `(n_annotations, 3)` tensor `(example_idx, start, end)`. Both
+loop one annotation at a time and stack, so the output carries an **extra leading
+axis** and the second axis differs between them:
+
+- `ablate_annotations` → `(n_annotations, 1, ...)` and
+  `(n_annotations, 1, n_shuffles, ...)`. The `1` is real, not `n_examples`: each
+  annotation is ablated on its own single example `X[idx:idx+1]`, so you almost
+  always want to squeeze it.
+- `marginalize_annotations` → `(n_annotations, len(X0), ...)` for both, since each
+  annotation's span is substituted into every background in `X0`.
+
+Index carefully before taking deltas. See [annotate.md](annotate.md) for building
+the annotation tensor.
 
 ## Attributions instead of predictions
 

--- a/tangermeme/_skills/data/references/notebook-walkthrough.md
+++ b/tangermeme/_skills/data/references/notebook-walkthrough.md
@@ -53,13 +53,16 @@ X, y = extract_loci(
     in_window=2114,              # match your model's input length
     out_window=1000,             # match your model's output length
 )
-X = X.float()
+# X comes back as int8. Leave it — predict / deep_lift_shap /
+# saturation_mutagenesis upcast each batch to the model's dtype, so keeping the
+# full tensor as int8 is the memory win. (pisa is the exception: pass X.float().)
 print(X.shape, y.shape)
 ```
 
 ```python
 # === Cell 4: predictions on the peaks, vs observed ===
-# predict batches to `device` and back, runs under eval()+no_grad, returns float32.
+# predict batches to `device` and back, runs under eval()+no_grad, and returns the
+# model's parameter dtype (float32 for a float32 model; override with dtype=).
 # Multi-output models return a list. See the predict bullet in SKILL.md.
 from tangermeme.predict import predict
 

--- a/tangermeme/_skills/data/references/plot.md
+++ b/tangermeme/_skills/data/references/plot.md
@@ -15,29 +15,47 @@ ax = plot_logo(X_attr[i], ax=ax, start=900, end=1200)
 - For a **probability PWM** (columns sum to 1), use `plot_pwm` instead — it draws
   the information-content-weighted logo. `plot_logo` is for attributions/weights.
 - It draws **only the logo panel** — add titles/labels/limits with normal matplotlib
-  afterward. It will make an `ax` if you don't pass one.
+  afterward. Without `ax=` it falls back to `plt.gca()`, i.e. the *current* axes, not
+  a fresh one — so pass `ax=` explicitly when looping over examples or you will stack
+  every logo onto one panel.
 - `start`/`end` subset the plotted window **and** are required for annotation
   coordinates to line up, because annotations use absolute coordinates.
 
 ## Annotations contract
 
 `annotations=` is a pandas DataFrame with columns `motif_name`, `start`, `end`,
-`strand` (currently unused), `score`. Coordinates are 0-indexed; `score` is both
-shown and used to order overlapping annotations. Extra columns are ignored.
+`strand` (currently unused), `score`. Coordinates are 0-indexed. Extra columns are
+ignored. Three non-obvious rules:
+
+- **The label is read positionally, as the first column** (`row.values[0]`), not from
+  a column named `motif_name`. FIMO frames already lead with `motif_name`; seqlet
+  frames lead with `example_idx`, so reorder those (below).
+- **`score` is only rendered into the label** (`show_score=False` hides it).
+  Annotations are packed into rows in **`start` order**, not score order, so a
+  high-scoring hit gets no priority for the top track.
+- **Window filtering is strict**: a row is drawn only if `row.start > start` **and**
+  `row.end < end`. A hit flush with either edge is silently dropped — including one
+  at position 0 when you didn't pass `start` (which defaults to 0). Widen the window
+  by a base if you need the edges.
 
 ```python
 plot_logo(X_attr[i], ax=ax, annotations=hits, start=900, end=1200)
 ```
 
-### Seqlet footgun: set score_key and filter per example
+### Seqlet footgun: set score_key, filter per example, put a name column first
 
 Seqlet DataFrames use the column `attribution`, not `score`, so pass
-`score_key='attribution'`. And a seqlet DataFrame holds **all examples in one
-frame** — filter to the example you're plotting first, or you'll draw another
-example's coordinates:
+`score_key='attribution'`. They hold **all examples in one frame** — filter to the
+example you're plotting first, or you'll draw another example's coordinates. And
+their first column is `example_idx`, so passing one straight through labels every
+annotation with the example index; insert the motif name (or any label) as the
+first column:
 
 ```python
-s = seqlets[seqlets['example_idx'] == i]
+# names / motif_idxs from annotate_seqlets — see annotate.md. recursive_seqlets
+# returns a 0..n-1 index aligned with the motif_idxs rows, so s.index maps across.
+s = seqlets[seqlets['example_idx'] == i].copy()
+s.insert(0, 'motif_name', [names[j] for j in motif_idxs[s.index, 0]])
 plot_logo(X_attr[i], ax=ax, annotations=s, score_key='attribution',
           start=900, end=1200)
 ```
@@ -45,7 +63,8 @@ plot_logo(X_attr[i], ax=ax, annotations=s, score_key='attribution',
 ## Three interoperable annotation sources
 
 The same `annotations=` arg accepts: a hand-built DataFrame, FIMO hits (from the
-external `memelite` package — `fimo(motifs, X, dim=1)[i]`), and seqlets from
+external `memelite` package — `fimo(motifs, X, dim=1)[i]` gives the i-th sequence's
+hits, already in `motif_name`/`start`/`end`/`score` form), and seqlets from
 `recursive_seqlets` / `tfmodisco_seqlets`.
 
 ## Track packing
@@ -60,6 +79,17 @@ or an **array-like the length of the sequence** (per position). A per-position
 array can hold color specs (names/hex/RGB(A)) used verbatim, or numeric values
 mapped through `color_cmap` with optional `color_vmin`/`color_vmax`. It is sliced
 alongside `X_attr`; a length mismatch warns and falls back to per-character color.
+
+## The other entry points
+
+- `plot_attributions(models, X, func=deep_lift_shap, attribute_kwargs=,
+  plot_kwargs=, layout=)` — attribute *and* plot in one call, over one or more
+  models × sequences. Its `func` is the attribution function, not the `func(model,
+  X)` plug-point (see [func-pattern.md](func-pattern.md)).
+- `interactive_logo` — the `plot_logo` counterpart with hover tooltips listing every
+  column of the annotation. Needs the optional `interactive` extra (`mpld3`). Worth
+  it only when each annotation carries several useful fields.
+- `plot_pwm` for probability PWMs, as above.
 
 ## Related references
 

--- a/tangermeme/_skills/data/references/product.md
+++ b/tangermeme/_skills/data/references/product.md
@@ -2,8 +2,8 @@
 
 `tangermeme.product` applies any `func` across combinations of `X` and additional
 inputs — e.g. running a single-cell model over (sequence × cell-state × read-depth).
-Both take `func` as the **first positional argument** and satisfy the `func=`
-contract themselves.
+Both take `func` as a **required first positional argument**, and both need `args`
+(`apply_pairwise` nominally defaults it to `None`, but `None` raises).
 
 ```python
 from tangermeme.product import apply_pairwise, apply_product
@@ -15,12 +15,14 @@ apply_product(predict, model, X, args=(cell_states, read_depths))
 
 ## pairwise vs product is a CORRECTNESS choice, not a perf choice
 
-- **`apply_pairwise`** zips the args: example `i` is run with `args[0][i]`,
-  `args[1][i]`, … — the paired metadata that belong **together** (e.g. the cell
-  state and read depth measured from the *same* cell). Output gains **one** axis,
-  length = `len(args[0])`.
+- **`apply_pairwise`** zips the args *with each other* — row `j` of every arg belongs
+  together (e.g. the cell state and read depth measured from the *same* cell) — and
+  crosses that paired list with **every** example: `(X_i, (a_j, b_j))` for all `i, j`.
+  `X` is not zipped in, so `len(X)` and `len(args[0])` are independent; all args must
+  be the same length as each other. Output gains **one** axis, length =
+  `len(args[0])`, giving `(len(X), len(args[0]), ...)`.
 - **`apply_product`** takes the full Cartesian product: every `(X_i, a_j, b_k)`.
-  Output gains **one axis per arg**.
+  Output gains **one axis per arg**, giving `(len(X), len(a), len(b), ...)`.
 
 Using `apply_product` on metadata that is actually paired is a **silent scientific
 bug** — it fabricates examples where the read depth and cell state come from
@@ -38,13 +40,26 @@ y = apply_product(predict, model, X, args=(a, b))[:, 0, 0]    # two product args
 
 ## Composing and nesting
 
-Any `func` works — `predict`, `deep_lift_shap`, even `marginalize` (which returns
-its `(y_before, y_after)` pair through the product). To nest, route the inner
-function through `additional_func_kwargs` so the outer product doesn't intercept it:
+**Product on the outside** — any `func` works: `predict`, `deep_lift_shap`, even
+`marginalize` (which returns its `(y_before, y_after)` pair through the product).
+Route the *inner* function through `additional_func_kwargs` so the outer product
+doesn't intercept it:
 
 ```python
 apply_pairwise(marginalize, model, X, args=(cell_states,),
                additional_func_kwargs={'func': deep_lift_shap}, motif="TGACGTCA")
+```
+
+**Product on the inside** — because `func` is positional here, these two do **not**
+satisfy the `func=` contract themselves. Passing `apply_pairwise` straight to
+`marginalize(..., func=...)` misaligns every positional argument and raises
+`TypeError: apply_pairwise() missing 1 required positional argument: 'X'`. Bind the
+inner `func` first:
+
+```python
+from functools import partial
+marginalize(model, X, motif, func=partial(apply_pairwise, predict),
+            args=(cell_states,))
 ```
 
 Batches are built iteratively, so the full product is never materialized in memory.

--- a/tangermeme/_skills/data/references/saturation_mutagenesis.md
+++ b/tangermeme/_skills/data/references/saturation_mutagenesis.md
@@ -6,11 +6,10 @@ mutagenesis (ISM) mutates every position to every base and measures the change i
 the model's output. It is **purely forward-pass**, so it sidesteps the gradient /
 custom-backward machinery entirely.
 
-Every forward pass is run through `predict`, so inference happens under
-`model.eval()` and `torch.no_grad()` — no autograd graph is built and
-dropout/batchnorm run in eval mode, for maximum throughput. Your model's original
-training mode and device are restored afterward, so you never need to set (or
-reset) `.eval()` yourself.
+Every forward pass goes through `predict`, so inference runs under `model.eval()`
+and `torch.no_grad()` — no autograd graph, and dropout/batchnorm in eval mode. Your
+model's original training mode and device are restored afterward, so you never need
+to set (or reset) `.eval()` yourself.
 
 ## Signature (defaults that matter)
 
@@ -25,8 +24,15 @@ saturation_mutagenesis(
     raw_outputs=False,
     dtype=None, device=None,        # device None -> CUDA if available else CPU
     verbose=False,
+    func=None,                      # POST-PROCESSING hook, not the func= plug-point
 )
 ```
+
+`func=` here has the same meaning as `predict(..., func=None)`: a function applied
+to each batch of predictions after the forward pass (pick a head, apply a final
+non-linearity). It is applied identically to the reference prediction and to every
+perturbation, so attributions are computed on the post-processed values. This is
+**not** the `func(model, X)` plug-point — see [func-pattern.md](func-pattern.md).
 
 ## When to use ISM instead of DeepLIFT/SHAP
 
@@ -51,6 +57,14 @@ are independent), so there is no accuracy cost — only speed (~15× faster for 
 the sequence). Triage pattern: loop windowed ISM over a list of motif-hit
 coordinates and sum `(X_ism * X)` over each window to rank which hits actually drive
 the prediction.
+
+## Footgun: `X` is cast to int8, so soft one-hots are truncated
+
+The edit-distance-one kernel works on int8, so a non-integer `X` — a scaled,
+softened or probability-valued one-hot — is truncated toward zero. Anything with
+magnitude below 1 becomes 0, which can zero out the whole input and hand back an
+all-zero attribution. It does emit a `TangermemeWarning`, but that is easy to miss
+in a notebook. Pass a hard one-hot (int8, or float-valued 0/1).
 
 ## Single-tensor requirement
 

--- a/tangermeme/_skills/data/references/seqlets.md
+++ b/tangermeme/_skills/data/references/seqlets.md
@@ -33,9 +33,12 @@ seqlets = recursive_seqlets(attr_sums, threshold=0.01, additional_flanks=0)
   often use `0.001`.
 - `min_seqlet_len` (default 4) is also the smallest span the recursive property must
   hold over — **don't set it to 1**. `max_seqlet_len` (default 25) raises cost.
-- `additional_flanks` is **cosmetic**: it pads the reported `start`/`end` but does
-  **not** change `attribution`/`p-value`, and these flanks may overlap neighbors
-  even though the cores cannot.
+- `additional_flanks` pads the reported `start`/`end` **and** the reported
+  `attribution` is re-summed over the padded span, so it grows with the flanks. The
+  `p-value` is unchanged — it is computed on the un-padded core. Flanks may overlap
+  neighbors even though the cores cannot, so flanked spans are not disjoint, their
+  attributions can double-count the same positions, and
+  `pairwise_annotations_spacing` rejects them (see [annotate.md](annotate.md)).
 - **Over-calls on a single example** (it can't fit a null from one sequence) — pass
   many examples, or threshold by magnitude.
 
@@ -65,8 +68,9 @@ spans. Both flow straight into annotation and plotting.
 
 - **Label / count seqlets** → [annotate.md](annotate.md) (`annotate_seqlets`,
   `count_annotations`, `pairwise_annotations`).
-- **Plot seqlets** → [plot.md](plot.md): `plot_logo(attr, annotations=seqlets,
-  score_key='attribution')`, filtered to one example
-  (`seqlets[seqlets['example_idx'] == i]`).
+- **Plot seqlets** → [plot.md](plot.md). Three things to get right: filter to one
+  example, pass `score_key='attribution'`, and move a name column to the front —
+  `plot_logo` reads the label from column 0, which in a seqlet frame is
+  `example_idx`.
 - **Where the attributions come from** → [deep_lift_shap.md](deep_lift_shap.md)
   (projected vs hypothetical).

--- a/tangermeme/_skills/data/references/variant-effect.md
+++ b/tangermeme/_skills/data/references/variant-effect.md
@@ -23,7 +23,7 @@ y_before, y_after = substitution_effect(model, X, subs)
 variant at genome position `g` in a window starting at `w` goes at `position = g - w`
 (account for any `max_jitter` expansion). Off-by-window errors silently mis-score.
 
-### Footgun #1 — edits are per-example, not per-variant (the collision trap)
+### Footgun #1 — edits are per-example, not per-variant
 
 Rows are grouped by `example_idx` and **all applied to that one sequence at once**;
 they do not each yield an independent result. Two rows on example 0 give you the
@@ -36,8 +36,17 @@ subs = torch.stack([torch.tensor([i, pos[i], alt[i]]) for i in range(N)])  # one
 y_before, y_after = substitution_effect(model, Xr, subs)
 ```
 
-Multiple rows targeting the **same `(example, position)`** are applied in row order
-by tensor assignment — the **last row wins**. Order rows accordingly if chaining.
+### Footgun #2 — one substitution per `(example, position)`
+
+**Duplicate `(example_idx, position)` coordinates raise a `ValueError`**, because the
+edit is a vectorized assignment that would set every listed alt base to 1 and leave a
+multi-hot column. There is no last-write-wins. To score several alternate alleles at
+one position, replicate the example so each allele gets its own row of `X` (as
+above). The same position in *different* examples is fine.
+
+`deletion_effect` and `insertion_effect` are unconstrained here: duplicate deletion
+rows collapse to a single deletion, and insertions are applied one at a time in a
+loop.
 
 ## deletion_effect — remove characters (needs over-length input)
 
@@ -50,8 +59,13 @@ y_before, y_after = deletion_effect(model, X_long, dels, left=False)
 ```
 
 - Deleting shortens the sequence, but the model needs a fixed window, so **`X` must
-  be `model_length + max_deletions_per_example`** wide (raises otherwise). Every
-  sequence is padded to the same over-length even if it has fewer deletions.
+  be `model_length + max_deletions_per_example`** wide. Every sequence is trimmed to
+  the same post-deletion length even if it has fewer deletions.
+- **tangermeme cannot check this for you** — it has no idea what length your model
+  expects, and only raises when the deletions would consume the entire sequence
+  (`max_deletions >= X.shape[-1]`). Pass a model-length `X` and nothing is caught: a
+  fixed-length model fails with its own shape error, and a length-flexible model
+  silently scores a shortened window.
 - `left=` chooses which side to trim back to `model_length` (`False`/right is
   default). Use whichever side matches how the model was trained.
 - **`y_before` is computed on the *trimmed* slice of `X`, not the raw input** — so

--- a/tangermeme/annotate.py
+++ b/tangermeme/annotate.py
@@ -283,6 +283,23 @@ def pairwise_annotations(
 	return torch.from_numpy(y)
 
 
+def _check_spacing(d, start0, end0, start1, end1):
+	"""Raise if a pair of annotations overlaps, giving a negative distance.
+
+	The distance between two annotations is the gap between the end of the
+	left one and the start of the right one. When they overlap this quantity
+	is negative, which would index from the far end of the distance axis and
+	be silently indistinguishable from a pair `max_distance + d` apart.
+	"""
+
+	if d < 0:
+		raise ValueError("pairwise_annotations_spacing requires that "
+			"annotations within an example do not overlap, because "
+			"overlapping spans produce a negative distance; got the pair "
+			f"[{start0}, {end0}) and [{start1}, {end1}), which overlap by "
+			f"{-d}. Drop or merge overlapping annotations before calling.")
+
+
 def pairwise_annotations_spacing(
 	X: torch.Tensor | pandas.DataFrame,
 	max_distance: int = 100,
@@ -314,7 +331,10 @@ def pairwise_annotations_spacing(
 		annotation_idx, start of the annotation, and end of the annotation.
 		The end of the annotation should not be inclusive, so two adjacent
 		annotations with zero spacing between them should have the same integer
-		index for the end of one motif and the start of the next.
+		index for the end of one motif and the start of the next. Annotations
+		within an example must not overlap, because the distance between an
+		overlapping pair is negative and has no bin in the returned tensor;
+		an overlapping pair raises a `ValueError`.
 
 	max_distance: int, optional
 		The maximum distance between two annotations in the same example to
@@ -400,6 +420,8 @@ def pairwise_annotations_spacing(
 					if d >= max_distance:
 						continue
 
+					_check_spacing(d, start0, end0, start1, end1)
+
 					y[idx0, idx1, d] += 1
 					if symmetric and idx0 != idx1:
 						y[idx1, idx0, d] += 1
@@ -409,8 +431,10 @@ def pairwise_annotations_spacing(
 					if d >= max_distance:
 						continue
 
+					_check_spacing(d, start1, end1, start0, end0)
+
 					y[idx1, idx0, d] += 1
 					if symmetric and idx0 != idx1:
-						y[idx0, idx1, d] += 1 
+						y[idx0, idx1, d] += 1
 
 	return torch.from_numpy(y)

--- a/tangermeme/design/beam_substitution.py
+++ b/tangermeme/design/beam_substitution.py
@@ -82,6 +82,8 @@ def beam_substitution(
 	X: torch.tensor, shape=(1, len(alphabet), length)
 		A one-hot encoded sequence to use as the base for design. This must be
 		a single sequence and has the first dimension for broadcasting reasons.
+		A first dimension other than 1 raises a `ValueError`; loop over the
+		examples, passing `X[i:i+1]` to each call, to design more than one.
 
 	y: torch.Tensor or list of torch.Tensors or None
 		A tensor or list of Tensors providing the desired output from the model.
@@ -176,6 +178,12 @@ def beam_substitution(
 
 	tic = time.time()
 	iteration = 0
+
+	if X.shape[0] != 1:
+		raise ValueError("beam_substitution designs a single sequence at a "
+			"time and requires X.shape[0] == 1; got X with shape[0] == "
+			f"{X.shape[0]}. Loop over the examples, passing X[i:i+1] to each "
+			"call.")
 
 	X = torch.clone(X)
 	y_orig = predict(model, X, args=args, batch_size=batch_size, device=device,

--- a/tangermeme/design/greedy_substitution.py
+++ b/tangermeme/design/greedy_substitution.py
@@ -63,6 +63,8 @@ def greedy_substitution(
 	X: torch.tensor, shape=(1, len(alphabet), length)
 		A one-hot encoded sequence to use as the base for design. This must be
 		a single sequence and has the first dimension for broadcasting reasons.
+		A first dimension other than 1 raises a `ValueError`; loop over the
+		examples, passing `X[i:i+1]` to each call, to design more than one.
 
 	y: torch.Tensor or list of torch.Tensors or None
 		A tensor or list of Tensors providing the desired output from the model.
@@ -150,8 +152,14 @@ def greedy_substitution(
 	tic = time.time()
 	iteration = 0
 
+	if X.shape[0] != 1:
+		raise ValueError("greedy_substitution designs a single sequence at a "
+			"time and requires X.shape[0] == 1; got X with shape[0] == "
+			f"{X.shape[0]}. Loop over the examples, passing X[i:i+1] to each "
+			"call.")
+
 	X = torch.clone(X)
-	y_orig = predict(model, X, args=args, batch_size=batch_size, device=device, 
+	y_orig = predict(model, X, args=args, batch_size=batch_size, device=device,
 		verbose=False)
 
 	if motifs is None:

--- a/tangermeme/variant_effect.py
+++ b/tangermeme/variant_effect.py
@@ -66,10 +66,12 @@ def substitution_effect(
 		variant, the first column is the index in `X`, the second index is the
 		position in that example, and the third index is the index into the
 		alphabet that should be present at that position (overriding whatever
-		is currently there). Note: multiple rows targeting the same
-		`(example, position)` pair are applied in row order via tensor
-		assignment, so the *last* row wins. Order your rows accordingly if
-		you intend to chain edits at the same position.
+		is currently there). Note: all rows for an example are applied to that
+		one sequence at once, so at most one row may target any given
+		`(example, position)` pair; duplicate coordinates would leave a
+		multi-hot column and raise a `ValueError` instead. To score several
+		alternate alleles at one position, replicate the example so each
+		allele gets its own row of `X`.
 
 	args: tuple or None, optional
 		An optional set of additional arguments to pass into the model. If
@@ -109,6 +111,17 @@ def substitution_effect(
 	"""
 
 	substitutions = _cast_as_tensor(substitutions)
+
+	# The substitutions are applied with two vectorized assignments over an
+	# example-shaped X_var, so rows that collide on the same (example,
+	# position) would each set their own 1 and leave a multi-hot column.
+	coords = substitutions[:, :2]
+	if len(torch.unique(coords, dim=0)) != len(coords):
+		raise ValueError("substitution_effect requires at most one "
+			"substitution per (example_idx, position); the provided "
+			"substitutions contain duplicate coordinates, which would "
+			"produce a multi-hot column. De-duplicate them, or replicate "
+			"the example so each substitution gets its own row of X.")
 
 	additional_func_kwargs = dict(additional_func_kwargs or {})
 

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -380,3 +380,43 @@ def test_annotate_seqlets_dict_motifs(X, X_contrib):
 
 	assert_array_almost_equal(idxs_d, idxs_s)
 	assert_array_almost_equal(pvals_d, pvals_s)
+
+
+def test_pairwise_annotations_spacing_rejects_overlapping():
+	# Overlapping annotations give start1 - end0 < 0, which would index from
+	# the far end of the distance axis and be indistinguishable from a pair
+	# that is genuinely max_distance + d apart.
+	X = torch.tensor([
+		[0, 0, 10, 30],
+		[0, 1, 20, 40],
+	], dtype=torch.int64)
+
+	with pytest.raises(ValueError, match="overlapping"):
+		pairwise_annotations_spacing(X, max_distance=100)
+
+
+def test_pairwise_annotations_spacing_allows_abutting():
+	# Annotations that touch but do not overlap give a distance of exactly 0.
+	X = torch.tensor([
+		[0, 0, 10, 20],
+		[0, 1, 20, 30],
+	], dtype=torch.int64)
+
+	y = pairwise_annotations_spacing(X, max_distance=100)
+
+	assert int(y[0, 1, 0]) == 1
+	assert int(y[1, 0, 0]) == 1
+	assert int(y.sum()) == 2
+
+
+def test_pairwise_annotations_spacing_overlap_across_examples_ok():
+	# Spans that overlap in coordinate space but sit in different examples
+	# are never paired, so they must not raise.
+	X = torch.tensor([
+		[0, 0, 10, 30],
+		[1, 1, 20, 40],
+	], dtype=torch.int64)
+
+	y = pairwise_annotations_spacing(X, max_distance=100)
+
+	assert int(y.sum()) == 0

--- a/tests/test_beam_substitution.py
+++ b/tests/test_beam_substitution.py
@@ -154,3 +154,15 @@ def test_beam_substitution_input_mask(X, device):
 
 	assert_array_almost_equal(X[:, :, :54], X_hat[:, :, :54])
 	assert_array_almost_equal(X[:, :, 58:], X_hat[:, :, 58:])
+
+
+def test_beam_substitution_rejects_batch(motifs, device):
+	# A batch larger than one previously ran off the end of the numba
+	# substitution kernel rather than raising.
+	torch.manual_seed(0)
+	model = SmallDeepSEA()
+	X = random_one_hot((2, 4, 100), random_state=0)
+	y = [[10]]
+
+	with pytest.raises(ValueError, match="X.shape\\[0\\] == 1"):
+		beam_substitution(model, X, y, motifs, device=device, max_iter=1)

--- a/tests/test_greedy_substitution.py
+++ b/tests/test_greedy_substitution.py
@@ -204,3 +204,15 @@ def test_greedy_substitution_pre_encoded_motif_tensors(X, device):
 
 	assert_raises(Exception, greedy_substitution, model, X, y, [motif_tensor],
 		device=device, max_iter=1)
+
+
+def test_greedy_substitution_rejects_batch(motifs, device):
+	# A batch larger than one previously ran off the end of the numba
+	# substitution kernel rather than raising.
+	torch.manual_seed(0)
+	model = SmallDeepSEA()
+	X = random_one_hot((2, 4, 100), random_state=0)
+	y = [[10]]
+
+	with pytest.raises(ValueError, match="X.shape\\[0\\] == 1"):
+		greedy_substitution(model, X, y, motifs, device=device, max_iter=1)

--- a/tests/test_variant_effect.py
+++ b/tests/test_variant_effect.py
@@ -368,3 +368,31 @@ def test_variant_effect_returns_named_tuple(device):
 	insertions = torch.tensor([[0, 5, 2], [1, 10, 3]], dtype=torch.int64)
 	result = insertion_effect(model, X, insertions)
 	assert isinstance(result, PerturbationResult)
+
+
+###
+
+
+def test_substitution_effect_rejects_duplicate_positions():
+	# Two rows targeting the same (example, position) would each set a 1 in
+	# the same column, handing the model a multi-hot column rather than a
+	# one-hot one.
+	model = SumModel()
+	X = random_one_hot((1, 4, 20), random_state=0)
+	substitutions = torch.tensor([[0, 5, 2], [0, 5, 0]])
+
+	with pytest.raises(ValueError, match="duplicate"):
+		substitution_effect(model, X, substitutions)
+
+
+def test_substitution_effect_allows_repeated_position_across_examples():
+	# The same position in two different examples is not a collision.
+	model = SumModel()
+	X = random_one_hot((2, 4, 20), random_state=0)
+	substitutions = torch.tensor([[0, 5, 2], [1, 5, 0]])
+
+	y_before, y_after = substitution_effect(model, X, substitutions)
+
+	assert int(y_before.sum(dim=-1)[0]) == 20
+	assert int(y_after.sum(dim=-1)[0]) == 20
+	assert int(y_after.sum(dim=-1)[1]) == 20


### PR DESCRIPTION
Audits the bundled Agent Skill against the library, then fixes the three cases where the audit turned up a silent failure in the library itself rather than a documentation error.

## Library fixes

Each raises where it previously produced a wrong answer or crashed, and each lands with regression tests that were confirmed failing first.

- **`variant_effect.substitution_effect`** — the edits are two vectorized assignments over an example-shaped tensor, so two rows targeting the same `(example_idx, position)` each set their own alphabet index to one and the model received a **multi-hot column** with no error. A `SumModel` on a 20 bp sequence reported 21 one-hot entries. Now raises; the same position in different examples is still valid.
- **`annotate.pairwise_annotations_spacing`** — the distance between a pair is the gap from the end of the left annotation to the start of the right one, which is negative when they overlap. Only the upper bound was guarded, so a negative distance indexed from the far end of the distance axis: motifs at `[10,30)` and `[20,40)` were recorded at distance **90** with `max_distance=100`, indistinguishable from a genuine long-range pair. Now raises; abutting spans (distance 0) are unaffected.
- **`design.greedy_substitution` / `beam_substitution`** — both design a single sequence, but the batch dimension was never checked. A larger batch tiled more rows than the numba kernel had indices for, reading out of bounds and **segfaulting the interpreter**. Now raises with a pointer to `X[i:i+1]`.

### Compatibility

`pairwise_annotations_spacing` is the one behavioral break with reach: overlapping FIMO hits from a redundant motif DB now error instead of returning wrong counts. Tutorial A5 feeds it `recursive_seqlets` output, whose un-flanked cores are disjoint — verified across 358 seqlets from 64 sequences, still runs. The variant-effect tutorials use distinct coordinates.

## Skill corrections

Every claim below was reproduced against the library before being rewritten:

- `predict` returns the model's parameter dtype, not always float32.
- `extract_loci`'s int8 output should stay int8 — every entry point except `pisa` upcasts each batch, so the old `.float()` advice discarded the memory win it advertised.
- `recursive_seqlets`' `additional_flanks` re-sums the reported `attribution`; only the `p-value` is unchanged.
- `product.*` take `func` as a required first positional argument and so do **not** satisfy the `func=` contract themselves.
- `apply_pairwise` zips the elements of `args` with each other and crosses that list with every example; `X` is not zipped in.
- `ablate_annotations`' second output axis is always 1, not `n_examples`.
- `plot_logo` reads the annotation label from the **first column positionally** (`row.values[0]`), so the skill's own seqlet snippet labelled every annotation `0.0`; it also filters the window strictly, silently dropping edge hits.
- The DeepLIFT/SHAP hooks cover 20 stock non-linearities, not 5 — the old text sent users to write `additional_nonlinear_ops` they didn't need.
- `pairwise_annotations` sorts away input row order under the default `unique=True`.
- `max_iter=-1` is a no-op **only** in `greedy_substitution`; `tol` is an improvement floor everywhere except `screen`. Consolidated into one table.
- `saturation_mutagenesis` has its own `func=` post-processing hook, and truncates non-integer `X` to int8.

Also fixes three examples that could not run: `"TAL1"` used as a motif sequence (not in the DNA alphabet), a flat `spacing` list where `space` requires a nested one, and base frequencies summing to 1.001.

## Verification

- **1043 passed, 2 skipped** on Python 3.10 and 3.13, CPU and CUDA (+9 new tests).
- `pytest -m cmd` (excluded by default): 1 passed.
- Every executable snippet in the skill re-run, not just the ones tied to a finding.
- `whats_new.rst` parses; wheel builds at 1.4.1 with all 15 skill files packaged.
- Ruff unchanged at 178 pre-existing findings.

Users who installed the skill with `tangermeme-install-skills` should re-run with `--force`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)