### PR TITLE
ADD CLAUDE.md to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,8 @@ MANIFEST
 *.fai
 tests/data/r
 
-# Working notes (per-module reviews, package overviews, etc.)
+# Agent instructions and working notes -- local only, never distributed
+CLAUDE.md
 claude_comments/
 
 # OS-generated files


### PR DESCRIPTION
`CLAUDE.md` holds local agent instructions and is not meant to be distributed. It was already untracked in this repository, but only by convention — nothing stopped a `git add -A` from sweeping it into a commit. This adds it to `.gitignore` alongside `claude_comments/`, which was already ignored for the same reason, and generalizes that section's comment to cover both.

No effect on the package or the tests; `.gitignore` only.

`ledidi` already ignores `CLAUDE.md`. `cherimoya` does not, and there the file is actually tracked, so it needs a `git rm --cached` rather than just this line — handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)