### PR TITLE
Fixed GPU memory leak in deep_lift_shap.py

### DIFF
--- a/tangermeme/deep_lift_shap.py
+++ b/tangermeme/deep_lift_shap.py
@@ -111,9 +111,12 @@ def _clear_hooks(module):
 
 		del module.handles
 
-	# Delete detached input/output if exists, to prevent memory leak
+	# Drop the activations cached by `_fp_hook` and `_f_hook`, which are as
+	# large as the activations themselves and would otherwise stay attached to
+	# the module for as long as the model is alive. Only tensors are removed,
+	# so a model carrying its own attribute named `input` or `output` keeps it.
 	for name in ("input", "output"):
-		if name in module.__dict__:
+		if isinstance(module.__dict__.get(name), torch.Tensor):
 			delattr(module, name)
 
 

--- a/tangermeme/deep_lift_shap.py
+++ b/tangermeme/deep_lift_shap.py
@@ -111,6 +111,11 @@ def _clear_hooks(module):
 
 		del module.handles
 
+	# Delete detached input/output if exists, to prevent memory leak
+	for name in ("input", "output"):
+		if name in module.__dict__:
+			delattr(module, name)
+
 
 def _fp_hook(module, inputs): 
 	module.input = inputs[0].clone().detach()

--- a/tests/test_deep_lift_shap.py
+++ b/tests/test_deep_lift_shap.py
@@ -37,6 +37,7 @@ from .toy_models import DilatedConv
 from .toy_models import MultiActivation
 from .toy_models import DropoutConv
 from .toy_models import MultiInputMultiOutput
+from .toy_models import AttributeNameConv
 
 from numpy.testing import assert_raises
 from numpy.testing import assert_array_almost_equal
@@ -1865,3 +1866,46 @@ def test_deep_lift_shap_verbose(X, device):
 		random_state=0, verbose=True)
 
 	assert_array_almost_equal(X_quiet, X_loud)
+
+
+def test_deep_lift_shap_clears_hook_caches(X, device):
+	torch.manual_seed(0)
+	model = SmallDeepSEA()
+
+	deep_lift_shap(model, X[:2], n_shuffles=2, device=device, random_state=0)
+
+	# The forward hooks cache a detached copy of each non-linearity's input
+	# and output. Those copies are as large as the activations themselves, so
+	# leaving them attached pins that much memory for the life of the model.
+	for module in model.modules():
+		assert "input" not in module.__dict__
+		assert "output" not in module.__dict__
+
+
+def test_deep_lift_shap_clears_hook_caches_on_error(X, device):
+	torch.manual_seed(0)
+	model = SmallDeepSEA()
+
+	# `target` is out of range for a one-output model, so the attribution loop
+	# raises and unwinds through the `finally` block that clears the hooks.
+	assert_raises(IndexError, deep_lift_shap, model, X[:2], target=5,
+		n_shuffles=2, device=device, random_state=0)
+
+	for module in model.modules():
+		assert "input" not in module.__dict__
+		assert "output" not in module.__dict__
+
+
+def test_deep_lift_shap_preserves_user_attributes(X, device):
+	torch.manual_seed(0)
+	model = AttributeNameConv()
+
+	deep_lift_shap(model, X[:2], n_shuffles=2, device=device, random_state=0)
+
+	# Hooks are only registered on non-linearities, but the caches are cleared
+	# across every module, so attributes that merely share a name with them
+	# must survive the call.
+	assert model.input == "sequence"
+	assert model.output == 1
+	assert model.conv.input == "kernel"
+	assert model.conv.output == "logits"

--- a/tests/test_pisa.py
+++ b/tests/test_pisa.py
@@ -1072,3 +1072,22 @@ def test_pisa_verbose(X, device):
 		random_state=0, verbose=True)
 
 	assert_array_almost_equal(X_quiet, X_loud)
+
+
+def test_pisa_clears_hook_caches(X, device):
+	torch.manual_seed(0)
+	model = torch.nn.Sequential(
+		torch.nn.Conv1d(4, 8, (5,)),
+		torch.nn.ReLU(),
+		torch.nn.MaxPool1d(4),
+		torch.nn.ReLU(),
+		TorchSum()
+	)
+
+	pisa(model, X[:1], n_shuffles=2, device=device, random_state=0)
+
+	# `pisa` shares `_clear_hooks` with `deep_lift_shap`, so the cached
+	# activations must not outlive the call here either.
+	for module in model.modules():
+		assert "input" not in module.__dict__
+		assert "output" not in module.__dict__

--- a/tests/toy_models.py
+++ b/tests/toy_models.py
@@ -350,3 +350,29 @@ class MultiInputMultiOutput(torch.nn.Module):
 			self.conv(X) + a,
 			self.dense(X.reshape(X.shape[0], -1)) * beta,
 		)
+
+
+class AttributeNameConv(torch.nn.Module):
+	"""conv -> relu -> dense, carrying plain attributes named `input`/`output`.
+
+	The forward hooks cache activations on non-linear modules under those two
+	names, and `_clear_hooks` is applied to every module in the model rather
+	than only the hooked ones. This model puts ordinary, non-tensor attributes
+	of the same name on modules that never get hooked, so that clearing the
+	caches can be checked not to take them along with it.
+	"""
+
+	def __init__(self, seq_len=100, n_outputs=1):
+		super(AttributeNameConv, self).__init__()
+		self.conv = torch.nn.Conv1d(4, 8, (3,), padding='same')
+		self.relu = torch.nn.ReLU()
+		self.dense = torch.nn.Linear(8 * seq_len, n_outputs)
+
+		self.input = "sequence"
+		self.output = n_outputs
+		self.conv.input = "kernel"
+		self.conv.output = "logits"
+
+	def forward(self, X):
+		h = self.relu(self.conv(X))
+		return self.dense(h.reshape(h.shape[0], -1))


### PR DESCRIPTION
Summary: Found a GPU memory leak in `deep_lift_shap.py`. `_clear_hooks()` did not clear detached input/output tensors, keeping it in GPU memory. Fixed by explicitly deleting `module.input`, `module.output` when `_clear_hooks()` is called.

Cause: `module.input` and `module.output` stores detached input and activations. However, they are never cleared even when _clear_hooks() is called (as this only clears the hooks themselves). So input/activations are kept and only cleared when the entire module is cleared (which typically only happens when the entire model is cleared). Causing GPU memory leak.

Problem: Arises when: 
- Loading multiple models, running `deep_lift_shap` on each model serially (now GPU must hold `N models x (model weights + inputs + activations)`, rather than `N models x model weights + 1 x (inputs + activations)`)
- Loading model, running `deep_lift_shap`, then performing other action (e.g., prediction; haven't explicitly tried this)

Future: Could also define a separate function for clearing input/outputs (e.g., `_clear_input_output()` or `_clear_activations()`)