### PR TITLE
Mirror the package layout in tests/ and drop the skill's doubled markdown links

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -13,6 +13,7 @@ Claude Code skill
 -----------------
 
 	- Corrects the bundled Agent Skill against the library. Claims that did not match the implementation are fixed: ``predict`` returns the model's parameter dtype rather than always float32; the int8 sequences from ``extract_loci`` should be left as int8 because every entry point except ``pisa`` upcasts each batch; ``recursive_seqlets``' ``additional_flanks`` re-sums the reported attribution rather than only padding the coordinates; ``product.apply_pairwise``/``apply_product`` take ``func`` as a required first positional argument and so do not satisfy the ``func=`` contract themselves; ``apply_pairwise`` zips the elements of ``args`` with each other and crosses that list with every example; ``ablate_annotations``' second output axis is always one; ``plot_logo`` reads the annotation label from the first column positionally and filters the plotted window strictly; the DeepLIFT/SHAP hooks cover twenty stock non-linearities rather than five; ``pairwise_annotations`` sorts away input row order under the default ``unique=True``; and the deletion-width guard and the ``max_iter``/``tol`` stop conditions differ per function. Also documents ``saturation_mutagenesis``' own ``func=`` post-processing hook and its int8 truncation warning, and fixes three examples that could not run.
+	- Replaces every cross-reference between skill files with a backticked path, ``references/design.md``, in place of a Markdown link. Nothing that reads a skill renders Markdown, so ``[references/design.md](references/design.md)`` spent twice the characters to show the agent the same path twice; the eighty-eight links in the skill are now single backticked paths. The bare mentions that named a file without its directory, such as ``model-wrapping.md``, are now complete paths, which previously left the reader to work out that the file sits under ``references/``.
 	- If you installed the skill with ``tangermeme-install-skills``, re-run it with ``--force`` to pick up the corrections.
 
 annotate
@@ -29,6 +30,12 @@ variant_effect
 --------------
 
 	- ``substitution_effect`` now raises a ``ValueError`` when two rows of ``substitutions`` target the same ``(example_idx, position)``. The substitutions are applied with two vectorized assignments over an example-shaped tensor, so colliding rows each set their own alphabet index to one and the model was handed a multi-hot column with no error. The same position in different examples is still valid.
+
+Testing
+-------
+
+	- Moves the tests for the ``tangermeme.design`` subpackage into ``tests/design/`` and the installer test into ``tests/_skills/test_install.py``, so the test tree mirrors the package tree. ``tangermeme.design`` became a subpackage in 1.4.0 but its tests stayed flat in ``tests/``, leaving no way to tell from the test tree which module a file covered.
+	- Rewrites the bundled-skill integrity checks against backticked reference paths rather than Markdown-link syntax. The old check scanned for ``](...)`` and so would have reported success on a skill with no links left in it at all. It now also fails when a Markdown link is reintroduced, and when a ``references/*.md`` file is not reachable from the ``SKILL.md`` router table.
 
 
 Version 1.4.0

--- a/tangermeme/_skills/data/SKILL.md
+++ b/tangermeme/_skills/data/SKILL.md
@@ -19,7 +19,7 @@ reproducibility traps).
 
 ## Two cross-cutting concepts (read these first if unsure)
 
-- **[The `func=` plug-point](references/func-pattern.md)** — `ablate`,
+- **The `func=` plug-point** (`references/func-pattern.md`) — `ablate`,
   `marginalize`, `space`, `variant_effect.*`, and `product.*` (where it is the
   first positional argument) all accept `func(model, X, args=, **kwargs)`.
   Swapping `predict` for
@@ -27,7 +27,7 @@ reproducibility traps).
   "attributions before/after" one. Covers the `additional_func_kwargs` collision
   trap. **This is what makes the library compose.**
 
-- **[Wrapping models](references/model-wrapping.md)** — tangermeme assumes
+- **Wrapping models** (`references/model-wrapping.md`) — tangermeme assumes
   `y = model(X)` returns a single tensor with layout `(batch, channels, length)`.
   Real multi-input / multi-output models must be wrapped first. Read this before
   attribution or design on any non-trivial model. Data preprocessing or output
@@ -38,20 +38,20 @@ reproducibility traps).
 
 | If the task is… | Read |
 |---|---|
-| **starting from scratch** — set up a notebook to load a model and run predictions → attributions → seqlets → motif tests, end to end | [references/notebook-walkthrough.md](references/notebook-walkthrough.md) |
-| attribution via **DeepLIFT/SHAP** — "which bases drive this prediction", attribution logos, hypothetical contributions for CWMs | [references/deep_lift_shap.md](references/deep_lift_shap.md) |
-| attribution via **ISM / saturation mutagenesis** — the forward-pass alternative; use it when DeepLIFT/SHAP convergence deltas are too high, an op can't be registered, or the model is massively multi-task | [references/saturation_mutagenesis.md](references/saturation_mutagenesis.md) |
-| comparing predictions/attributions **across N models** (replicates, architectures, ensembles) | [references/comparing-models.md](references/comparing-models.md) |
-| effect of a motif / region: marginalize, ablate, spacing between motifs | [references/motif-effects.md](references/motif-effects.md) |
-| scoring **variant effects** (substitution / deletion / insertion, from a VCF) | [references/variant-effect.md](references/variant-effect.md) |
-| **calling seqlets** from attributions (recursive / TF-MoDISco) | [references/seqlets.md](references/seqlets.md) |
-| **annotating / counting motifs** — TOMTOM/FIMO labels, co-occurrence, spacing | [references/annotate.md](references/annotate.md) |
-| running a function over a **product of inputs** (sequence × cell-state × …) | [references/product.md](references/product.md) |
-| **plotting logos** and drawing seqlet/motif annotations on them | [references/plot.md](references/plot.md) |
-| composing predict / deep_lift_shap / saturation_mutagenesis through a perturbation fn | [references/func-pattern.md](references/func-pattern.md) |
-| adapting a multi-input/output PyTorch model to the tangermeme contract | [references/model-wrapping.md](references/model-wrapping.md) |
-| loading sequences/signals at loci, reading FASTA/bigWig/BED/MEME/VCF | [references/io-loci.md](references/io-loci.md) |
-| designing sequences to hit a target output (screen / greedy / beam substitution) | [references/design.md](references/design.md) |
+| **starting from scratch** — set up a notebook to load a model and run predictions → attributions → seqlets → motif tests, end to end | `references/notebook-walkthrough.md` |
+| attribution via **DeepLIFT/SHAP** — "which bases drive this prediction", attribution logos, hypothetical contributions for CWMs | `references/deep_lift_shap.md` |
+| attribution via **ISM / saturation mutagenesis** — the forward-pass alternative; use it when DeepLIFT/SHAP convergence deltas are too high, an op can't be registered, or the model is massively multi-task | `references/saturation_mutagenesis.md` |
+| comparing predictions/attributions **across N models** (replicates, architectures, ensembles) | `references/comparing-models.md` |
+| effect of a motif / region: marginalize, ablate, spacing between motifs | `references/motif-effects.md` |
+| scoring **variant effects** (substitution / deletion / insertion, from a VCF) | `references/variant-effect.md` |
+| **calling seqlets** from attributions (recursive / TF-MoDISco) | `references/seqlets.md` |
+| **annotating / counting motifs** — TOMTOM/FIMO labels, co-occurrence, spacing | `references/annotate.md` |
+| running a function over a **product of inputs** (sequence × cell-state × …) | `references/product.md` |
+| **plotting logos** and drawing seqlet/motif annotations on them | `references/plot.md` |
+| composing predict / deep_lift_shap / saturation_mutagenesis through a perturbation fn | `references/func-pattern.md` |
+| adapting a multi-input/output PyTorch model to the tangermeme contract | `references/model-wrapping.md` |
+| loading sequences/signals at loci, reading FASTA/bigWig/BED/MEME/VCF | `references/io-loci.md` |
+| designing sequences to hit a target output (screen / greedy / beam substitution) | `references/design.md` |
 
 ## Quick orientation (the rest of the library)
 

--- a/tangermeme/_skills/data/references/annotate.md
+++ b/tangermeme/_skills/data/references/annotate.md
@@ -9,7 +9,7 @@ Two conventions show up:
 
 - **Region annotations** `(n, 3)` = `(example_idx, start, end)` (0-indexed, end
   exclusive). This is what `ablate_annotations` / `marginalize_annotations` consume
-  (see [motif-effects.md](motif-effects.md)).
+  (see `references/motif-effects.md`).
 - **Counting input** `(n, 2)` = `(example_idx, annotation_idx)` for `count_annotations`
   / `pairwise_annotations`, or `(n, 4)` = `(example_idx, annotation_idx, start, end)`
   for spacing.
@@ -102,7 +102,7 @@ sp = pairwise_annotations_spacing(df4, max_distance=100)   # (n_motifs, n_motifs
 
 ## The discovery pipeline
 
-attributions → [seqlets.md](seqlets.md) (`recursive_seqlets`) →
+attributions → `references/seqlets.md` (`recursive_seqlets`) →
 `annotate_seqlets` → `count_annotations` / `pairwise_annotations` /
 `pairwise_annotations_spacing`. For a method-selection view (TF-MoDISco vs
 marginalize vs seqlet+TOMTOM vs FIMO), see the "Inspecting what cis-regulatory
@@ -110,6 +110,6 @@ features a model has learned" vignette.
 
 ## Related references
 
-[seqlets.md](seqlets.md) (producing the spans), [io-loci.md](io-loci.md)
-(`read_meme`), [motif-effects.md](motif-effects.md) (the `*_annotations`
-perturbation variants), [plot.md](plot.md) (drawing annotations on logos).
+`references/seqlets.md` (producing the spans), `references/io-loci.md`
+(`read_meme`), `references/motif-effects.md` (the `*_annotations`
+perturbation variants), `references/plot.md` (drawing annotations on logos).

--- a/tangermeme/_skills/data/references/comparing-models.md
+++ b/tangermeme/_skills/data/references/comparing-models.md
@@ -6,7 +6,7 @@ fine-tuning sweep) is mostly "loop the single-model calls" — `predict` and
 iterating is safe. The traps are not in the looping; they are in making the
 results **comparable**. This file covers the four that bite.
 
-Start from the single-model flow in [notebook-walkthrough.md](notebook-walkthrough.md);
+Start from the single-model flow in `references/notebook-walkthrough.md`;
 everything here assumes you already know how to run one model.
 
 ## 1. Fair attribution comparison needs shared references (the big one)
@@ -31,7 +31,7 @@ attrs = {
 
 A fixed `random_state=0` on each call is the lighter-weight alternative, but
 explicit shared `references=` is unambiguous and also lets `only_warn=True` paths
-work (see [deep_lift_shap.md](deep_lift_shap.md)).
+work (see `references/deep_lift_shap.md`).
 
 ## 2. Harmonize outputs before correlating
 
@@ -43,7 +43,7 @@ Models rarely agree on shape. Before any concordance metric:
   different models — map by name, don't assume aligned columns.
 - **Input length:** if input windows differ, re-`extract_loci` per model at its own
   `in_window` from the *same loci* rather than reusing one `X`
-  (see [io-loci.md](io-loci.md)).
+  (see `references/io-loci.md`).
 
 ```python
 preds = {name: predict(m, X, batch_size=64, device=device)
@@ -85,7 +85,7 @@ models = {name: torch.load(p, weights_only=False) for name, p in paths.items()}
 This is the *across-models* half of memory management. The *within-call* half —
 lowering `batch_size` (which counts example×reference pairs) or `n_shuffles` when a
 single `deep_lift_shap` call OOMs — is in
-[deep_lift_shap.md](deep_lift_shap.md), under "`batch_size` counts example-reference
+`references/deep_lift_shap.md`, under "`batch_size` counts example-reference
 pairs".
 
 ## Concordance / ensembling (generic — brief)
@@ -97,7 +97,7 @@ use whatever you normally would (`scipy.stats`, `numpy`).
 
 ## Related references
 
-[notebook-walkthrough.md](notebook-walkthrough.md) (the single-model spine),
-[deep_lift_shap.md](deep_lift_shap.md) (references / `random_state`),
-[io-loci.md](io-loci.md) (per-model windows),
-[model-wrapping.md](model-wrapping.md) (aligning heterogeneous model outputs).
+`references/notebook-walkthrough.md` (the single-model spine),
+`references/deep_lift_shap.md` (references / `random_state`),
+`references/io-loci.md` (per-model windows),
+`references/model-wrapping.md` (aligning heterogeneous model outputs).

--- a/tangermeme/_skills/data/references/deep_lift_shap.md
+++ b/tangermeme/_skills/data/references/deep_lift_shap.md
@@ -39,7 +39,7 @@ X_attr = deep_lift_shap(model, X, target=267, random_state=0)
 
 If the model returns *multiple tensors* (a list), `target` cannot select among
 them — wrap the model so its forward returns a single tensor first (see
-[model-wrapping.md](model-wrapping.md)).
+`references/model-wrapping.md`).
 
 ## Footgun #2 — reproducibility needs `random_state=`
 
@@ -49,7 +49,7 @@ make them deterministic (required when capturing regression values). For compari
 attributions **across tasks or models**, holding `random_state` *and* `n_shuffles`
 fixed is mandatory — otherwise each call attributes against different backgrounds
 and the differences you see are noise, not signal (see
-[comparing-models.md](comparing-models.md)). A custom `references=` callable has the
+`references/comparing-models.md`). A custom `references=` callable has the
 signature `f(X, n, random_state) -> (n_examples, n, len(alphabet), length)`; if you
 only shuffle a sub-span, attributions are exactly `0` outside it — don't interpret
 those positions.
@@ -123,7 +123,7 @@ genuinely precision-driven deltas, `deep_lift_shap(model.double(), X.double(),
 references=refs.double(), ...)` drops them to ~1e-16 (slower; fp64).
 
 When you can't get deltas down (an op that can't be expressed as a shape-preserving
-hook), switch to ISM — see [saturation_mutagenesis.md](saturation_mutagenesis.md).
+hook), switch to ISM — see `references/saturation_mutagenesis.md`.
 
 ## hypothetical vs projected attributions
 
@@ -134,7 +134,7 @@ hook), switch to ISM — see [saturation_mutagenesis.md](saturation_mutagenesis.
   downstream — **not** as the seqlet-caller input.
 
 The seqlet callers take the projected output collapsed over the channel axis
-(`X_attr.sum(dim=1)`) — see [seqlets.md](seqlets.md).
+(`X_attr.sum(dim=1)`) — see `references/seqlets.md`.
 
 ## Return type
 
@@ -154,11 +154,11 @@ plot_logo(X_attr[0], ax=ax)   # tangermeme has its own logo plotting (no logomak
 `deep_lift_shap` satisfies the `func=` contract, so it drops into `marginalize`,
 `ablate`, `variant_effect.*`, etc. to get attributions before/after an edit —
 route attribution kwargs via `additional_func_kwargs` (see
-[func-pattern.md](func-pattern.md)).
+`references/func-pattern.md`).
 
 ## Related references
 
-[saturation_mutagenesis.md](saturation_mutagenesis.md) (the forward-pass
-alternative), [seqlets.md](seqlets.md) (consuming projected attributions),
-[model-wrapping.md](model-wrapping.md) (single-tensor requirement),
-[comparing-models.md](comparing-models.md) (shared references across models).
+`references/saturation_mutagenesis.md` (the forward-pass
+alternative), `references/seqlets.md` (consuming projected attributions),
+`references/model-wrapping.md` (single-tensor requirement),
+`references/comparing-models.md` (shared references across models).

--- a/tangermeme/_skills/data/references/design.md
+++ b/tangermeme/_skills/data/references/design.md
@@ -140,7 +140,7 @@ it never reaches, `screen` loops forever — give it one or the other.
   holds the others near baseline rather than ignoring them.
 - `y` (the target `y_bar`) and `loss` must be shaped consistently with the model
   output. For multi-output models, either pass a list `y` matching the outputs or
-  wrap the model to a single objective head (see [model-wrapping.md](model-wrapping.md)),
+  wrap the model to a single objective head (see `references/model-wrapping.md`),
   and use `output_mask` to focus the loss.
 - The choice of loss + target *is* the design objective — get these right before
   worrying about iterations. Euclidean/MSE is the usual default; supply a custom
@@ -156,6 +156,6 @@ substitution.
 
 ## Related references
 
-[model-wrapping.md](model-wrapping.md) (collapsing multi-output models to a design
-objective), [func-pattern.md](func-pattern.md) (the `func=` candidate generator in
+`references/model-wrapping.md` (collapsing multi-output models to a design
+objective), `references/func-pattern.md` (the `func=` candidate generator in
 `screen`).

--- a/tangermeme/_skills/data/references/func-pattern.md
+++ b/tangermeme/_skills/data/references/func-pattern.md
@@ -33,7 +33,7 @@ product.apply_product(func, model, X, ...)
 `variant_effect` functions. On `product.apply_pairwise` / `apply_product` it is a
 **required first positional argument** with no default — and because of that
 position they do **not** themselves satisfy the contract; see
-[product.md](product.md).
+`references/product.md`.
 
 **Elsewhere in the library `func=` is a different contract entirely.** None of these
 take the `func(model, X)` predictor contract above:
@@ -98,11 +98,11 @@ into `func` into `model(X, *args)`.
 
 `product.apply_pairwise` / `apply_product` are the exception: there `args` defines
 the axes to sweep over rather than per-example inputs, so its rows are *not* aligned
-to `X` (see [product.md](product.md)).
+to `X` (see `references/product.md`).
 
 ## Related references
 
-[motif-effects.md](motif-effects.md) for marginalize/ablate/space specifics,
-[deep_lift_shap.md](deep_lift_shap.md) and
-[saturation_mutagenesis.md](saturation_mutagenesis.md) for the attribution
-methods, [model-wrapping.md](model-wrapping.md) for adapting multi-output models.
+`references/motif-effects.md` for marginalize/ablate/space specifics,
+`references/deep_lift_shap.md` and
+`references/saturation_mutagenesis.md` for the attribution
+methods, `references/model-wrapping.md` for adapting multi-output models.

--- a/tangermeme/_skills/data/references/io-loci.md
+++ b/tangermeme/_skills/data/references/io-loci.md
@@ -103,7 +103,7 @@ Feed variants into `tangermeme.variant_effect.*` to score substitution / deletio
 
 ## Related references
 
-[notebook-walkthrough.md](notebook-walkthrough.md) (loading is step 3 of the
-end-to-end flow), [model-wrapping.md](model-wrapping.md) (the
+`references/notebook-walkthrough.md` (loading is step 3 of the
+end-to-end flow), `references/model-wrapping.md` (the
 `(batch, channels, length)` layout the loaded `X` follows),
-[motif-effects.md](motif-effects.md) (consuming the loaded sequences).
+`references/motif-effects.md` (consuming the loaded sequences).

--- a/tangermeme/_skills/data/references/model-wrapping.md
+++ b/tangermeme/_skills/data/references/model-wrapping.md
@@ -68,7 +68,7 @@ class CountWrapper(torch.nn.Module):
   outputs (`y['human']`) or bin-summing (`y.sum(dim=-2)`).
 - **Harmonize length across models** — pad or trim wrappers let you compare models
   with different input windows on the same loci (also see
-  [comparing-models.md](comparing-models.md)). Padding with N pushes sequences
+  `references/comparing-models.md`). Padding with N pushes sequences
   out-of-distribution if the model wasn't trained on N; trimming discards flanks.
 - **Squish N models into one** — a wrapper that runs several models and concatenates
   their outputs feeds straight into `marginalize` / `saturation_mutagenesis` as a
@@ -94,7 +94,7 @@ mode afterward. Your wrapper only needs a correct `forward`.
 
 ## Related references
 
-[func-pattern.md](func-pattern.md) (how wrapped models flow through
-perturbations), [deep_lift_shap.md](deep_lift_shap.md) and
-[saturation_mutagenesis.md](saturation_mutagenesis.md) (why a single-tensor
+`references/func-pattern.md` (how wrapped models flow through
+perturbations), `references/deep_lift_shap.md` and
+`references/saturation_mutagenesis.md` (why a single-tensor
 forward is required there).

--- a/tangermeme/_skills/data/references/motif-effects.md
+++ b/tangermeme/_skills/data/references/motif-effects.md
@@ -99,14 +99,14 @@ axis** and the second axis differs between them:
 - `marginalize_annotations` → `(n_annotations, len(X0), ...)` for both, since each
   annotation's span is substituted into every background in `X0`.
 
-Index carefully before taking deltas. See [annotate.md](annotate.md) for building
+Index carefully before taking deltas. See `references/annotate.md` for building
 the annotation tensor.
 
 ## Attributions instead of predictions
 
 All three take `func=`. Swap in `deep_lift_shap` to see the effect on
 attributions rather than predictions; route attribution kwargs through
-`additional_func_kwargs=` (see [func-pattern.md](func-pattern.md)):
+`additional_func_kwargs=` (see `references/func-pattern.md`):
 
 ```python
 from tangermeme.deep_lift_shap import deep_lift_shap
@@ -125,6 +125,6 @@ attr_before, attr_after = marginalize(model, X, "CTCAGTGATG", func=deep_lift_sha
 
 ## Related references
 
-[func-pattern.md](func-pattern.md), [deep_lift_shap.md](deep_lift_shap.md),
-[saturation_mutagenesis.md](saturation_mutagenesis.md),
-[model-wrapping.md](model-wrapping.md).
+`references/func-pattern.md`, `references/deep_lift_shap.md`,
+`references/saturation_mutagenesis.md`,
+`references/model-wrapping.md`.

--- a/tangermeme/_skills/data/references/notebook-walkthrough.md
+++ b/tangermeme/_skills/data/references/notebook-walkthrough.md
@@ -10,7 +10,7 @@ exact signatures and footguns. Read those before relying on a step.
 
 Assumed layout: a one-hot input of shape `(batch, 4, length)`, a model where
 `y = model(X)` returns a single tensor (wrap yours first if not — see
-[model-wrapping.md](model-wrapping.md)).
+`references/model-wrapping.md`).
 
 ```python
 # === Cell 1: setup ===
@@ -32,7 +32,8 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 model = torch.load("model.pt", weights_only=False)
 
 # If the model is multi-output (returns a list) or multi-input, wrap it so that
-# forward returns a single tensor before attribution/design. See model-wrapping.md.
+# forward returns a single tensor before attribution/design. See
+# references/model-wrapping.md.
 # class Wrapper(torch.nn.Module):
 #     def __init__(self, model): super().__init__(); self.model = model
 #     def forward(self, X, *args): return self.model(X, *args)[0]
@@ -42,8 +43,8 @@ model = torch.load("model.pt", weights_only=False)
 ```python
 # === Cell 3: load peaks + sequence (and observed signal) ===
 # extract_loci returns a VARIABLE number of objects depending on which kwargs are
-# set — here (sequences + signals) it returns two. See io-loci.md for the full
-# return-order rules and the counts/exclusion filters.
+# set — here (sequences + signals) it returns two. See references/io-loci.md
+# for the full return-order rules and the counts/exclusion filters.
 from tangermeme.io import extract_loci
 
 X, y = extract_loci(
@@ -79,7 +80,7 @@ plt.show()
 # === Cell 5: attributions at loci of interest ===
 # Pick a few loci to inspect (here the highest-signal peaks). For a multi-task
 # model you MUST pass target= or you silently attribute output 0. random_state=
-# makes the shuffled references reproducible. See deep_lift_shap.md.
+# makes the shuffled references reproducible. See references/deep_lift_shap.md.
 from tangermeme.deep_lift_shap import deep_lift_shap
 from tangermeme.plot import plot_logo
 
@@ -97,7 +98,7 @@ plt.show()
 # === Cell 6 (optional): ISM as a cross-check / fallback ===
 # Use ISM if DeepLIFT/SHAP convergence deltas are high, an op can't be registered,
 # or the model is massively multi-task. Restrict to a window — cost scales with
-# length. See saturation_mutagenesis.md.
+# length. See references/saturation_mutagenesis.md.
 from tangermeme.saturation_mutagenesis import saturation_mutagenesis
 
 X_ism = saturation_mutagenesis(model, X[idx], start=900, end=1200, target=0,
@@ -110,8 +111,9 @@ plt.show()
 # === Cell 7: call seqlets from the attributions ===
 # recursive_seqlets takes per-position PROJECTED attribution sums, shape
 # (n, length) — collapse the channel axis. Returns a DataFrame sorted by p-value
-# with columns example_idx / start / end / attribution / p-value. See seqlets.md;
-# label/count the seqlets with annotate.md, draw them with plot.md.
+# with columns example_idx / start / end / attribution / p-value. See
+# references/seqlets.md; label/count the seqlets with references/annotate.md,
+# draw them with references/plot.md.
 from tangermeme.seqlet import recursive_seqlets
 
 # Attribute the whole batch first (here just the few loci; scale up as needed).
@@ -125,7 +127,7 @@ print(seqlets.head())
 ```python
 # === Cell 8: test a motif hypothesis with marginalization ===
 # Did a motif you found in the seqlets actually drive the model? Insert it into
-# shuffled backgrounds and measure the delta. See motif-effects.md.
+# shuffled backgrounds and measure the delta. See references/motif-effects.md.
 from tangermeme.ersatz import dinucleotide_shuffle
 from tangermeme.marginalize import marginalize
 
@@ -141,12 +143,13 @@ print("mean marginal effect:", delta.mean().item())
 - **Multiple models / comparisons** — loop the same `predict` / `deep_lift_shap`
   calls over a list of models; the device/state handling is per-call and safe. To
   keep the results *comparable* (shared references, output harmonization, scale
-  normalization, memory), see [comparing-models.md](comparing-models.md).
+  normalization, memory), see `references/comparing-models.md`.
 - **Variant effects** — `tangermeme.variant_effect.*` with variants from
-  `io.read_vcf` (see [variant-effect.md](variant-effect.md)).
-- **Spacing / cooperativity** — `tangermeme.space.space` (see motif-effects.md).
-- **Sequence design** — [design.md](design.md).
+  `io.read_vcf` (see `references/variant-effect.md`).
+- **Spacing / cooperativity** — `tangermeme.space.space` (see
+  `references/motif-effects.md`).
+- **Sequence design** — `references/design.md`.
 - **Any perturbation as attributions** — pass `func=deep_lift_shap` into
-  marginalize/ablate/etc. ([func-pattern.md](func-pattern.md)).
+  marginalize/ablate/etc. (`references/func-pattern.md`).
 
-Each step above links to its deep-dive file inline; see those for the footguns.
+Each step above names its deep-dive file inline; see those for the footguns.

--- a/tangermeme/_skills/data/references/plot.md
+++ b/tangermeme/_skills/data/references/plot.md
@@ -52,8 +52,9 @@ annotation with the example index; insert the motif name (or any label) as the
 first column:
 
 ```python
-# names / motif_idxs from annotate_seqlets — see annotate.md. recursive_seqlets
-# returns a 0..n-1 index aligned with the motif_idxs rows, so s.index maps across.
+# names / motif_idxs from annotate_seqlets — see references/annotate.md.
+# recursive_seqlets returns a 0..n-1 index aligned with the motif_idxs rows, so
+# s.index maps across.
 s = seqlets[seqlets['example_idx'] == i].copy()
 s.insert(0, 'motif_name', [names[j] for j in motif_idxs[s.index, 0]])
 plot_logo(X_attr[i], ax=ax, annotations=s, score_key='attribution',
@@ -85,7 +86,7 @@ alongside `X_attr`; a length mismatch warns and falls back to per-character colo
 - `plot_attributions(models, X, func=deep_lift_shap, attribute_kwargs=,
   plot_kwargs=, layout=)` — attribute *and* plot in one call, over one or more
   models × sequences. Its `func` is the attribution function, not the `func(model,
-  X)` plug-point (see [func-pattern.md](func-pattern.md)).
+  X)` plug-point (see `references/func-pattern.md`).
 - `interactive_logo` — the `plot_logo` counterpart with hover tooltips listing every
   column of the annotation. Needs the optional `interactive` extra (`mpld3`). Worth
   it only when each annotation carries several useful fields.
@@ -93,5 +94,5 @@ alongside `X_attr`; a length mismatch warns and falls back to per-character colo
 
 ## Related references
 
-[seqlets.md](seqlets.md) and [annotate.md](annotate.md) (producing annotations),
-[deep_lift_shap.md](deep_lift_shap.md) (producing `X_attr`).
+`references/seqlets.md` and `references/annotate.md` (producing annotations),
+`references/deep_lift_shap.md` (producing `X_attr`).

--- a/tangermeme/_skills/data/references/product.md
+++ b/tangermeme/_skills/data/references/product.md
@@ -66,5 +66,5 @@ Batches are built iteratively, so the full product is never materialized in memo
 
 ## Related references
 
-[func-pattern.md](func-pattern.md) (the `func`/`additional_func_kwargs` contract),
-[model-wrapping.md](model-wrapping.md) (passing per-example extra inputs).
+`references/func-pattern.md` (the `func`/`additional_func_kwargs` contract),
+`references/model-wrapping.md` (passing per-example extra inputs).

--- a/tangermeme/_skills/data/references/saturation_mutagenesis.md
+++ b/tangermeme/_skills/data/references/saturation_mutagenesis.md
@@ -1,7 +1,7 @@
 # Saturation mutagenesis (ISM) in tangermeme
 
 `tangermeme.saturation_mutagenesis.saturation_mutagenesis` is an attribution
-method, alongside [deep_lift_shap.md](deep_lift_shap.md). In-silico saturation
+method, alongside `references/deep_lift_shap.md`. In-silico saturation
 mutagenesis (ISM) mutates every position to every base and measures the change in
 the model's output. It is **purely forward-pass**, so it sidesteps the gradient /
 custom-backward machinery entirely.
@@ -32,7 +32,7 @@ saturation_mutagenesis(
 to each batch of predictions after the forward pass (pick a head, apply a final
 non-linearity). It is applied identically to the reference prediction and to every
 perturbation, so attributions are computed on the post-processed values. This is
-**not** the `func(model, X)` plug-point — see [func-pattern.md](func-pattern.md).
+**not** the `func(model, X)` plug-point — see `references/func-pattern.md`.
 
 ## When to use ISM instead of DeepLIFT/SHAP
 
@@ -74,7 +74,7 @@ model must not return a *list* of tensors. `target=None` (the default) averages 
 attribution across **all** tasks; for a model with thousands of heterogeneous heads
 (binding + expression + histone) that average is noisy and uninterpretable, so pass
 an int or slice to subset to the output(s) you care about first, or wrap the model —
-see [model-wrapping.md](model-wrapping.md). `target=N` is exactly equivalent to a
+see `references/model-wrapping.md`. `target=N` is exactly equivalent to a
 single-task slice wrapper.
 
 ## Return type
@@ -99,7 +99,7 @@ single-task slice wrapper.
 `saturation_mutagenesis` satisfies the `func=` contract, so it drops into
 `marginalize`, `ablate`, `variant_effect.*`, etc. to get ISM scores before/after
 an edit — route ISM kwargs via `additional_func_kwargs` (see
-[func-pattern.md](func-pattern.md)).
+`references/func-pattern.md`).
 
 ## Plotting
 
@@ -110,5 +110,5 @@ plot_logo(X_ism[0], ax=ax)
 
 ## Related references
 
-[deep_lift_shap.md](deep_lift_shap.md) (the gradient-based attribution method),
-[model-wrapping.md](model-wrapping.md), [func-pattern.md](func-pattern.md).
+`references/deep_lift_shap.md` (the gradient-based attribution method),
+`references/model-wrapping.md`, `references/func-pattern.md`.

--- a/tangermeme/_skills/data/references/seqlets.md
+++ b/tangermeme/_skills/data/references/seqlets.md
@@ -14,7 +14,7 @@ attr_sums = X_attr.sum(dim=1)        # (n, 4, length) -> (n, length)
 ```
 
 Do **not** pass the `(n, 4, length)` attributions or hypothetical attributions.
-(See [deep_lift_shap.md](deep_lift_shap.md): hypothetical is for building CWMs, not
+(See `references/deep_lift_shap.md`: hypothetical is for building CWMs, not
 for seqlet calling.)
 
 ## recursive_seqlets — sharp, p-value based
@@ -38,7 +38,7 @@ seqlets = recursive_seqlets(attr_sums, threshold=0.01, additional_flanks=0)
   `p-value` is unchanged — it is computed on the un-padded core. Flanks may overlap
   neighbors even though the cores cannot, so flanked spans are not disjoint, their
   attributions can double-count the same positions, and
-  `pairwise_annotations_spacing` rejects them (see [annotate.md](annotate.md)).
+  `pairwise_annotations_spacing` rejects them (see `references/annotate.md`).
 - **Over-calls on a single example** (it can't fit a null from one sequence) — pass
   many examples, or threshold by magnitude.
 
@@ -66,11 +66,11 @@ spans. Both flow straight into annotation and plotting.
 
 ## Related references
 
-- **Label / count seqlets** → [annotate.md](annotate.md) (`annotate_seqlets`,
+- **Label / count seqlets** → `references/annotate.md` (`annotate_seqlets`,
   `count_annotations`, `pairwise_annotations`).
-- **Plot seqlets** → [plot.md](plot.md). Three things to get right: filter to one
-  example, pass `score_key='attribution'`, and move a name column to the front —
-  `plot_logo` reads the label from column 0, which in a seqlet frame is
+- **Plot seqlets** → `references/plot.md`. Three things to get right: filter to
+  one example, pass `score_key='attribution'`, and move a name column to the
+  front — `plot_logo` reads the label from column 0, which in a seqlet frame is
   `example_idx`.
-- **Where the attributions come from** → [deep_lift_shap.md](deep_lift_shap.md)
+- **Where the attributions come from** → `references/deep_lift_shap.md`
   (projected vs hypothetical).

--- a/tangermeme/_skills/data/references/variant-effect.md
+++ b/tangermeme/_skills/data/references/variant-effect.md
@@ -87,13 +87,13 @@ y_before, y_after = insertion_effect(model, X, ins, left=False)
 
 ## From a VCF
 
-Read variants with `io.read_vcf` (see [io-loci.md](io-loci.md)) and build the COO
+Read variants with `io.read_vcf` (see `references/io-loci.md`) and build the COO
 `substitutions` tensor (`example_idx`, `position` relative to your extracted window,
 `alt` allele index). Remember one row per variant **and one example copy per variant**
 if you want per-variant scores.
 
 ## Related references
 
-[func-pattern.md](func-pattern.md) (swapping `func`/`additional_func_kwargs`),
-[io-loci.md](io-loci.md) (`read_vcf`, extracting the windows),
-[model-wrapping.md](model-wrapping.md) (multi-output / multi-input models).
+`references/func-pattern.md` (swapping `func`/`additional_func_kwargs`),
+`references/io-loci.md` (`read_vcf`, extracting the windows),
+`references/model-wrapping.md` (multi-output / multi-input models).

--- a/tests/_skills/__init__.py
+++ b/tests/_skills/__init__.py
@@ -1,0 +1,2 @@
+import torch
+torch.use_deterministic_algorithms(True, warn_only=True)

--- a/tests/_skills/test_install.py
+++ b/tests/_skills/test_install.py
@@ -1,4 +1,4 @@
-# test_install_skills.py
+# test_install.py
 # Contact: Jacob Schreiber <jmschreiber91@gmail.com>
 
 import re

--- a/tests/_skills/test_install.py
+++ b/tests/_skills/test_install.py
@@ -18,10 +18,16 @@ from tangermeme._skills.install import install_skill
 # Helpers
 
 
-def _link_targets(text):
-	"""Return the basenames of every Markdown link to a .md file in `text`."""
+def _ref_mentions(text):
+	"""Return the basenames of every backticked reference path in `text`.
 
-	return [m.split("/")[-1] for m in re.findall(r'\]\(([^)]+\.md)\)', text)]
+	The skill writes cross-references as backticked paths, ``references/x.md``,
+	rather than as Markdown links, because nothing that reads a skill renders
+	Markdown and a link spends twice the characters on the same path.
+	"""
+
+	return [m.split("/")[-1]
+		for m in re.findall(r'`(references/[\w.-]+\.md)`', text)]
 
 
 def _seed_fake_skill(root):
@@ -58,18 +64,41 @@ def test_skill_frontmatter():
 	assert 0 < len(fields.get("description", "")) <= 1536
 
 
-def test_internal_links_all_resolve():
+def test_internal_references_all_resolve():
 	data = _bundled_skill_dir()
 	refs = data / "references"
 	existing = {p.name for p in refs.glob("*.md")}
 
 	broken = []
 	for f in [data / "SKILL.md", *refs.glob("*.md")]:
-		for target in _link_targets(f.read_text()):
+		for target in _ref_mentions(f.read_text()):
 			if target not in existing:
 				broken.append("{} -> {}".format(f.name, target))
 
-	assert broken == [], "broken internal links: {}".format(broken)
+	assert broken == [], "broken internal references: {}".format(broken)
+
+
+def test_no_markdown_links_to_reference_files():
+	# Backticked paths only. A Markdown link would also make the resolution and
+	# orphan checks above pass vacuously, since neither one looks for links.
+	data = _bundled_skill_dir()
+
+	found = []
+	for f in [data / "SKILL.md", *(data / "references").glob("*.md")]:
+		for m in re.findall(r'\[[^\]]*\]\([^)]*\.md\)', f.read_text()):
+			found.append("{}: {}".format(f.name, m))
+
+	assert found == [], "use `references/x.md`, not a link: {}".format(found)
+
+
+def test_every_reference_is_linked_from_the_router():
+	data = _bundled_skill_dir()
+	refs = data / "references"
+
+	routed = set(_ref_mentions((data / "SKILL.md").read_text()))
+	orphans = sorted(p.name for p in refs.glob("*.md") if p.name not in routed)
+
+	assert orphans == [], "not reachable from SKILL.md: {}".format(orphans)
 
 
 ###

--- a/tests/design/__init__.py
+++ b/tests/design/__init__.py
@@ -1,0 +1,2 @@
+import torch
+torch.use_deterministic_algorithms(True, warn_only=True)

--- a/tests/design/test_beam_substitution.py
+++ b/tests/design/test_beam_substitution.py
@@ -10,7 +10,7 @@ from tangermeme.design import greedy_substitution
 from tangermeme.design import beam_substitution
 from tangermeme.io import read_meme
 from tangermeme.utils import characters
-from .toy_models import SmallDeepSEA
+from ..toy_models import SmallDeepSEA
 from numpy.testing import assert_array_almost_equal
 
 

--- a/tests/design/test_greedy_marginalize.py
+++ b/tests/design/test_greedy_marginalize.py
@@ -8,7 +8,7 @@ from tangermeme.utils import random_one_hot
 from tangermeme.design import greedy_marginalize
 from tangermeme.io import read_meme
 from tangermeme.utils import characters
-from .toy_models import SmallDeepSEA
+from ..toy_models import SmallDeepSEA
 
 
 torch.manual_seed(0)

--- a/tests/design/test_greedy_substitution.py
+++ b/tests/design/test_greedy_substitution.py
@@ -9,8 +9,8 @@ from tangermeme.predict import predict
 from tangermeme.design import greedy_substitution
 from tangermeme.io import read_meme
 from tangermeme.utils import characters
-from .toy_models import SumModel
-from .toy_models import SmallDeepSEA
+from ..toy_models import SumModel
+from ..toy_models import SmallDeepSEA
 from numpy.testing import assert_raises
 from numpy.testing import assert_array_almost_equal
 

--- a/tests/design/test_screen.py
+++ b/tests/design/test_screen.py
@@ -6,8 +6,8 @@ import torch
 from tangermeme.utils import random_one_hot
 from tangermeme.predict import predict
 from tangermeme.design import screen
-from .toy_models import SumModel
-from .toy_models import SmallDeepSEA
+from ..toy_models import SumModel
+from ..toy_models import SmallDeepSEA
 from numpy.testing import assert_raises
 from numpy.testing import assert_array_almost_equal
 


### PR DESCRIPTION
Two independent housekeeping changes, one commit each.

## 1. Mirror the package layout in `tests/`

`references/testing.md` says `<submodule>/<module>.py` is covered by
`tests/<submodule>/test_<module>.py`. `tangermeme.design` became a subpackage in
1.4.0 but its tests stayed flat in `tests/`, so this moves them:

- `tests/test_{beam_substitution,greedy_marginalize,greedy_substitution,screen}.py`
  → `tests/design/`, with `from .toy_models import X` → `from ..toy_models import X`.
- `tests/test_install_skills.py` → `tests/_skills/test_install.py`, mirroring
  `tangermeme/_skills/install.py`.
- New `tests/design/__init__.py` and `tests/_skills/__init__.py`; without them the
  relative import raises `ImportError: attempted relative import with no known
  parent package`.

`tests/test_dependency_map.py` and `tests/test_product.py` mirror top-level
modules and stay put.

The installer test locates the shipped skill through
`tangermeme._skills.install._bundled_skill_dir()`, which resolves from the
*package* `__file__`, not the test's — so moving the test a level deeper does not
change what it inspects. Verified after the move: it still resolves to
`tangermeme/_skills/data`.

## 2. Backticked paths instead of Markdown links in the bundled skill

Per the skill-authoring convention, a cross-reference is written as
`` `references/x.md` ``. Nothing that reads a skill renders Markdown, so
`[references/x.md](references/x.md)` spends twice the characters to show the agent
the same path twice.

- 86 links whose text equalled their target were rewritten mechanically.
- 2 links in `SKILL.md` whose text differed (`[The `func=` plug-point]`,
  `[Wrapping models]`) were rewritten by hand so the sentence still reads.
- 10 bare mentions that named a file without its directory (`model-wrapping.md`,
  `plot.md`, …) became complete paths, mostly inside the walkthrough's code
  comments; a couple of comment blocks were re-wrapped as a result.

Every path written was checked against `ls references/`: 99 mentions, all
resolving, all 14 reference files reachable from the router table, zero Markdown
links left.

`tests/_skills/test_install.py` had to change in the same commit. Its link check
scanned for `](...)` and would have passed vacuously once the links were gone. It
now parses backticked paths, additionally fails if a Markdown link is
reintroduced, and asserts no `references/*.md` is orphaned from the router table.
Each of those three was verified against a deliberately broken copy of the skill
data.

## The six surfaces

1. **Tests** — applied. Layout moved; the skill-integrity checks rewritten and
   negative-controlled. `uv run pytest -x -q`: 1051 → 1053 passed, 2 skipped, 1
   deselected (the two new tests are the delta). `uv run pytest -m cmd`: 1 passed,
   unchanged.
2. **Documentation** — N/A for content: no public symbol, signature, or module
   changed, so no API page or tutorial is affected. The strict build was run
   anyway to cover the changelog edit — `sphinx-build -W` reports the same 13
   pre-existing docstring/notebook warnings as `main`, none in `whats_new.rst`.
3. **README** — N/A. The README's only relevant section documents
   `tangermeme-install-skills`, whose behavior and flags are unchanged.
4. **Changelog** — applied. `docs/whats_new.rst`, under 1.4.1: one bullet under
   *Claude Code skill* and a new *Testing* section.
5. **The bundled skill** — applied; it is half the PR. The existing "re-run
   `tangermeme-install-skills --force` to pick up the corrections" line in the
   1.4.1 changelog now covers this change too.
6. **Compatibility** — N/A. Nothing touches a `state_dict`, module structure,
   kernel, or model head; `tests/` is excluded from the sdist and the skill is
   inert data.

`diff -r tangermeme/_skills/data/ ~/.claude/skills/tangermeme/` before starting:
no drift, the two were identical. The installed copy was not edited and
`tangermeme-install-skills` was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
